### PR TITLE
use correct icon sizes instead of relying on background-size to scale up hmrc icon.

### DIFF
--- a/assets/scss/modules/_organisation-logo.scss
+++ b/assets/scss/modules/_organisation-logo.scss
@@ -12,7 +12,6 @@
   padding: 3px 0 2px 30px;
   background-image: url("../images/icons/crests/hmrc_crest_13px.png");
   background-position: 5px center;
-  background-size: auto 20px;
   background-repeat: no-repeat;
   border-left: 2px solid $hm-revenue-customs;
 
@@ -39,7 +38,6 @@ a.organisation-logo {
   padding: 20px 0 0 6px;
   background-image: url("../images/icons/crests/hmrc_crest_13px.png");
   background-position: 5px top;
-  background-size: auto 20px;
 }
 
 .organisation-logo-stacked span {
@@ -61,9 +59,8 @@ a.organisation-logo {
     font-size: 18px;
     line-height: 22px;
     padding: 3px 0 2px 38px;
-    background-image: url("../images/icons/crests/hmrc_crest_27px.png");
+    background-image: url("../images/icons/crests/hmrc_crest_18px.png");
     background-position: 6px center;
-    background-size: auto 25px;
     border-left: 2px solid $hm-revenue-customs;
   }
 }
@@ -77,9 +74,8 @@ a.organisation-logo {
   @extend .organisation-logo-medium;
   @include media(tablet){
     padding: 25px 0 0 7px;
-    background-image: url("../images/icons/crests/hmrc_crest_27px.png");
+    background-image: url("../images/icons/crests/hmrc_crest_18px.png");
     background-position: 6px top;
-    background-size: auto 25px;
   }
 }
 
@@ -92,7 +88,7 @@ a.organisation-logo {
   @media all and (-webkit-min-device-pixel-ratio: 2) {
     .organisation-logo-medium,
     .organisation-logo-stacked-medium {
-      background-image: url("../images/icons/crests/hmrc_crest_27px_x2.png");
+      background-image: url("../images/icons/crests/hmrc_crest_18px_x2.png");
     }
   }
 }


### PR DESCRIPTION
resolves #131