### PR TITLE
AOSS-329 Ajax behaviour for PAYE Client List page

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -138,6 +138,38 @@ $(function() {
 
   toggleDynamicFormFields();
 
+  window.GOVUK.callbacks = window.GOVUK.callbacks || {
+      ajaxFormSubmit: {
+        clientList: {
+          insertFormResponse: {
+            success: function(response, data, container, type) {
+              var re = new RegExp('&?email=([^&]+)', 'gi'),
+                emails = data.match(re);
+
+              if (type === 'replace') {
+                $(container).replaceWith(response);
+              } else {
+                // 'insert'
+                $(container).html(response);
+              }
+
+              if (!!emails.length) {
+                $('input[name="email"]').each(function(index, element) {
+                  $(element).attr('value', decodeURIComponent(emails[0]).replace(re, '$1'));
+                });
+              }
+            },
+
+            error: function(xhr) {
+              var htmlText = xhr.responseText;
+              $('head').html(htmlText.substring(htmlText.indexOf('<head>') + 6, htmlText.indexOf('</head>')));
+              $('body').html(htmlText.substring(htmlText.indexOf('<body>') + 6, htmlText.indexOf('</body>')));
+            }
+          }
+        }
+      }
+    };
+
   //TODO: replace toggleDynamicFormField usage in all exemplars and rename this function
   ajaxFormSubmit.init();
   simpleToggleDynamicFormFields();

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -8,6 +8,7 @@ var setSSOLinks = require('./modules/SSO_links.js'),
     contentNudge = require('./modules/contentNudge.js'),
     tableRowClick = require('./modules/tableRowClick.js'),
     reportAProblem = require('./modules/reportAProblem.js'),
+    ajaxFormSubmit = require('./modules/ajaxFormSubmit.js'),
     preventDoubleSubmit = require('./modules/preventDoubleSubmit.js'),
     toggleContextualFields = require('./modules/toggleContextualFields.js'),
     toggleDynamicFormFields = require('./modules/toggleDynamicFormFields.js'),
@@ -138,6 +139,7 @@ $(function() {
   toggleDynamicFormFields();
 
   //TODO: replace toggleDynamicFormField usage in all exemplars and rename this function
+  ajaxFormSubmit.init();
   simpleToggleDynamicFormFields();
   questionnaireSubmission();
   registerBlockInputFields();

--- a/assets/javascripts/modules/ajaxFormSubmit.js
+++ b/assets/javascripts/modules/ajaxFormSubmit.js
@@ -1,0 +1,67 @@
+/**
+ * Submit a form via AJAX
+ *
+ * Hijack's a forms submit event and POSTs its data via AJAX to avoid page reloads.
+ *
+ * Usage:
+ *
+ *  Place the attribute 'data-ajax-submit="true"' on either a form tag or a button
+ *  that has a formaction attribute.
+ *
+ *  <form action="#" data-ajax-submit="true">
+ *      <input type="submit" value="Submit"/>
+ *  </form>
+ *
+ *  or
+ *
+ *  <button formaction="#" data-ajax-submit="true">Submit</button>
+ *
+ **/
+
+require('jquery');
+
+var ajaxFormSubmit = {
+
+  init: function() {
+    var path,
+        _this = this,
+        $ajaxForm = $('[data-ajax-submit]');
+
+    if (!$ajaxForm.length) {
+      return false;
+    }
+
+    $ajaxForm.parents('form').on('submit', function(event) {
+      event.preventDefault();
+
+      if ($ajaxForm[0].nodeName.toLowerCase() === 'button') {
+        path = $ajaxForm.attr('formaction');
+      }
+      else {
+        path = $ajaxForm.attr('action');
+      }
+
+      _this.doSubmit(path, $(this).serialize() + '&isAjax');
+    });
+  },
+
+  doSubmit: function(path, data) {
+    $.ajax({
+      url: path,
+      type: 'POST',
+      data: data
+    })
+    .done(function(result) {
+      console.log('success', result);
+    })
+    .fail(function(result) {
+      console.log('error', result);
+    })
+    .always(function(result) {
+      console.log('complete', result);
+    });
+  }
+
+};
+
+module.exports = ajaxFormSubmit;

--- a/assets/javascripts/modules/ajaxFormSubmit.js
+++ b/assets/javascripts/modules/ajaxFormSubmit.js
@@ -6,62 +6,128 @@
  * Usage:
  *
  *  Place the attribute 'data-ajax-submit="true"' on either a form tag or a button
- *  that has a formaction attribute.
+ *  that has:
+ *    - a formaction attribute for non-javascript enabled form post (full page reload)
+ *    - a 'data-container' attribute with a selector for the element which contains 'scoped' form values
+ *    - a 'data-callback-name' attribute with name-spaced object property name with contains 'success' and 'error' property functions
+ *    - a 'data-callback-args' attribute containing comma separated list of argument parameters to pass to callback:
+ *      + 1. the selector where the partial view content will be added
+ *      + 2. the method to use when adding new content to the container - options are 'insert' or 'replace' (insert is the default)
  *
- *  <form action="#" data-ajax-submit="true">
+ *
+ *
+ *  <form action="#"
+ *   data-ajax-submit="true"
+ *   data-container="#selector" data-callback-name="window.GOVUK.callbacks.[libraryname].[pagename].[functionname]"
+ *   data-callback-args="#selector,insert|replace">
  *      <input type="submit" value="Submit"/>
  *  </form>
  *
  *  or
  *
- *  <button formaction="#" data-ajax-submit="true">Submit</button>
+ *  <button class="button" type="submit" id="missing-client-submit" formaction="#"
+ *   data-ajax-submit="true"
+ *   data-container="#selector" data-callback-name="window.GOVUK.callbacks.[libraryname].[pagename].[functionname]"
+ *   data-callback-args="#selector,insert|replace">Submit</button>
  *
  **/
-
 require('jquery');
 
 var ajaxFormSubmit = {
 
   init: function() {
-    var path,
-        _this = this,
-        $ajaxForm = $('[data-ajax-submit]');
+    var _this = this,
+        $ajaxForm = $('form:has([data-ajax-submit])'),
+        ajaxFormCount = $ajaxForm.length,
+        a = 0,
+        $ajaxItem = null;
 
-    if (!$ajaxForm.length) {
-      return false;
+    for (; a < ajaxFormCount; a++) {
+      $ajaxItem = $($ajaxForm[a]);
+
+      $ajaxItem.on('submit', function(event) {
+        event.preventDefault();
+
+        var $this = $(this),
+            $form = $this.attr('data-ajax-submit') ? $this : $this.find('[data-ajax-submit]'),
+            path = $form.attr('formaction') || $form.attr('action'),
+            $scope = $form.attr('data-container') || $this,
+            serializedData = _this.serializeForAjax($scope),
+            callback = {
+              config: {
+                name: $form.attr('data-callback-name'),
+                args: $form.attr('data-callback-args')
+              },
+              fn: null
+            };
+
+        callback.fn = _this.getCalllback(callback.config, serializedData);
+
+        if (!!callback) {
+          _this.doSubmit(path, serializedData, callback.fn);
+        }
+      });
     }
-
-    $ajaxForm.parents('form').on('submit', function(event) {
-      event.preventDefault();
-
-      if ($ajaxForm[0].nodeName.toLowerCase() === 'button') {
-        path = $ajaxForm.attr('formaction');
-      }
-      else {
-        path = $ajaxForm.attr('action');
-      }
-
-      _this.doSubmit(path, $(this).serialize() + '&isAjax');
-    });
   },
 
-  doSubmit: function(path, data) {
+  doSubmit: function(path, data, callback) {
     $.ajax({
       url: path,
       type: 'POST',
       data: data
     })
     .done(function(result) {
-      console.log('success', result);
+      if (!!callback) {
+        callback('success', result);
+      }
     })
     .fail(function(result) {
-      console.log('error', result);
+      if (!!callback) {
+        callback('error', result);
+      }
     })
     .always(function(result) {
-      console.log('complete', result);
     });
-  }
+  },
 
+  serializeForAjax: function(formScope) {
+    var ret = ['isajax=true'];
+    $.each($(formScope).find(':input'), function() {
+      ret.push(encodeURIComponent(this.name) + '=' + encodeURIComponent($(this).val()));
+    });
+
+    return ret.join('&').replace(/%20/g, '+').replace(/=$/, '').replace(/&$/, '');
+  },
+
+  getCalllback: function(config, data) {
+    var parts = config.name.split('.'),
+        method = window;
+
+    if (!!config.name) {
+      if (!!config.args) {
+        config.parameters = [].concat(config.args.split(','));
+      }
+
+      if (!!data) {
+        config.parameters.unshift(data);
+      }
+
+      jQuery.each(parts, function(index, value) {
+        method = method[value];
+      });
+
+      return function(type, response) {
+        if (!!response) {
+          config.parameters.unshift(response);
+        }
+
+        method[type].apply(null, config.parameters);
+      };
+    }
+    else {
+      return null;
+    }
+  }
 };
 
 module.exports = ajaxFormSubmit;

--- a/assets/javascripts/modules/ajaxFormSubmit.js
+++ b/assets/javascripts/modules/ajaxFormSubmit.js
@@ -61,7 +61,7 @@ var ajaxFormSubmit = {
               fn: null
             };
 
-        callback.fn = _this.getCalllback(callback.config, serializedData);
+        callback.fn = _this.getCallback(callback.config, serializedData);
 
         if (!!callback) {
           _this.doSubmit(path, serializedData, callback.fn);
@@ -99,7 +99,7 @@ var ajaxFormSubmit = {
     return ret.join('&').replace(/%20/g, '+').replace(/=$/, '').replace(/&$/, '');
   },
 
-  getCalllback: function(config, data) {
+  getCallback: function(config, data) {
     var parts = config.name.split('.'),
         method = window;
 

--- a/assets/javascripts/modules/ajaxFormSubmit.js
+++ b/assets/javascripts/modules/ajaxFormSubmit.js
@@ -45,28 +45,31 @@ var ajaxFormSubmit = {
     for (; a < ajaxFormCount; a++) {
       $ajaxItem = $($ajaxForm[a]);
 
-      $ajaxItem.on('submit', function(event) {
-        event.preventDefault();
+      $ajaxItem.on('submit', {context: _this}, _this.submitHandler);
+    }
+  },
 
-        var $this = $(this),
-            $form = $this.attr('data-ajax-submit') ? $this : $this.find('[data-ajax-submit]'),
-            path = $form.attr('formaction') || $form.attr('action'),
-            $scope = $form.attr('data-container') || $this,
-            serializedData = _this.serializeForAjax($scope),
-            callback = {
-              config: {
-                name: $form.attr('data-callback-name'),
-                args: $form.attr('data-callback-args')
-              },
-              fn: null
-            };
+  submitHandler: function(event) {
+    event.preventDefault();
 
-        callback.fn = _this.getCallback(callback.config, serializedData);
+    var $this = $(this),
+      _this = event.data.context,
+      $form = $this.attr('data-ajax-submit') ? $this : $this.find('[data-ajax-submit]'),
+      path = $form.attr('formaction') || $form.attr('action'),
+      $scope = $form.attr('data-container') || $this,
+      serializedData = _this.serializeForAjax($scope),
+      callback = {
+        config: {
+          name: $form.attr('data-callback-name'),
+          args: $form.attr('data-callback-args')
+        },
+        fn: null
+      };
 
-        if (!!callback) {
-          _this.doSubmit(path, serializedData, callback.fn);
-        }
-      });
+    callback.fn = _this.getCallback(callback.config, serializedData);
+
+    if (!!callback) {
+      _this.doSubmit(path, serializedData, callback.fn);
     }
   },
 

--- a/assets/scss/base/_buttons.scss
+++ b/assets/scss/base/_buttons.scss
@@ -41,3 +41,9 @@ button, .button {
   @include button($grey-8);
   @include core-19();
 }
+
+.button--small {
+  @include button($button-colour);
+  @include core-16();
+  margin-top: 10px;
+}

--- a/assets/test/specs/ajaxFormSubmit.spec.js
+++ b/assets/test/specs/ajaxFormSubmit.spec.js
@@ -1,0 +1,283 @@
+require('jquery');
+
+describe('AjaxFormSubmit', function() {
+  var ajaxFormSubmit,
+    forms = [],
+    formCount = 0;
+    
+
+  beforeEach(function () {
+    this.originalTimeout = 0;
+    this.timeoutInterval = 2000;
+
+    jasmine.getFixtures().fixturesPath = "base/specs/fixtures/";
+
+    this.baseBeforeEachAsync = function (done, timeoutInterval) {
+      this.originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = timeoutInterval;
+      
+      loadFixtures('ajax-form-client-access-request.html');
+      forms = $("form[data-ajax-submit], button[data-ajax-submit], input[data-ajax-submit]");
+      formCount = forms.length;
+      ajaxFormSubmit = require('../../javascripts/modules/ajaxFormSubmit.js');
+      ajaxFormSubmit.init();
+      
+      setTimeout(function () {
+        done();
+      }, 1);
+    };
+
+  });
+
+  afterEach(function (done) {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = this.originalTimeout;
+    done();
+  });
+  
+  describe('When the client access request fixture loads', function() {
+    beforeEach(function (done) {
+      this.baseBeforeEachAsync(done, 2000);
+    });
+    
+    it('Form element is present', function() {
+      expect($('#verify-form').length).toBeTruthy();
+    });
+    
+    for (var e = 0; e < formCount; e++) {
+      var payeId = Array(4).join(e.toString()) + "/Z" + Array(4).join(e.toString()),
+          panelId = '#client_' + payeId.replace('/', '') + '_notes';
+      
+      it('Form elements for PAYE Ref '+ payeId + ' are present', function () {
+        var $formPanel = $(panelId);
+        expect($formPanel.find('input[name="csrfToken"]')).toBeDefined();
+        expect($formPanel.find('input[name="csrfToken"]').attr('value').length).toBeTruthy();
+
+        expect($formPanel.find('input[name="name"]')).toBeDefined();
+        expect((/^Employer[0-9]$/i).test($formPanel.find('input[name="name"]').attr('value'))).toBe(true);
+
+        expect($formPanel.find('input[name="payeref"]')).toBeDefined();
+        expect((/^[0-9]{3}\/[A-Z][0-9]{3}$/i).test($formPanel.find('input[name="payeref"]').attr('value'))).toBe(true);
+
+        expect($formPanel.find('input[name="email"]')).toBeDefined();
+      });
+
+      it('Form button attributes for PAYE Ref '+ payeId + ' are present', function () {
+        var $button = $(panelId + ' > details > .panel-indent > .button');
+        expect($button.length).toBeTruthy();
+
+        expect($button.attr('data-ajax-submit')).not.toBeUndefined();
+        expect($button.attr('data-ajax-submit')).toBe('true');
+
+        expect($button.attr('data-container')).not.toBeUndefined();
+        expect((/^#client_[0-9]{3}[A-Z][0-9]{3}_notes$/i).test($button.attr('data-container'))).toBe(true);
+
+        expect($button.attr('data-callback-name')).not.toBeUndefined();
+        expect($button.attr('data-callback-name')).toBe('window.callbacks.ajaxFormSubmit.clientList.insertFormResponse');
+
+        expect($button.attr('data-callback-args')).not.toBeUndefined();
+
+        var callbackArgs = $button.attr('data-callback-args').split(',');
+        expect(callbackArgs.length).toBe(2);
+        expect(callbackArgs[0]).toBe($button.attr('data-container'));
+        expect(callbackArgs[1]).toBe('insert');
+        expect(callbackArgs[1]).not.toBe('replace');
+      });
+    }
+  });
+  
+  describe('When the "ajaxFormSubmit.js" is loaded in the client access request fixture', function() {
+    beforeEach(function (done) {
+      this.baseBeforeEachAsync(done, 2000);
+      done();
+    });
+    
+    it("the 'ajaxFormSubmit' var loads if we wait", function (done) {
+      setTimeout(function () {
+        expect(ajaxFormSubmit).toBeDefined();
+        done();
+      }, this.timeoutInterval - 500);
+    });
+
+    it("the 'ajaxFormSubmit.init' property is available", function (done) {
+      setTimeout(function () {
+        expect(ajaxFormSubmit.init).toBeDefined();
+        expect(typeof ajaxFormSubmit.init).toBe('function');
+        done();
+      }, this.timeoutInterval - 500);
+    });
+
+    it("the 'ajaxFormSubmit.doSubmit' property is available", function (done) {
+      setTimeout(function () {
+        expect(ajaxFormSubmit.doSubmit).toBeDefined();
+        expect(typeof ajaxFormSubmit.doSubmit).toBe('function');
+        // doSubmit: function(path, data, targetContainer, targetType, callback
+        done();
+      }, this.timeoutInterval - 500);
+    });
+
+    it("the 'ajaxFormSubmit.serializeForAjax' property is available", function (done) {
+      setTimeout(function () {
+        expect(ajaxFormSubmit.serializeForAjax).toBeDefined();
+        expect(typeof ajaxFormSubmit.serializeForAjax).toBe('function');
+        // serializeForAjax: function(formScope)
+        done();
+      }, this.timeoutInterval - 500);
+    });
+
+    it("the 'ajaxFormSubmit.getCalllback' property is available", function (done) {
+      setTimeout(function () {
+        expect(ajaxFormSubmit.getCalllback).toBeDefined();
+        expect(typeof ajaxFormSubmit.getCalllback).toBe('function');
+        // getCalllback: function(config, data)
+        done();
+      }, this.timeoutInterval - 500);
+    });
+  });
+  
+  describe('When the "ajaxFormSubmit.js" is initialized in the client access request fixture', function() {
+    beforeEach(function (done) {
+      this.baseBeforeEachAsync(done, 2000);
+      done();
+    });
+
+    it("'doSubmit' handler is bound to the client access form", function (done) {
+      setTimeout(function () {
+        var handlers = $._data($('#verify-form')[0], 'events');
+
+        expect(handlers.submit.length).toBeTruthy();
+        expect(typeof handlers.submit[0].handler).toBe("function");
+
+        var formHandler;
+
+        for (var f = 0; f < handlers.submit.length; f++) {
+          var h = handlers.submit[f].handler;
+
+          if (h.toString().indexOf(".doSubmit(") > -1) {
+            formHandler = h;
+          }
+        }
+
+        expect(formHandler).toBeDefined();
+
+        done();
+      }, this.timeoutInterval - 500);
+    });
+  });
+
+  describe("When 'serializeForAjax' creates a data string for the scoped form ONLY", function () {
+    
+    var scopeForms = [],
+        scopeCount = 0;
+    
+    beforeEach(function (done) {
+      this.baseBeforeEachAsync(done, 10000);
+
+      setTimeout(function () {
+        for (var e = 0; e < formCount; e++) {
+          var payeId = Array(4).join(e.toString()) + "/Z" + Array(4).join(e.toString()),
+            containerId = '#client_' + payeId.replace('/', '') + '_notes',
+            data = ajaxFormSubmit.serializeForAjax(containerId);
+
+          scopeForms.push({
+            payeId: payeId,
+            containerId: containerId,
+            $fields: $(containerId).find('input[name]'),
+            serial: data.replace(/&?isajax=true&?/i, '').split('&')
+          });
+          scopeCount++;
+        }
+        done();
+      }, this.timeoutInterval - 500);
+    });
+
+    it('scoped forms exist',function(done) {
+      setTimeout(function () {
+        expect(scopeCount).toBeTruthy();
+        done();
+      }, this.timeoutInterval - 500);
+    });
+
+    it('serialized form fields match field values', function (done) {
+      setTimeout(function () {
+        for (var f = 0; f < scopeCount; f++) {
+          var form = scopeForms[f],
+            data = form.serial,
+            count = data.length,
+            $fields = form.$fields,
+            fieldCount = $fields.length,
+            dataValues = {};
+        
+          for (var d = 0; d < count; d++) {
+            var kvp = data[d].split('=');
+            dataValues[kvp[0]] = kvp[1];
+          }
+        
+          for (var i = 0; i < fieldCount; i++) {
+            var $field = $($fields[i]),
+              name = $field.attr('name'),
+              value = $field.attr('value');
+            expect(dataValues[name]).toBe(encodeURIComponent(value));
+          }
+        }
+        done();
+      }, this.timeoutInterval - 500);
+    });
+
+  });
+
+  describe("When 'getCallback' gets the callback function", function() {
+    beforeEach(function (done) {
+      this.baseBeforeEachAsync(done, 2000);
+    });
+
+    for (var e = 0; e < formCount; e++) {
+      var payeId = Array(4).join(e.toString()) + "/Z" + Array(4).join(e.toString()),
+        panelId = '#client_' + payeId.replace('/', '') + '_notes';
+
+      it('The Button "data-callback" values for  '+ payeId + ' return a function', function () {
+        var $button = $(panelId + ' > details > .panel-indent > .button'),
+            callback = ajaxFormSubmit.getCalllback({
+          name: $button.attr('data-callback-name'),
+          args: $button.attr('data-callback-args')
+        }, ajaxFormSubmit.serializeForAjax($button.attr('data-container')));
+        expect(typeof callback).toBe("function");
+      });
+    }
+  });
+
+  describe('When the a client access request form is submitted', function() {
+    beforeEach(function (done) {
+      this.baseBeforeEachAsync(done, 2000);
+      done();
+    });
+
+    it("Makes an ajax post", function (done) {
+      setTimeout(function () {
+        debugger;
+
+        var callbackMethod = spyOn($, "ajax").and.callFake(function() {
+          this.done = function() {
+            return this; // "<p>You asked for access on d MMMM YYYY.</p><p>You’ll usually hear back within 2 days.</p>";
+          };
+          this.fail = function() { return this; };
+          this.always = function() { return this; };
+          return this;
+        });
+
+        if (forms[0].tagName === "FORM") {
+          forms[0].submit();
+        }
+        else {
+          forms[0].click();
+        }
+
+        expect(callbackMethod).toHaveBeenCalled();
+        expect(callbackMethod.calls.mostRecent().args[0].type).toBe("POST");
+        expect(callbackMethod.calls.mostRecent().args[0].data).toBe(
+          ajaxFormSubmit.serializeForAjax($(forms[0]).attr('data-callback-args').split(',')[0])
+        );
+        done();
+      }, this.timeoutInterval - 500);
+    });
+  });  
+});

--- a/assets/test/specs/ajaxFormSubmit.spec.js
+++ b/assets/test/specs/ajaxFormSubmit.spec.js
@@ -124,11 +124,11 @@ describe('AjaxFormSubmit', function() {
       }, this.timeoutInterval - 500);
     });
 
-    it("the 'ajaxFormSubmit.getCalllback' property is available", function (done) {
+    it("the 'ajaxFormSubmit.getCallback' property is available", function (done) {
       setTimeout(function () {
-        expect(ajaxFormSubmit.getCalllback).toBeDefined();
-        expect(typeof ajaxFormSubmit.getCalllback).toBe('function');
-        // getCalllback: function(config, data)
+        expect(ajaxFormSubmit.getCallback).toBeDefined();
+        expect(typeof ajaxFormSubmit.getCallback).toBe('function');
+        // getCallback: function(config, data)
         done();
       }, this.timeoutInterval - 500);
     });
@@ -236,7 +236,7 @@ describe('AjaxFormSubmit', function() {
 
       it('The Button "data-callback" values for  '+ payeId + ' return a function', function () {
         var $button = $(panelId + ' > details > .panel-indent > .button'),
-            callback = ajaxFormSubmit.getCalllback({
+            callback = ajaxFormSubmit.getCallback({
           name: $button.attr('data-callback-name'),
           args: $button.attr('data-callback-args')
         }, ajaxFormSubmit.serializeForAjax($button.attr('data-container')));

--- a/assets/test/specs/fixtures/ajax-form-client-access-request.html
+++ b/assets/test/specs/fixtures/ajax-form-client-access-request.html
@@ -1,0 +1,103 @@
+<script>
+    window.callbacks = window.callbacks || {
+                ajaxFormSubmit: {
+                    clientList: {
+                        insertFormResponse: {
+                            success: function (response, data, container, type) {
+                            },
+
+                            error: function (xhr) {
+                            }
+                        }
+                    }
+                }
+            };
+</script>
+<form id="verify-form" method="post" action="/agent/client-list" class="js-datatable-wrapper">
+    <div id="client_000Z000_notes">
+        <p>You’re not authorised to view this account.</p>
+        <details id="ask-for-access-000Z000" role="group">
+            <summary role="button" aria-controls="details-content-0" tabindex="0" aria-expanded="false">
+                <span class="summary">Ask for access</span>
+            </summary>
+            <div class="panel-indent" id="details-content-0" aria-hidden="true" style="display: none;">
+                <input type="hidden" name="csrfToken"
+                       value="00000a000aa00000aaa0000aa00aa0aaa0a00000-0000000000000-0a00000000aa0000a0a00aa0">
+                <input name="name" type="hidden" value="Employer0">
+                <input name="payeref" type="hidden" value="000/Z000">
+                <label for="email" class="form-label">Your email</label>
+                <input name="email" id="ask-for-access-000Z000-email" class="input--fullwidth" type="text"
+                       value="test@email.com">
+                <button class="button button--small" type="submit" id="ask-for-access-000Z000-submit"
+                        formaction="client-access-request.html" data-ajax-submit="true"
+                        data-container="#client_000Z000_notes"
+                        data-callback-name="window.callbacks.ajaxFormSubmit.clientList.insertFormResponse"
+                        data-callback-args="#client_000Z000_notes,insert">
+                    Send
+                </button>
+            </div>
+        </details>
+    </div>
+    <div id="client_111Z111_notes">
+        <p>You’re not authorised to view this account.</p>
+        <details id="ask-for-access-111Z111" role="group">
+            <summary role="button" aria-controls="details-content-0" tabindex="0" aria-expanded="false">
+                <span class="summary">Ask for access</span>
+            </summary>
+
+            <div class="panel-indent" id="details-content-1" aria-hidden="true" style="display: none;">
+                <input type="hidden" name="csrfToken"
+                       value="11111b111bb11111bbb1111bb11bb1bbb1b11111-1111111111111-1b11111111bb1111b1b11bb1">
+                <input name="name" type="hidden" value="Employer1">
+                <input name="payeref" type="hidden" value="111/Z111">
+                <label for="email" class="form-label">Your email</label>
+                <input name="email" id="ask-for-access-111Z111-email" class="input--fullwidth" type="text"
+                       value="foo@bar.com">
+                <button class="button button--small" type="submit" id="ask-for-access-111Z111-submit"
+                        formaction="client-access-request.html" data-ajax-submit="true"
+                        data-container="#client_111Z111_notes"
+                        data-callback-name="window.callbacks.ajaxFormSubmit.clientList.insertFormResponse"
+                        data-callback-args="#client_111Z111_notes,insert">
+                    Send
+                </button>
+            </div>
+        </details>
+    </div>
+</form>
+
+<details id="missing-client" role="group" open="">
+    <summary role="button" aria-controls="details-content-1" tabindex="0" aria-expanded="true">
+        <span class="summary">Can't find your client?</span>
+    </summary>
+    <div class="panel-indent" id="details-content-2" aria-hidden="false" style="display: block;">
+        <p>You can’t see clients authorised with a paper 64-8 form only.</p>
+        <strong>Ask for access for missing 64-8 clients</strong>
+
+
+        <form action="/agent/client-list/client-access-request" method="POST" id="missing-client-form"
+              class="form-group">
+
+            <input type="hidden" name="csrfToken"
+                   value="22222c222cc22222ccc2222cc22cc2ccc2c22222">
+
+            <label for="paye-reference" class="form-label">PAYE reference</label>
+
+            <input name="payeref" id="missing-client-paye-ref" type="text" value="">
+
+            <label for="email" class="form-label">Your email</label>
+
+
+            <input name="email" id="missing-client-email" type="text" value="agent@agency.com">
+
+
+            <input name="missingclient" type="hidden" value="true">
+            <button class="button" type="submit" id="missing-client-submit"
+                    formaction="/agent/client-list/client-access-xhr-request" data-ajax-submit="true"
+                    data-container="#missing-client-form"
+                    data-callback-name="window.GOVUK.callbacks.ajaxFormSubmit.clientList.insertFormResponse"
+                    data-callback-args="#missing-client-form,replace">Send
+            </button>
+
+        </form>
+    </div>
+</details>


### PR DESCRIPTION
Adds AJAX form POST handler, using form/button element attributes to override the HTML form submit event:
 * POSTs data via AJAX to avoid page reloads;
 * Configure data callback functions for success or error in name-spaced object under properties for 'page > module';
 * USAGE:  
   Place the attribute `data-ajax-submit="true"` on either a form tag or a button
   that has:
     - a `formaction` attribute for non-javascript enabled form post (full page reload)
     - a `data-container` attribute with a selector for the element which contains 'scoped' form values to be posted;
     - a `data-callback-name` attribute with name-spaced object property name with contains 'success' and 'error' property functions;
     - a `data-callback-args` attribute containing comma separated list of argument parameters to pass to callback:
       + 1. the selector for the target element (e.g. where the partial view content will be added);
       + 2. other parameters (e.g. the method to use when adding new content to the container - options are 'insert' or 'replace';

 * EXAMPLES:
   ```
<form action="#"
    data-ajax-submit="true"
    data-container="#selector" data-callback-name="window.GOVUK.callbacks.[libraryname].[pagename].[functionname]"
    data-callback-args="#selector,insert|replace">
       <input type="submit" value="Submit"/>
   </form>
```
   or
```
   <button class="button" type="submit" id="missing-client-submit" formaction="#"
    data-ajax-submit="true"
    data-container="#selector" data-callback-name="window.GOVUK.callbacks.[libraryname].[pagename].[functionname]"
    data-callback-args="#selector,insert|replace">Submit</button>
```

