### PR TITLE
Api 525 tweaks on regressed styles

### DIFF
--- a/assets/govuk_frontend_toolkit/stylesheets/_css3.scss
+++ b/assets/govuk_frontend_toolkit/stylesheets/_css3.scss
@@ -1,61 +1,86 @@
-// CSS 3 Mixins
+// CSS 3 mixins
 
-// Add them as you need them. This should let us manage vendor prefixes in one place.
+// This file includes mixins for CSS properties that require vendor prefixes.
 
+// Please add more mixins here as you need them, rather than adding them to
+// your application - this lets us manage them in one place.
+
+// You can use the @warn directive to deprecate a mixin where the property
+// no longer needs prefixes.
 
 @mixin border-radius($radius) {
-  -webkit-border-radius: $radius;
-     -moz-border-radius: $radius;
-          border-radius: $radius;
+  -webkit-border-radius: $radius; // Chrome 4.0, Safari 3.1 to 4.0, Mobile Safari 3.2, Android Browser 2.1
+  -moz-border-radius: $radius; // Firefox 2.0 to 3.6
+  border-radius: $radius;
 }
+
 @mixin box-shadow($shadow) {
-  -webkit-box-shadow: $shadow;
-     -moz-box-shadow: $shadow;
-          box-shadow: $shadow;
+  -webkit-box-shadow: $shadow; // Chrome 4.0 to 9.0, Safari 3.1 to 5.0, Mobile Safari 3.2 to 4.3, Android Browser 2.1 to 3.0
+  -moz-box-shadow: $shadow; // Firefox 3.5 to 3.6
+  box-shadow: $shadow;
 }
+
+@mixin scale($x, $y, $transform-origin: 50% 50% 0) {
+  // $x and $y should be numeric values without units
+  -webkit-transform: scale($x, $y); // Still in use now, started at: Chrome 4.0, Safari 3.1, Mobile Safari 3.2, Android 2.1
+  -moz-transform: scale($x, $y); // Firefox 3.5 to 15.0
+  -ms-transform: scale($x, $y); // IE9 only
+  transform: scale($x, $y);
+
+  -webkit-transform-origin: $transform-origin; // Chrome, Safari 3.1
+  -moz-transform-origin: $transform-origin; // Firefox 10 to 15.0
+  -ms-transform-origin: $transform-origin; // IE9
+  transform-origin: $transform-origin;
+}
+
 @mixin translate($x, $y) {
-  -webkit-transform: translate($x, $y);
-     -moz-transform: translate($x, $y);
-       -o-transform: translate($x, $y);
-          transform: translate($x, $y);
+  -webkit-transform: translate($x, $y); // Still in use now, started at: Chrome 4.0, Safari 3.1, Mobile Safari 3.2, Android 2.1
+  -moz-transform: translate($x, $y); // Firefox 3.5 to 15.0
+  -ms-transform: translate($x, $y); // IE9 only
+  -o-transform: translate($x, $y); // Opera 10.5 to 12.0
+  transform: translate($x, $y);
 }
 
 @mixin gradient($from, $to) {
-  background-color: $from; // fallback/image non-cover color
-  background-image: -moz-linear-gradient($from, $to); // Firefox 3.6+
-  background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from($from), to($to)); // Safari 4+, Chrome 1+
-  background-image: -webkit-linear-gradient($from, $to); // Safari 5.1+, Chrome 10+
-  background-image: -o-linear-gradient($from, $to); // Opera 11.10+
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$from}', endColorstr='#{$to}',GradientType=0 ); // IE6-9
+  // Creates a vertical gradient where $from is the colour at the top of the element
+  // and $to is the colour at the bottom. The top colour is used as a background-color
+  // for browsers that don't support gradients.
+  background-color: $from;
+  background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from($from), to($to)); // Safari 4.0 to 5.1, Chrome 1.0 to 10.0, old deprecated syntax
+  background-image: -webkit-linear-gradient($from, $to); // Chrome 10.0 to 25.0, Safari 5.1 to 6.0, Mobile Safari 5.0 to 6.1, Android Browser 4.0 to 4.3
+  background-image:    -moz-linear-gradient($from, $to); // Firefox 3.6 to 15.0
+  background-image:      -o-linear-gradient($from, $to); // Opera 11.1 to 12.0
+  background-image:         linear-gradient($from, $to);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$from}', endColorstr='#{$to}',GradientType=0 ); // IE6 to IE9
 }
 
 @mixin transition($property, $duration, $function, $delay: 0s) {
-  -webkit-transition: ($property $duration $function $delay);
-     -moz-transition: ($property $duration $function $delay);
-      -ms-transition: ($property $duration $function $delay);
-       -o-transition: ($property $duration $function $delay);
-          transition: ($property $duration $function $delay);
+  -webkit-transition: ($property $duration $function $delay); // Chrome 4.0 to 25.0, Safari 3.1 to 6.0, Mobile Safari 3.2 to 6.1, Android Browser 2.1 to 4.3
+  -moz-transition: ($property $duration $function $delay); // Firefox 4.0 to 15.0
+  -o-transition: ($property $duration $function $delay); // Opera 10.5 to 12.0
+  transition: ($property $duration $function $delay);
 }
 
-@mixin box-sizing($type) { // Acceptable values are border, content, and padding - content is the default W3C model
-  -webkit-box-sizing: $type;
-     -moz-box-sizing: $type;
-          box-sizing: $type;
+@mixin box-sizing($type) {
+  // http://www.w3.org/TR/css3-ui/#box-sizing
+  // $type can be one of: content-box | padding-box | border-box | inherit
+  -webkit-box-sizing: $type; // Chrome 4.0 to 9.0, Safari 3.1 to 5.0, Mobile Safari 3.2 to 4.3, Android Browser 2.1 to 3.0
+  -moz-box-sizing: $type; // Firefox 2.0 to 28.0, Firefox for Android 26.0 onwards
+  box-sizing: $type;
 }
 
 @mixin appearance($appearance) {
   -webkit-appearance: $appearance;
-     -moz-appearance: $appearance;
+  -moz-appearance: $appearance;
 }
 
 @mixin calc($property, $calc) {
-  #{$property}: -webkit-calc(#{$calc});
-  #{$property}: calc(#{$calc});
+  #{$property}: -webkit-calc(#{$calc}); // Chrome 19.0 to 25.0, Safari 6.0, Mobile Safari 6.0 to 6.1
+  #{$property}:         calc(#{$calc});
 }
 
 @mixin opacity($trans) {
   zoom: 1;
-  filter: unquote('alpha(opacity=' + ($trans * 100) + ')');
+  filter: unquote('alpha(opacity=' + ($trans * 100) + ')'); // IE6 to IE8
   opacity: $trans;
 }
-

--- a/assets/govuk_frontend_toolkit/stylesheets/_grid_layout.scss
+++ b/assets/govuk_frontend_toolkit/stylesheets/_grid_layout.scss
@@ -49,7 +49,7 @@ $site-width: 960px;
   }
 }
 
-// An extendable selector to define a row for grid columns to sit in
+// An extendable selector to define a row for grid columns to sit in using floats
 //
 // Usage:
 //
@@ -58,10 +58,61 @@ $site-width: 960px;
 // }
 
 %grid-row {
+  @extend %contain-floats;
+  margin: 0 (-$gutter-half);
+}
+
+// A mixin for a grid column
+// Creates a cross browser grid column with a standardised gutter between the
+// columns. Widths should be defined as fractions of the full desktop width
+// they want to fill. By default they break to become full width at tablet size
+// but that can be configured to be desktop using the `$full-width` argument.
+//
+// Usage:
+//
+//   .column-quarter {
+//     @include grid-column( 1/4 );
+//   }
+//   .column-half {
+//     @include grid-column( 1/2 );
+//   }
+//   .column-third {
+//     @include grid-column( 1/3 );
+//   }
+//   .column-two-thirds {
+//     @include grid-column( 2/3 );
+//   }
+//   .column-desktop-third {
+//     @include grid-column( 1/3, $full-width: desktop );
+//   }
+
+@mixin grid-column($width, $full-width: tablet, $float: left) {
+  @include media($full-width){
+    float: $float;
+    width: percentage($width);
+  }
+  @include ie-lte(7){
+    width: (($site-width + $gutter) * $width) - $gutter;
+  }
+
+  padding: 0 $gutter-half;
+  @include box-sizing(border-box);
+}
+
+
+// An extendable selector to define a row for grid columns to sit in using display:table
+//
+// Usage:
+//
+// .grid-row-table {
+//   @extend %grid-row-table;
+// }
+
+%grid-row-table {
   width: 100%;
   @include media(tablet){
-    margin-left: $gutter/2;
-    margin-right: $gutter/2;
+    margin-left: $gutter-half;
+    margin-right: $gutter-half;
     display: table;
   }
 }
@@ -90,12 +141,15 @@ $site-width: 960px;
 //     @include grid-column( 1/3, $full-width: desktop );
 //   }
 
-@mixin grid-column($width, $full-width: tablet) {
+@mixin grid-column-table($width, $full-width: tablet) {
   @include media($full-width){
     width: percentage($width);
   }
   @include ie-lte(7){
     width: (($site-width + $gutter) * $width) - $gutter;
   }
+  vertical-align: top;
+  display: table-cell;
+  width: 100%;
   @include box-sizing(border-box);
 }

--- a/assets/govuk_frontend_toolkit/stylesheets/_grid_layout.scss
+++ b/assets/govuk_frontend_toolkit/stylesheets/_grid_layout.scss
@@ -1,36 +1,101 @@
 @import '_conditionals.scss';
+@import '_css3.scss';
 @import '_measurements.scss';
 @import '_shims.scss';
 
-// Outer block sets a max width
-@mixin outer-block {
-  margin: 0 auto;
-  width: auto;
-  max-width: 960 + $gutter*2;
-  @extend %contain-floats;
-  @include ie-lte(8) {
-    width: 1020px;
+$site-width: 960px;
+
+// An extendable selector to wrap your entire site content block
+// It limits the sites width to be 960px wide and maintains consistent margins
+// on the site of the page and shrinks the margins for mobile.
+//
+// Usage:
+//
+// #page-container {
+//   @extend %site-width-container;
+// }
+
+%site-width-container {
+  max-width: $site-width;
+  @include ie-lte(8){
+    width: $site-width;
+  }
+
+  margin: 0 $gutter-half;
+  @include media(tablet){
+    margin: 0 $gutter;
+  }
+  @include media($min-width: ($site-width + $gutter * 2)){
+    margin: 0 auto;
   }
 }
 
-// Outer block usage:
+// An extendable selector to outdent to the full page-width
+// So that you can create elements that take up the gutters on the side of the
+// page and butt up to the edge of the browser on smaller screens (rather than
+// leaving a gutter at the edge of the page).
 //
-// .outer-block {
-//    @include outer-block;
+// Usage:
+//
+// .hero-image-container {
+//   @extend %outdent-to-full-width;
 // }
-
-// Inner block sets gutters to align content with header and footer
-@mixin inner-block {
-  padding-left: $gutter-half;
-  padding-right: $gutter-half;
-  @include media(tablet) {
-    padding-left: $gutter;
-    padding-right: $gutter;
+%outdent-to-full-width {
+  margin-left: -$gutter-half;
+  margin-right: -$gutter-half;
+  @include media(tablet){
+    margin-left: -$gutter;
+    margin-right: -$gutter;
   }
 }
 
-// Inner block usage:
+// An extendable selector to define a row for grid columns to sit in
 //
-// .inner-block {
-//    @include inner-block;
+// Usage:
+//
+// .grid-row {
+//   @extend %grid-row;
 // }
+
+%grid-row {
+  width: 100%;
+  @include media(tablet){
+    margin-left: $gutter/2;
+    margin-right: $gutter/2;
+    display: table;
+  }
+}
+
+// A mixin for a grid column
+// Creates a cross browser grid column with a standardised gutter between the
+// columns. Widths should be defined as fractions of the full desktop width
+// they want to fill. By default they break to become full width at tablet size
+// but that can be configured to be desktop using the `$full-width` argument.
+//
+// Usage:
+//
+//   .column-quarter {
+//     @include grid-column( 1/4 );
+//   }
+//   .column-half {
+//     @include grid-column( 1/2 );
+//   }
+//   .column-third {
+//     @include grid-column( 1/3 );
+//   }
+//   .column-two-thirds {
+//     @include grid-column( 2/3 );
+//   }
+//   .column-desktop-third {
+//     @include grid-column( 1/3, $full-width: desktop );
+//   }
+
+@mixin grid-column($width, $full-width: tablet) {
+  @include media($full-width){
+    width: percentage($width);
+  }
+  @include ie-lte(7){
+    width: (($site-width + $gutter) * $width) - $gutter;
+  }
+  @include box-sizing(border-box);
+}

--- a/assets/govuk_frontend_toolkit/stylesheets/_measurements.scss
+++ b/assets/govuk_frontend_toolkit/stylesheets/_measurements.scss
@@ -5,6 +5,7 @@ $one-quarter: $full-width/4;
 $one-third: $full-width/3;
 $half: $full-width/2;
 $two-thirds: ($full-width)-($one-third);
+$three-quarters: ($full-width)-($one-quarter);
 
 $gutter: 30px;
 $gutter-one-quarter: $gutter/4;

--- a/assets/scss/base/_grid.scss
+++ b/assets/scss/base/_grid.scss
@@ -16,46 +16,41 @@ Usage:
 */
 
 .grid-layout {
-  width: 100%;
-  @include contain-floats;
-  @include media(tablet){
-    margin-left: $gutter/2;
-    margin-right: $gutter/2;
-    display: table;
-  }
+  @extend %grid-row-table;
 }
 
 .grid-layout__column {
+  vertical-align: top;
   display: table-cell;
   width: 100%;
 }
 
 .grid-layout__column--1-4 {
   @include media(tablet) {
-    width: 25%;
+    @include grid-column-table(1/4);
   }
 }
 
 .grid-layout__column--1-3 {
   @include media(tablet) {
-    width: 33.333333333%;
+    @include grid-column-table(1/3);
   }
 }
 
 .grid-layout__column--1-2 {
   @include media(tablet) {
-    width: 50%;
+    @include grid-column-table(1/2);
   }
 }
 
 .grid-layout__column--2-3 {
   @include media(tablet) {
-    width: 66.666666667%;
+    @include grid-column-table(2/3);
   }
 }
 
 .grid-layout__column--3-4 {
   @include media(tablet) {
-    width: 75%;
+    @include grid-column-table(3/4);
   }
 }

--- a/assets/scss/modules/_breadcrumb.scss
+++ b/assets/scss/modules/_breadcrumb.scss
@@ -11,19 +11,18 @@
 </nav>
 */
 
-.breadcrumb-nav {
+.breadcrumb-nav {}
 
-  .breadcrumb-nav__item {
-    @include copy-16();
-    display: inline-block;
-  }
+.breadcrumb-nav__item {
+  @include copy-16();
+  display: inline-block;
+}
 
-  .breadcrumb-nav__item--trail {
-    margin-left: $gutter/5;
-    margin-right: $gutter/5;
+.breadcrumb-nav__item--trail {
+  margin-left: $gutter/5;
+  margin-right: $gutter/5;
 
-      &:after {
-        content: "›";
-      }
+  &:after {
+    content: "›";
   }
 }

--- a/assets/scss/modules/_side-navigation.scss
+++ b/assets/scss/modules/_side-navigation.scss
@@ -3,8 +3,6 @@
    ========================================================================== */
 
 .side-nav {
-  margin-top: $gutter;
-
   @include media(mobile) {
     display: none;
   }


### PR DESCRIPTION
- Tweaks for regressed styles
- Update some govuk_frontend_toolkit mixins/helpers
- Update the gird implementation to use styles taken from govuk_frontend_toolkit
- Use preferred BEM layout for styles (non nested)

#### Of Note
I have added the:
- **mixin grid-column-table**
- **placeholder selector” %grid-row-table**  

These are implementations from govuk_frontend_toolkit that use display:table rather than floats.
@rpowis this is first cut on this process.