### PR TITLE
[SA-583] Added left and right margins for flags

### DIFF
--- a/assets/scss/base/_lists.scss
+++ b/assets/scss/base/_lists.scss
@@ -113,12 +113,14 @@ ul {
   margin: 0;
   padding: 0;
   clear: both;
-
   li {
     border-top: 1px solid $border-colour;
     padding: 0.5em 0;
     margin: 0;
     overflow: hidden;
+    .badge {
+      margin-left:6px;
+    }
   }
 }
 

--- a/assets/scss/base/_lists.scss
+++ b/assets/scss/base/_lists.scss
@@ -118,9 +118,6 @@ ul {
     padding: 0.5em 0;
     margin: 0;
     overflow: hidden;
-    .badge {
-      margin-left:6px;
-    }
   }
 }
 

--- a/assets/scss/base/_typography.scss
+++ b/assets/scss/base/_typography.scss
@@ -141,6 +141,12 @@ small {
   &.flag--urgent {
     background-color: $red;
   }
+  &.flag--on-left-side {
+    margin-right:6px;
+  }
+  &.flag--on-right-side {
+    margin-left:6px;
+  }
 }
 
 .highlight-block--red {


### PR DESCRIPTION
Added class 'badge' to target any badges (red blocks "New", "Unread", "Overdue" etc) that appear in action lists, e.g. Tax Summary link.