### PR TITLE
[YTA-1147] Styles and JS switch for mobile view of YTA help pages. Fi…

### DIFF
--- a/assets/javascripts/modules/helpAndContact.js
+++ b/assets/javascripts/modules/helpAndContact.js
@@ -4,78 +4,120 @@ module.exports = function() {
 
   var contactHmrc = '/contact-hmrc',
     baseUrlRegex = new RegExp(contactHmrc + '.*'),
+    subpathRegex = new RegExp('.*' + contactHmrc + '/'),
+    onHelpHomeRegex = new RegExp('.*' + contactHmrc + '/?$'),
 
-  updateSelectedMenuItem = function(selected) {
-    $('.menu__list li').removeClass('menu__list-item--selected');
-    var selectedLi = $('.menu__list a[href*='+selected+']').closest('li');
-    selectedLi.addClass('menu__list-item--selected');
-  },
+    supportsHistoryApi = function() {
+      return !!(window.history && history.pushState);
+    },
 
-  updateHistory = function(selected) {
-    var baseUrl = window.location.href.replace(baseUrlRegex, '');
-    var newUrl = baseUrl + contactHmrc + '/' + selected;
-    history.pushState(null, null, newUrl);
-  },
+    onHelpPage = function() {
+      return window.location.pathname.indexOf(contactHmrc) > -1;
+    },
 
-  updateHelpContent = function(partial) {
-    var ajaxUrl = '/business-account/contact-hmrc/partial/'+partial;
-    var $contentPane = $('.help-content');
-    $contentPane.load(ajaxUrl, function(response, status, xhr) {
-      if (status === 'error') {
-        location.reload();
+    isHelpHome = function(url) {
+      return onHelpHomeRegex.test(url);
+    },
+
+    addMobileViewClass = function() {
+      $('.help__wrapper').addClass('help-item--selected');
+    },
+
+    removeMobileViewClass = function() {
+      $('.help__wrapper').removeClass('help-item--selected');
+    },
+
+    getBaseUrl = function() {
+      return window.location.href.replace(baseUrlRegex, '');
+    },
+
+    getSubpage = function(url) {
+      if (isHelpHome(url)) {
+        return "";
       } else {
-        updateSelectedMenuItem(partial);
-        initYoutubeLinks();
-        applyDetailsPolyfill();
+        var helpSubPath = url.replace(subpathRegex, '');
+        if (helpSubPath.charAt(helpSubPath.length - 1) === '/') {
+          return helpSubPath.substring(0, helpSubPath.length - 2);
+        } else {
+          return helpSubPath;
+        }
       }
-    });
-  },
+    },
 
-  applyDetailsPolyfill = function() {
-    window.dispatchEvent(new Event('reapplyDetails'));
-  },
+    applyDetailsPolyfill = function() {
+      window.dispatchEvent(new Event('reapplyDetails'));
+    },
 
-  supportsHistoryApi = function() {
-    return !!(window.history && history.pushState);
-  },
+    updateSelectedMenuItem = function(selected) {
+      $('.side-nav li').removeClass('side-nav__list--selected');
+      if (selected) {
+        var selectedLi = $('.side-nav a[href*=' + selected + ']').closest('li');
+        selectedLi.addClass('side-nav__list--selected');
+      }
+    },
 
-  initYoutubeLinks = function() {
+    updateHistory = function(selected) {
+      var newUrl = getBaseUrl() + contactHmrc + '/' + selected;
+      history.pushState(null, null, newUrl);
+    },
 
-    // 'Jump links' to timed points in embedded YouTube video replace the iframe contents
-    var $videoIframe = $('#video-iframe');
-    if ($($videoIframe).length) {
-      $('.youtube-link').click(function(e) {
-        e.preventDefault();
-        var iframeUrl = $(this).attr('href').replace(/.*\//, 'https://www.youtube.com/embed/');
-        if (iframeUrl) {
-          $videoIframe.attr('src', iframeUrl);
-        }
-      });
-    }
-  },
+    updateHelpContent = function(subpage) {
+      var $contentPane = $('.help-content');
+      if (subpage) {
+        var ajaxUrl = '/business-account/contact-hmrc/partial/' + subpage;
+        $contentPane.load(ajaxUrl, function(response, status, xhr) {
+          if (status === 'error') {
+            location.reload();
+          } else {
+            updateSelectedMenuItem(subpage);
+            addMobileViewClass();
+            initYoutubeLinks();
+            applyDetailsPolyfill();
+          }
+        });
+      } else {
+        $contentPane.empty();
+        updateSelectedMenuItem('');
+        removeMobileViewClass();
+      }
+    },
 
-  init = function() {
+    initYoutubeLinks = function() {
+      var $videoIframe = $('#video-iframe');
+      if ($($videoIframe).length) {
+        $('.youtube-link').click(function(e) {
+          e.preventDefault();
+          var iframeUrl = $(this).attr('href').replace(/.*\//, 'https://www.youtube.com/embed/');
+          if (iframeUrl) {
+            $videoIframe.attr('src', iframeUrl);
+          }
+        });
+      }
+    },
 
-    // Allow Ajax help menu sub page switching
-    if (supportsHistoryApi()) {
+    init = function() {
 
-      $('.help-menu-link').click(function(e) {
-        e.preventDefault();
-        var partial = $(this).attr('href').replace(/.*\//, '');
-        updateHelpContent(partial);
-        updateHistory(partial);
-      });
+      // 'Jump links' to timed points in embedded YouTube video replace the iframe contents
+      initYoutubeLinks();
 
-      window.addEventListener('popstate', function (e) {
-        if (window.location.pathname.indexOf(contactHmrc) > -1) {
-          var partial = e.target.location.pathname.replace(/.*\//, '');
-          updateHelpContent(partial);
-        }
-      });
-    }
+      // Allow Ajax help menu sub page switching
+      if (supportsHistoryApi()) {
 
-    initYoutubeLinks();
-  };
+        $('.side-nav__link').click(function(event) {
+          event.preventDefault();
+          var subpage = getSubpage($(this).attr('href'));
+          updateHelpContent(subpage);
+          updateHistory(subpage);
+        });
+
+        window.addEventListener('popstate', function(event) {
+          if (onHelpPage()) {
+            var subpage = getSubpage(event.target.location.pathname);
+            updateHelpContent(subpage);
+          }
+        });
+      }
+    };
 
   return {
     init: init

--- a/assets/scss/modules/_side-navigation.scss
+++ b/assets/scss/modules/_side-navigation.scss
@@ -15,7 +15,7 @@
   list-style: none;
 }
 
-.side-nav__list--selected {
+.side-nav__list--selected, .side-nav__list--selected:hover {
   .side-nav__link {
     color: $white;
     background-color: $govuk-blue;

--- a/assets/scss/pages/_help.scss
+++ b/assets/scss/pages/_help.scss
@@ -8,60 +8,63 @@
     padding-bottom: 30px;
   }
 
+  details summary {
+    color: $govuk-blue;
+  }
+
   .help-menu {
-    float: left;
-    width: 30%;
-    border-right: 1px solid #bfc1c3;
+    width: 100%;
     margin: 0;
-    padding-bottom: 300px;
-  }
-
-  .menu__list, .menu__list-item {
-    margin: 0;
-  }
-
-  .menu__list-item {
-    a:focus {
-      background-color: inherit;
-      outline: 0;
-    }
-    &:hover {
-      background-color: #DEE0E2;
-    }
-    a:after {
-      content: '\203A';
-      float: right;
-      color: #005FA8;
-    }
-    a, a:visited {
-      text-decoration: none;
-      @include core-19;
-      color: #000;
-      display: block;
-      padding: 18px 15px;
-      &:hover {
-        color: #005FA8;
-      }
+    @include media(tablet) {
+      width: 30%;
+      float: left;
+      border-right: 1px solid #bfc1c3;
+      padding-bottom: 300px;
     }
   }
-
-  .menu__list-item--selected, .menu__list-item--selected:hover {
-    background-color: #005FA8;
-    a, a:visited {
-      color: #fff;
-    }
-    a:after {
-      color: #fff;
+  .help-item--selected .help-menu {
+    display: none;
+    @include media(tablet) {
+      display: initial;
+      width: 30%;
+      border-right: 1px solid #bfc1c3;
+      padding-bottom: 300px;
     }
   }
 
   .help-content {
-    float: right;
-    width: 66%;
+    width: 0;
+    display: none;
+    @include media(tablet) {
+      width: 66%;
+      display: initial;
+      float: right;
+    }
+  }
+  .help-item--selected .help-content {
+    width: 100%;
+    display: initial;
+    @include media(tablet) {
+      width: 66%;
+    }
   }
 
   .vertically-separated {
     margin: 10px 0;
   }
+
+  /* override styles in _side-navigation.scss */
+  .side-nav {
+    margin-top: 0;
+    @include media(mobile){
+      display: initial;
+    }
+  }
+
+  .side-nav__link {
+    @include core-19;
+    padding: 18px 15px;
+  }
+  /* end override styles */
 
 }


### PR DESCRIPTION
…x bugs in JS and refactor code for cleanliness.

[YTA-1147] Add and remove class on wrapper div rather than article.

[YTA-1147] Re-use YTA help page menu styles from _side-navigation.scss with a few overrides, and remove duplicate code.