### PR TITLE
AOSS-680 - Client list page error message styling

### DIFF
--- a/assets/scss/pages/_client-list.scss
+++ b/assets/scss/pages/_client-list.scss
@@ -22,3 +22,37 @@
     width: 28%;
   }
 }
+
+$client-list-error-background: #fef7f7;
+.missing-client-details,
+.client-access-details {
+  .form-field {
+    &.error,
+    &>.alert {
+      background-color: $client-list-error-background;
+    }
+    &.error {
+      padding: 0.75em 1em 1em 1em;
+    }
+
+    &>.alert {
+      margin-bottom: 0;
+      border-left-style: none;
+      padding: 0;
+      .error-message {
+        @include bold-16;
+      }
+    }
+
+    &.error {
+      border-left-width: 4px;
+    }
+    
+    &.error > input[type="text"] {
+      border: 4px solid $alert-bg-red;
+    }
+  }
+}
+.client-access-details .form-field.error {
+  margin-left: -1.1875em;
+}

--- a/assets/test/specs/ajaxCallbacks.spec.js
+++ b/assets/test/specs/ajaxCallbacks.spec.js
@@ -126,39 +126,41 @@ describe('AjaxCallbacks', function () {
 
     describe('.isFullPageError() should return', function () {
       var fullPageError = '<div style="visibility:hidden"><p>blah</p><h1>Sorry, we’re experiencing technical difficulties</h1><p>blah</p></div>',
-          $fullPageError = setFixtures(fullPageError),
-          $heading = $fullPageError.find('h1');
+          $fullPageError = setFixtures(fullPageError);
 
       it('true, when page contains full page error heading and text', function () {
+        var $heading = $fullPageError.find('h1');
         expect($heading.length).toBeTruthy();
         expect($heading.text().length).toBeTruthy();
 
-        expect(helpers.utilities.isFullPageError($heading)).toBe(true);
+        expect(helpers.utilities.isFullPageError(helpers, $fullPageError.html())).toBe(true);
       });
 
       it('false when page contains full page error heading without text', function () {
-        var $headingNoText = $heading.clone();
-        $headingNoText.text('');
+        var $fullPageErrorClone = $fullPageError.clone(),
+            $headingNoText = $fullPageErrorClone.find('h1');
 
         expect($headingNoText.length).toBeTruthy();
+        
+        $headingNoText.text('');
         expect($headingNoText.text().length).toBeFalsy();
 
-        expect(helpers.utilities.isFullPageError($headingNoText)).toBe(false);
+        expect(helpers.utilities.isFullPageError(helpers, $fullPageErrorClone.html())).toBe(false);
       });
       
-      it('false when heading param is null', function () {
-        expect(helpers.utilities.isFullPageError(null)).toBe(false);
+      it('false when html param is null', function () {
+        expect(helpers.utilities.isFullPageError(helpers, null)).toBe(false);
       });
 
-      it('false when heading param is undefined', function () {
-        expect(helpers.utilities.isFullPageError(undefined)).toBe(false);
+      it('false when html param is undefined', function () {
+        expect(helpers.utilities.isFullPageError(helpers, undefined)).toBe(false);
       });
 
-      it('false when heading param is empty string', function () {
-        expect(helpers.utilities.isFullPageError('')).toBe(false);
+      it('false when html param is empty string', function () {
+        expect(helpers.utilities.isFullPageError(helpers, '')).toBe(false);
       });
 
-      it('false when heading param is missing', function () {
+      it('false when html param is missing', function () {
         expect(helpers.utilities.isFullPageError()).toBe(false);
       });
       


### PR DESCRIPTION
* update client-list page CSS with error message styling
![image](https://cloud.githubusercontent.com/assets/5468091/8875728/12c0617c-3213-11e5-86bb-346d3e615d14.png)

* update ajaxCallbacks.helpers.insertResponseHtml:
  + use $.parseHtml (error partial view may have more than 1 validation error on missing client form)
  + handle error positioning (between label and invalid field)