### PR TITLE
Fixed JQuery Id lookup issue when input key contains dots

### DIFF
--- a/assets/javascripts/modules/validatorFocus.js
+++ b/assets/javascripts/modules/validatorFocus.js
@@ -9,7 +9,7 @@
     $('.error-summary a').on('click', function(e) {
       e.preventDefault();
       var focusId = $(this).attr('data-focuses'),
-        inputToFocus = $('#' + focusId),
+        inputToFocus = $('[id=\'' + focusId + '\']'),
         inputTagName = inputToFocus.prop("tagName").toLowerCase(),
         nodeToScrollTo = inputToFocus;
 


### PR DESCRIPTION
JQuery treats anything after the `.` character as a class which is incorrect in the validator focus (linkable error summaries), instead it wants to match exactly to the input id.

For example an input with id something.something will become $('#something.something') which will fail to find the correct input element. The `.` character needs to be escaped with double backslash or using [id='something.something'].  