### PR TITLE
AOSS-910 Firefox browser: Multiple Expand 

### DIFF
--- a/assets/scss/modules/_epaye-statements.scss
+++ b/assets/scss/modules/_epaye-statements.scss
@@ -155,6 +155,10 @@
       width: 100%;
       display: block;
       
+      &[aria-expanded=true] .summary::before {
+        content: "▼";
+      }
+      
       &.no-data {
         cursor: default;
         outline: none;
@@ -189,6 +193,11 @@
           padding: 0 2px;
           display: inline-block;
         }
+        
+      }
+
+      &> i.arrow {
+        @include accessibility;
       }
       
       .no-detail {
@@ -199,20 +208,12 @@
   }
 
   details[open] summary {
-    //&.no-data + div {
-    //  padding-top: 2px;
-    //}
     
     & > table {
       background-color: $grey-8;
     }
-
-    &[aria-expanded=true] .summary::before {
-      //transform: rotate(90deg);
-      content: "▼";
-    }
   }
-
+  
 
   .details {
     @include border-bottom-zero;


### PR DESCRIPTION
[AOSS-910](https://jira.tools.tax.service.gov.uk/browse/AOSS-910) Firefox browser: Multiple Expand icons for statements on the L&P page

* details.polyfill.js injects `<i class="arrow" />` where `<details />` is NOT native
 - 2 icons appear in Firefox 41.0.2