### PR TITLE
[API-674] Removed media queries from grid layout helper classes

### DIFF
--- a/assets/scss/base/_grid.scss
+++ b/assets/scss/base/_grid.scss
@@ -26,31 +26,21 @@ Usage:
 }
 
 .grid-layout__column--1-4 {
-  @include media(tablet) {
-    @include grid-column-table(1/4);
-  }
+  @include grid-column-table(1/4);
 }
 
-.grid-layout__column--1-3 {
-  @include media(tablet) {
-    @include grid-column-table(1/3);
-  }
+.grid-layout__column--1-3 {  
+  @include grid-column-table(1/3);
 }
 
 .grid-layout__column--1-2 {
-  @include media(tablet) {
-    @include grid-column-table(1/2);
-  }
+  @include grid-column-table(1/2); 
 }
 
-.grid-layout__column--2-3 {
-  @include media(tablet) {
-    @include grid-column-table(2/3);
-  }
+.grid-layout__column--2-3 {  
+  @include grid-column-table(2/3);
 }
 
 .grid-layout__column--3-4 {
-  @include media(tablet) {
-    @include grid-column-table(3/4);
-  }
+  @include grid-column-table(3/4); 
 }


### PR DESCRIPTION
Removed media queries from grid layout helper classes to prevent media query nesting (which is not cross-browser safe).