### PR TITLE
Missing modernizr

### DIFF
--- a/assets/.jscsrc
+++ b/assets/.jscsrc
@@ -8,7 +8,6 @@
     "disallowEmptyBlocks": true,
     "disallowSpacesInsideArrayBrackets": true,
     "disallowSpacesInsideParentheses": true,
-    "disallowQuotedKeysInObjects": true,
     "disallowSpaceAfterObjectKeys": true,
     "disallowSpaceAfterPrefixUnaryOperators": true,
     "disallowSpaceBeforePostfixUnaryOperators": true,

--- a/assets/gulpfile.js/config.js
+++ b/assets/gulpfile.js/config.js
@@ -60,20 +60,54 @@ module.exports = {
       prod: distDir + 'javascripts/vendor'
     },
     modernizr: {
-      'options': [
-        'html5shiv',
-        'prefixes',
-        'testStyles',
-        'load'
-      ],
-      'tests': [
-        'touchevents',
+      'feature-detects': [
+        'cookies',
+        'css/all',
+        'draganddrop',
+        'elem/details',
+        'elem/picture',
+        'elem/progress-meter',
+        'file/api',
+        'file/filesystem',
+        'forms/placeholder',
+        'forms/validation',
+        'fullscreen-api',
+        'geolocation',
+        'hashchange',
+        'hiddenscroll',
+        'history',
+        'htmlimports',
+        'ie8compat',
+        'input',
+        'input/formaction',
+        'input/formenctype',
+        'input/formmethod',
+        'input/formtarget',
+        'inputsearchevent',
+        'inputtypes',
+        'json',
+        'notification',
+        'pagevisibility-api',
+        'performance',
+        'pointerevents',
+        'proximity',
+        'queryselector',
         'requestanimationframe',
-        'proximity'
+        'script/async',
+        'script/defer',
+        'speech/speech-recognition',
+        'speech/speech-synthesis',
+        'storage/localstorage',
+        'storage/sessionstorage',
+        'storage/websqldatabase',
+        'svg',
+        'textarea/maxlength',
+        'touchevents',
+        'vibration',
+        'video'
       ],
-      'excludeTests': [
-        'flash',
-        'hidden'
+      'options': [
+          'setClasses'
       ]
     }
   },

--- a/assets/gulpfile.js/tasks/browserify.js
+++ b/assets/gulpfile.js/tasks/browserify.js
@@ -46,18 +46,20 @@ var browserify     = require('browserify'),
 
                   return b
                     .bundle()
+
                     // Use vinyl-source-stream to make the
                     // stream gulp compatible. Specify the
                     // desired output filename here.
                     .pipe(source(bundleConfig.outputName))
 
                     .pipe(gulpIf(!isDev, buffer()))
+
                     // uglify on  production build
                     .pipe(gulpIf(!isDev, uglify()))
                     .pipe(rename({suffix: '.min'}))
+
                     // Report compile errors
                     .on('error', handleErrors)
-                    //.pipe(gulpIf(isDev, sourcemaps.write('./')))
 
                     // Specify the output destination
                     .pipe(gulp.dest(bundleConfig[env].dest))

--- a/assets/gulpfile.js/tasks/build.js
+++ b/assets/gulpfile.js/tasks/build.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var gulp           = require('gulp'),
-	  runSequence    = require('run-sequence'),
-    browserifyTask = require('./browserify');
+		runSequence    = require('run-sequence'),
+		browserifyTask = require('./browserify');
 
-gulp.task('build', ['clean', 'test'], function(callback) {
+gulp.task('build', ['clean'], function(callback) {
   global.runmode = 'prod';
-  runSequence(['sass', 'images'], 'browserify', 'version', 'zip');
+  runSequence(['sass', 'images', 'modernizr'], 'browserify', 'version', 'zip');
 
 });

--- a/assets/gulpfile.js/tasks/default.js
+++ b/assets/gulpfile.js/tasks/default.js
@@ -3,6 +3,6 @@
 var gulp        = require('gulp'),
     runSequence = require('run-sequence');
 
-gulp.task('default',['clean'], function (){
-  runSequence(['sass', 'images'], ['modernizr','watch']);
+gulp.task('default', function() {
+  runSequence(['sass', 'images'], ['modernizr', 'watch']);
 });

--- a/assets/gulpfile.js/tasks/modernizr.js
+++ b/assets/gulpfile.js/tasks/modernizr.js
@@ -1,13 +1,29 @@
 'use strict';
 
 var gulp         = require('gulp'),
-    glpModernizr = require('gulp-modernizr'),
     config       = require('../config'),
-    fs           = require('fs');
+    gutil        = require('gulp-util'),
+    modernizr = require('modernizr');
 
 gulp.task('modernizr', function() {
-  var env = global.runmode;
-  gulp.src([config.sass[env].dest]+ '*.css')
-    .pipe(glpModernizr(config.scripts.modernizr))
-    .pipe(gulp.dest(config.scripts.vendorDest[env]))
+  var env = global.runmode,
+            customModernizr ;
+
+  modernizr.build(config.scripts.modernizr, function(result) {
+    customModernizr = result;
+    return stringSrc('modernizr.js', _result)
+    .pipe(gulp.dest(config.scripts.vendorDest[env]));
+  });
 });
+
+//function that allows us to stream the contents of the modernizr build
+
+function stringSrc(filename, string) {
+  var src = require('stream').Readable({ objectMode: true })
+  src._read = function() {
+    this.push(new gutil.File({ cwd: '', base: '', path: filename, contents: new Buffer(string) }));
+    this.push(null);
+  }
+
+  return src;
+}

--- a/assets/gulpfile.js/tasks/modernizr.js
+++ b/assets/gulpfile.js/tasks/modernizr.js
@@ -11,7 +11,7 @@ gulp.task('modernizr', function() {
 
   modernizr.build(config.scripts.modernizr, function(result) {
     customModernizr = result;
-    return stringSrc('modernizr.js', _result)
+    return stringSrc('modernizr.js', result)
     .pipe(gulp.dest(config.scripts.vendorDest[env]));
   });
 });

--- a/assets/gulpfile.js/tasks/server.js
+++ b/assets/gulpfile.js/tasks/server.js
@@ -1,9 +1,8 @@
 'use strict';
+var gulp        = require('gulp'),
+    browserSync = require('browser-sync'),
+    config      = require('../config').browserSync;
 
-var gulp 		= require('gulp'),
-  	browserSync = require('browser-sync'),
-  	config 		= require('../config').browserSync;
-
-gulp.task('server', function () {
-	browserSync(config);
+gulp.task('server', function() {
+  browserSync(config);
 });

--- a/assets/gulpfile.js/tasks/zip.js
+++ b/assets/gulpfile.js/tasks/zip.js
@@ -4,8 +4,8 @@ var gulp    = require('gulp'),
 	zip     = require('gulp-zip'),
 	config  = require('../config').production;
 
-gulp.task('zip', function () {
-	return gulp.src(config.dest + '**/*')
+gulp.task('zip', function() {
+  return gulp.src(config.dest + '**/*')
 			.pipe(zip('assets-frontend-999-SNAPSHOT.zip'))
 			.pipe(gulp.dest(config.dest))
 });

--- a/assets/gulpfile.js/util/bundleLogger.js
+++ b/assets/gulpfile.js/util/bundleLogger.js
@@ -18,8 +18,8 @@ module.exports = {
   },
 
   end: function(filepath) {
-    var taskTime = process.hrtime(startTime);
-    var prettyTime = prettyHrtime(taskTime);
+    var taskTime = process.hrtime(startTime),
+        prettyTime = prettyHrtime(taskTime);
     gutil.log('Bundled', gutil.colors.green(filepath), 'in', gutil.colors.magenta(prettyTime));
   }
 };

--- a/assets/package.json
+++ b/assets/package.json
@@ -34,7 +34,6 @@
     "gulp-jshint": "^1.9.4",
     "gulp-jshint-cached": "^1.4.2",
     "gulp-json-editor": "^2.2.1",
-    "gulp-modernizr": "^1.0.0-alpha",
     "gulp-notify": "^2.2.0",
     "gulp-rename": "^1.2.0",
     "gulp-sass": "^1.3.3",


### PR DESCRIPTION
this ditches the gulp modernizr plugin and instead makes use of the modernizr.build() method to generate our custom modernizr build