### PR TITLE
Move details styles to _typography and add underline to summary

### DIFF
--- a/assets/scss/base/_typography.scss
+++ b/assets/scss/base/_typography.scss
@@ -160,3 +160,11 @@ small {
 .heading--underlined {
   border-bottom: solid 5px $govuk-blue;
 }
+
+details {
+  margin: 15px 0;
+
+  .summary {
+    text-decoration: underline;
+  }
+}

--- a/assets/scss/modules/_unknown.scss
+++ b/assets/scss/modules/_unknown.scss
@@ -180,10 +180,6 @@ body.paye .has-paye {
   color: #454a4c;
 }
 
-details {
-  margin: 15px 0;
-}
-
 .panel-indent {
   margin: 0;
 


### PR DESCRIPTION
To align styles with [GDS](http://govuk-elements.herokuapp.com/#typography-hidden-text) by underlining *only* the summary text, nest a `span.summary` inside the `<summary>` element.
 
i.e.
```
<summary>
    <span class="summary">Authorisation levels explained</span>
</summary>
```

![image](https://cloud.githubusercontent.com/assets/1752124/7091264/7561c0ac-dfa0-11e4-9049-1decf841de70.png)
