### PR TITLE
[YTA-1193] Extend tab functionality and add classes for styling.

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -143,7 +143,7 @@ $(function() {
   attorneyBanner();
   youtubePlayer().init();
   ajaxFormSubmit.init(ajaxCallbacks); 
-  tabs(); 
+  tabs().init();
   accordion();
 
 });

--- a/assets/javascripts/modules/tabs.js
+++ b/assets/javascripts/modules/tabs.js
@@ -1,155 +1,247 @@
+require('jquery');
+
 /**
  * Tabs Module
- * 
+ *
  * Usage:
 
-    <div data-tabs>
+ <div data-tabs>
 
-      <ul>
-        <li>
-          <a href="#" data-tab-link="1">Tab Link 1</a>
-        </li>
-        <li>
-          <span data-tab-link="2">Tab Link 2</span>
-        </li>
-        <li>
-          <a href="#" data-tab-link="3">Tab Link 3</a>
-        </li>
-      </ul>
+   <ul class="tabs-nav">
+     <li class="tabs-nav__tab">
+      <a href="#" data-tab-link="1">Tab Link 1</a>
+     </li>
+     <li class="tabs-nav__tab--active">
+      <span data-tab-link="2">Tab Link 2</span>
+     </li>
+     <li class="tabs-nav__tab">
+      <a href="#" data-tab-link="3">Tab Link 3</a>
+     </li>
+   </ul>
 
-      <ul>
-        <li data-tab-content="1">
-          <p>Tab Content 1</p>
-        </li>
-        <li data-tab-content="2">
-          <p>Tab Content 2</p>
-        </li>
-        <li data-tab-content="3">
-          <p>Tab Content 3</p>
-        </li>
-      </ul>
+   <ul>
+     <li data-tab-content="1">
+      <p>Tab Content 1</p>
+     </li>
+     <li data-tab-content="2">
+       <p>Tab Content 2</p>
+     </li>
+     <li data-tab-content="3">
+       <p>Tab Content 3</p>
+     </li>
+   </ul>
 
-    </div>
+ </div>
+
+ * add class to initial div if tabs should open based on URL hash, or 1st tab if not found
+ *
+ <div data-tabs class="js-hash-selected-tab">
 
  */
 
+var activeTabClass,
+    inactiveTabClass,
+    $tabElems,
+    $firstTab,
+    selectActiveTabWithJs;
 
-module.exports = function() {
+// for each set of tabs in the page
+var initialiseTabs = function() {
+  $tabElems.each(function() {
 
-  // for each set of tabs in the page
-  $('[data-tabs]').each(function() {
-
-    var $tabs = $(this);
+    var $tabs = $(this),
+        activeTab;
 
     // initial setting of tab content to be visible/hidden
-    updateTabContents($tabs);
+    if (selectActiveTabWithJs) {
+      activeTab = findActiveTabFromHash();
+      updateTabLinks.call(activeTab, $tabs);
+      updateTabContents($tabs, activeTab);
+    } else {
+      updateTabContents($tabs);
+    }
 
     // for each tab link
     $tabs.on('click', '[data-tab-link]', function(e) {
-      e.preventDefault();
-      
+
+      // add tab hash to URL if enabled
+      if (!selectActiveTabWithJs) {
+        e.preventDefault();
+      }
+
       // set correct tab content to be visible
       updateTabContents($tabs, $(this));
 
       // update state of tab links
       updateTabLinks.call(this, $tabs);
-
     });
 
   });
+};
 
-  /**
-   * Update visibility of tab contents
-   * 
-   * @param  {Object} $tabs     jQuery object for tabs container
-   * @param  {Object} $tabLink  tab link that was just clicked
-   */
-  function updateTabContents($tabs, $tabLink) {
+/**
+ * Determine which tab to open at the start.
+ * The open tab will be that matching the URL hash,
+ * or the first tab if no hash present.
+ * @returns {string} jQuery object for the tab to open
+ */
+var findActiveTabFromHash = function() {
+  var activeTabLink = '',
+      tab;
 
-    var $tabContent;
-
-    // tab link is either tab just clicked or the active tab (on page load)
-    $tabLink = $tabLink || $tabs.find('span[data-tab-link]');
-
-    // find tab content that corresponds to tab link
-    $tabContent = $tabs.find('[data-tab-content="' + $tabLink.data('tab-link') + '"]');
-
-    // hide all tabs
-    $tabs.find('[data-tab-content]').addClass('hidden');
-
-    // reveal selected tab's content
-    $tabContent.removeClass('hidden');
-
+  if (selectActiveTabWithJs) {
+    tab = findTabByLinkAttr(window.location.hash);
+    activeTabLink = tab || $firstTab;
   }
+  return activeTabLink;
+};
 
-  /**
-   * Update tab link states
-   * 
-   * @param  {Object} $tabs     jQuery object for tabs container
-   */
-  function updateTabLinks($tabs) {
+/**
+ * Try to find a present tab matching the URL hash
+ * @param hash the URL hash
+ * @returns the jQuery object for the tab
+ */
+var findTabByLinkAttr = function(hash) {
+  var $tab;
 
-    var $clickedTab = $(this),
-        $tabLinks   = $tabs.find('[data-tab-link]');
-
-    $tabLinks.each(function() {
-
-      var $tabLink  = $(this),
-
-          // item will be clickable if it's not what was just clicked
-          clickable = $tabLink.data('tab-link') !== $clickedTab.data('tab-link');
-
-      // switch markup of tab link as needed
-      $tabLink = updateLinkMarkup($tabLink, clickable);
-
-    });
-
-  }
-
-  /**
-   * Updates a tab link's markup based on whether it should be clickable or not
-   * 
-   * @param  {Object} $tabLink    tab link that will be updated
-   * @param  {Object} clickable   whether tab link will be clickable
-   * @return {Object} $tabLink    updated tab link     
-   */
-  function updateLinkMarkup($tabLink, clickable) {
-
-    var attrs = {};
-
-    // save all attributes
-    $.each($tabLink[0].attributes, function(i, attr) {       
-      attrs[attr.nodeName] = attr.nodeValue;
-    });
-
-    // if tabLink should be clickable and is not already an anchor
-    if(clickable) {
-      
-      // convert to anchor
-      $tabLink.replaceWith(function() {
-
-        // restore url of anchor from data attribute
-        var hrefAttr = {'href': attrs['data-tab-url']};
-
-        return $("<a/>", $.extend(attrs, hrefAttr)).append($(this).contents());
-      });
-
+  if (hash.length > 1) {
+    $tab = $('a[data-tab-link=' + hash.substring(1) + ']');
+    if ($tab.length) {
+      return $tab;
     }
-    // if tabLink is not clickable
-    else {
-
-      // span does not need href attribute
-      delete attrs.href;
-
-      // convert link to span
-      $tabLink.replaceWith(function() {
-        return $("<span/>", attrs).append($(this).contents());
-      });
-
-    }
-
-    return $tabLink;
-
   }
+};
+
+/**
+ * Update visibility of tab contents
+ *
+ * @param  {Object} $tabs     jQuery object for tabs container
+ * @param  {Object} $tabLink  tab link that was just clicked
+ */
+var updateTabContents = function($tabs, $tabLink) {
+
+  var $tabContent;
+
+  // tab link is either tab just clicked or the active tab (on page load)
+  $tabLink = $tabLink || $tabs.find('span[data-tab-link]');
+
+  // find tab content that corresponds to tab link
+  $tabContent = $tabs.find('[data-tab-content="' + $tabLink.data('tab-link') + '"]');
+
+  // hide all tabs
+  $tabs.find('[data-tab-content]').addClass('hidden');
+
+  // reveal selected tab's content
+  $tabContent.removeClass('hidden');
 
 };
+
+/**
+ * Update tab link states
+ *
+ * @param  {Object} $tabs     jQuery object for tabs container
+ */
+var updateTabLinks = function($tabs) {
+
+  var $clickedTab = $(this),
+    $tabLinks = $tabs.find('[data-tab-link]');
+
+  $tabLinks.each(function() {
+
+    var $tabLink = $(this),
+
+    // item will be clickable if it's not what was just clicked
+      clickable = $tabLink.data('tab-link') !== $clickedTab.data('tab-link');
+
+    $tabLink = setActiveClass($tabLink, clickable);
+
+    // switch markup of tab link as needed
+    $tabLink = updateLinkMarkup($tabLink, clickable);
+  });
+};
+
+/**
+ * add and remove classes for styling active and non active tabs
+ * @param $tabLink tab jQuery object
+ * @param clickable whether tab is clickable
+ * @returns {*} tab jQuery object
+ */
+var setActiveClass = function($tabLink, clickable) {
+
+  if (clickable) {
+    $tabLink.removeClass(activeTabClass);
+    $tabLink.addClass(inactiveTabClass);
+  } else {
+    $tabLink.removeClass(inactiveTabClass);
+    $tabLink.addClass(activeTabClass);
+  }
+  return $tabLink;
+};
+
+/**
+ * Updates a tab link's markup based on whether it should be clickable or not
+ *
+ * @param  {Object} $tabLink    tab link that will be updated
+ * @param  {Object} clickable   whether tab link will be clickable
+ * @return {Object} $tabLink    updated tab link
+ */
+var updateLinkMarkup = function($tabLink, clickable) {
+
+  var attrs = {};
+
+  // save all attributes
+  $.each($tabLink[0].attributes, function(i, attr) {
+    attrs[attr.nodeName] = attr.nodeValue;
+  });
+
+  // if tabLink should be clickable and is not already an anchor
+  if (clickable) {
+
+    // convert to anchor
+    $tabLink.replaceWith(function() {
+
+      // restore url of anchor from data attribute
+      var hrefAttr = {'href': '#' + attrs['data-tab-link']};
+
+      return $("<a/>", $.extend(attrs, hrefAttr)).append($(this).contents());
+    });
+
+  }
+  // if tabLink is not clickable
+  else {
+
+    // span does not need href attribute
+    delete attrs.href;
+
+    // convert link to span
+    $tabLink.replaceWith(function() {
+      return $("<span/>", attrs).append($(this).contents());
+    });
+
+  }
+
+  return $tabLink;
+};
+
+/**
+ * if tabs present on page, initialise behaviour
+ */
+var init = function() {
+
+  activeTabClass = 'tabs-nav__tab--active';
+  inactiveTabClass = 'tabs-nav__tab';
+  $tabElems = $('[data-tabs]');
+  $firstTab = $('a[data-tab-link]:first');
+  selectActiveTabWithJs = $('.js-hash-selected-tab').length > 0;
+
+  if ($tabElems.length) {
+    initialiseTabs();
+  }
+};
+
+module.exports = function() {
+  return {
+    init: init
+  };
+};
+

--- a/assets/scss/modules/_navigation.scss
+++ b/assets/scss/modules/_navigation.scss
@@ -114,7 +114,7 @@ a.header__menu__proposition-name {
     display: flex;
   }
 
-  &__tab {
+  .tabs-nav__tab {
     margin-bottom: 0;
     border-top: 1px solid $border-colour;
     display: block;
@@ -136,7 +136,7 @@ a.header__menu__proposition-name {
     }
   }
 
-  &__tab--active {
+  .tabs-nav__tab--active {
     border-top: 1px solid $border-colour;
     margin-bottom: 0;
     padding: 0.5em 0;

--- a/assets/scss/modules/_tabular-data.scss
+++ b/assets/scss/modules/_tabular-data.scss
@@ -132,3 +132,8 @@
   }
 }
 
+.tabular-data__tab-content {
+  border: 1px solid #bfc1c3;
+  border-top: 0;
+  padding: 20px 15px;
+}

--- a/assets/test/specs/fixtures/tabs-fixtures-auto-open.html
+++ b/assets/test/specs/fixtures/tabs-fixtures-auto-open.html
@@ -1,0 +1,28 @@
+
+<div data-tabs class="js-hash-selected-tab">
+
+  <ul>
+    <li>
+      <a href="#one" data-tab-link="one">Tab One</a>
+    </li>
+    <li>
+      <a href="#two" data-tab-link="two">Tab Two</a>
+    </li>
+    <li>
+      <a href="#three" data-tab-link="three">Tab Three</a>
+    </li>
+  </ul>
+
+  <ul>
+    <li data-tab-content="one">
+      <p>Tab Content One</p>
+    </li>
+    <li data-tab-content="two">
+      <p>Tab Content Two</p>
+    </li>
+    <li data-tab-content="three">
+      <p>Tab Content Three</p>
+    </li>
+  </ul>
+
+</div>

--- a/assets/test/specs/tabs.spec.js
+++ b/assets/test/specs/tabs.spec.js
@@ -2,32 +2,19 @@ require('jquery');
 
 describe("Given I have a tabs module on the page", function() {
 
-  var tabs;
-
-  beforeEach(function() {
-
-    jasmine.getFixtures().fixturesPath = "base/specs/fixtures/";
-    loadFixtures('tabs-fixtures.html');
-
-    tabs = require('../../javascripts/modules/tabs.js');
-
-  });
+  jasmine.getFixtures().fixturesPath = "base/specs/fixtures/";
+  var tabs = require('../../javascripts/modules/tabs.js');
 
   describe("When I load the page", function() {
 
-    beforeEach(function() {  
-      tabs(); // init tabs module
+    beforeEach(function() {
+      loadFixtures('tabs-fixtures.html');
+      tabs().init(); // init tabs module
     });
 
-    it("Then the 1st tab content is hidden", function() {        
+    it("Then only the 2nd tab content is visible", function() {
       expect($('[data-tab-content="1"]')).toHaveClass('hidden');
-    });
-
-    it("Then the 2nd tab content is visible", function() {        
       expect($('[data-tab-content="2"]')).not.toHaveClass('hidden');
-    });
-
-    it("Then the 3rd tab content is hidden", function() {        
       expect($('[data-tab-content="3"]')).toHaveClass('hidden');
     });
 
@@ -35,23 +22,63 @@ describe("Given I have a tabs module on the page", function() {
 
   describe("When I click the first tab link", function() {
 
-    beforeEach(function() {  
-      tabs(); // init tabs module
+    beforeEach(function() {
+      loadFixtures('tabs-fixtures.html');
+      tabs().init(); // init tabs module
       $('[data-tab-link="1"]').click();
     });
 
-    it("Then the 1st tab content is visible", function() {        
+    it("Then only the 1st tab content is visible", function() {
       expect($('[data-tab-content="1"]')).not.toHaveClass('hidden');
-    });
-
-    it("Then the 2nd tab content is hidden", function() {        
       expect($('[data-tab-content="2"]')).toHaveClass('hidden');
-    });
-
-    it("Then the 3rd tab content is hidden", function() {        
       expect($('[data-tab-content="3"]')).toHaveClass('hidden');
     });
 
+  });
+
+  describe("With auto open tabs enabled", function() {
+
+    describe("When I open the page", function() {
+
+      describe("With no URL hash", function() {
+
+        beforeEach(function() {
+          loadFixtures('tabs-fixtures-auto-open.html');
+          tabs().init();
+        });
+
+        it("should have the first tab selected", function() {
+          expect($('.tabs-nav__tab--active').text()).toEqual("Tab One");
+        });
+
+        it("should have the first tab's content shown", function() {
+          expect($('[data-tab-content="one"]')).not.toHaveClass('hidden');
+          expect($('[data-tab-content="two"]')).toHaveClass('hidden');
+          expect($('[data-tab-content="three"]')).toHaveClass('hidden');
+        });
+      });
+
+      describe("With URL hash", function() {
+
+        beforeEach(function() {
+          loadFixtures('tabs-fixtures-auto-open.html');
+          window.history.replaceState(null, null, '#three');
+          tabs().init();
+        });
+
+        it("should have the tab matching the hash selected", function() {
+          expect($('.tabs-nav__tab--active').text()).toEqual("Tab Three");
+        });
+
+        it("should have the matching tab's content shown", function() {
+          expect($('[data-tab-content="one"]')).toHaveClass('hidden');
+          expect($('[data-tab-content="two"]')).toHaveClass('hidden');
+          expect($('[data-tab-content="three"]')).not.toHaveClass('hidden');
+
+        });
+      });
+
+    });
   });
 
 });


### PR DESCRIPTION
* Allow selected tab to be opened on page load from URL hash.
* Behaviour configurable by adding class to containing element.
* If enabled but no matching URL hash, first tab is opened.
* If not enabled, clicking tabs does not add hash to URL.
* active and inactive tab classes are added to match styles defined in _navigation.scss.