### PR TITLE
[PE-1518] Remove float styles that are causing clipping in "mobile" view

### DIFF
--- a/assets/scss/base/_form.scss
+++ b/assets/scss/base/_form.scss
@@ -13,8 +13,6 @@ fieldset {
   width: 100%;
   legend {
     width: 100%;
-    float: left;
-    clear: right;
     margin-bottom: 0.75em;
     &.h2-heading {
       margin: 0 0 0.25em 0;


### PR DESCRIPTION
Having the float information 
```
float: left;
clear: right;
```
on `fieldset legend` was causing clipping of the `legend` when in mobile view.

I had a sanity check with @benaveryee on YTA and this also fixed the same problem for him.

@stingrayfunk as cleanup potentially [this](https://github.com/hmrc/assets-frontend/blob/master/assets/scss/pages/_payments.scss#L22-L24) over ride could be removed now?

### Before
![screen shot 2015-10-06 at 13 04 46](https://cloud.githubusercontent.com/assets/2305016/10308074/3c0af0d6-6c2b-11e5-915e-110a4400d075.png)

### After
![screen shot 2015-10-06 at 13 05 04](https://cloud.githubusercontent.com/assets/2305016/10308081/4537448e-6c2b-11e5-8e33-1c7273fac413.png)

