### PR TITLE
normalize select font size

### DIFF
--- a/assets/scss/base/_form.scss
+++ b/assets/scss/base/_form.scss
@@ -36,6 +36,7 @@ select {
   margin: 0 0.625em;
   @include inline-block;
   width: auto;
+  @include core-19();
 }
 
 textarea {


### PR DESCRIPTION
I have been seeing issues on firefox with the select inheriting `font-size: 100%`

#### Before
![old](https://cloud.githubusercontent.com/assets/2305016/11369817/b96b7d8a-92b8-11e5-8886-d3e8456f3a6c.png)

#### After
![new](https://cloud.githubusercontent.com/assets/2305016/11369820/bc1489aa-92b8-11e5-975a-16b49bc55bb1.png)

