### PR TITLE
[API-686] Added break all to inline snippets

### DIFF
--- a/assets/scss/modules/_code.scss
+++ b/assets/scss/modules/_code.scss
@@ -13,6 +13,7 @@ pre.snippet--block {
 
 .snippet--inline {
   font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+  word-break: break-all;
 }
 
 code.snippet--inline { 
@@ -28,5 +29,3 @@ code.snippet--inline {
   padding: 3px 8px 1px 8px;
   @include border-radius(5px);
 }
-
-


### PR DESCRIPTION
Added break all to inline snippets, ensuring URLs and such non-breaking strings wrap correctly.

<img width="750" alt="screen shot 2015-12-01 at 2 51 18 p m" src="https://cloud.githubusercontent.com/assets/1764083/11504010/26cb04b8-983b-11e5-8ae7-537fa992fcc9.png">
