### PR TITLE
GG-292: improve error functionality, refactor, add TODO and comment

### DIFF
--- a/assets/javascripts/modules/sso.js
+++ b/assets/javascripts/modules/sso.js
@@ -10,22 +10,18 @@ module.exports = function () {
   var setSSOLinks = require('./SSO_links.js');
 
   var ssoPageRedirect = function () {
-    var performLinkDefaultBehaviour;
     var redirectSSoPage = $('.js-sso-page-redirect').get(0);
 
     if (redirectSSoPage) {
-      performLinkDefaultBehaviour = setSSOLinks(redirectSSoPage, window.ssoUrl, window.ssoMethod);
-
-      if (performLinkDefaultBehaviour) {
-        window.location.replace(redirectSSoPage.href);
-      }
+      setSSOLinks(redirectSSoPage, window.ssoUrl, window.ssoMethod);
     }
   };
 
   var addListeners = function () {
     // TODO-rory: fix error thrown when clicking a [data-sso] links
-    $(document).on('click', 'a[data-sso]', function (event) {
-      return setSSOLinks(event.target, window.ssoUrl, window.ssoMethod);
+    $(document).on('click', 'a[data-sso="(true|client|server)"]', function (event) {
+      event.preventDefault();
+      setSSOLinks(event.target, window.ssoUrl, window.ssoMethod);
     });
   };
 


### PR DESCRIPTION
Some work to support failure cases from a failed GET in the SSO encryption process.
- After a grep of the codebase tightened up the selector for SSO functionality so its not on all anchors
- Inject failure response into page
- Take event.preventDefault() back into listener rather than sending back from SSO_Links
- Added TODO to split this functionality out
- Added general Comment