### PR TITLE
[PAYM-379] 

### DIFF
--- a/assets/scss/modules/_unknown.scss
+++ b/assets/scss/modules/_unknown.scss
@@ -51,7 +51,7 @@ label.selectable input {
   overflow: hidden;
 }
 
-#content > article.full-width {
+#content > .full-width {
   width: auto;
   float: none;
 }


### PR DESCRIPTION
Changed the full-width css class to be more general, so we can use it for something besides the now-discarded article tag. With @siliconcat.