### PR TITLE
GG-359: Control Module 

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -7,10 +7,14 @@ require('govuk-template');
 window._gaq = window._gaq || [];
 
 var sso = require('./modules/sso.js'),
+<<<<<<< b67d303b675c85827b2b7c8514913d763a1014b3
     visibility = require('./modules/visibility.js'),
     form = require('./validation/form.js'),
     toggle = require('./modules/toggle.js'),
     autoCompleteFactory = require('./modules/autoCompleteFactory.js'),
+=======
+    control = require('./modules/control.js'),
+>>>>>>> GG-359: control JavaScript
     contentNudge = require('./modules/contentNudge.js'),
     tableRowClick = require('./modules/tableRowClick.js'),
     feedbackForms = require('./modules/feedbackForms.js'),
@@ -130,10 +134,14 @@ $(function() {
   }
 
   sso().init();
+<<<<<<< b67d303b675c85827b2b7c8514913d763a1014b3
   visibility().init();
   form().init();
   toggle().init();
   autoCompleteFactory().init(); //This needs to be below form as it add suggestion validation
+=======
+  control().init();
+>>>>>>> GG-359: control JavaScript
   toggleDynamicFormFields();
 
   //TODO: replace toggleDynamicFormField usage in all exemplars and rename this function

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -7,14 +7,11 @@ require('govuk-template');
 window._gaq = window._gaq || [];
 
 var sso = require('./modules/sso.js'),
-<<<<<<< b67d303b675c85827b2b7c8514913d763a1014b3
     visibility = require('./modules/visibility.js'),
     form = require('./validation/form.js'),
     toggle = require('./modules/toggle.js'),
     autoCompleteFactory = require('./modules/autoCompleteFactory.js'),
-=======
     control = require('./modules/control.js'),
->>>>>>> GG-359: control JavaScript
     contentNudge = require('./modules/contentNudge.js'),
     tableRowClick = require('./modules/tableRowClick.js'),
     feedbackForms = require('./modules/feedbackForms.js'),
@@ -134,14 +131,11 @@ $(function() {
   }
 
   sso().init();
-<<<<<<< b67d303b675c85827b2b7c8514913d763a1014b3
   visibility().init();
   form().init();
   toggle().init();
   autoCompleteFactory().init(); //This needs to be below form as it add suggestion validation
-=======
   control().init();
->>>>>>> GG-359: control JavaScript
   toggleDynamicFormFields();
 
   //TODO: replace toggleDynamicFormField usage in all exemplars and rename this function

--- a/assets/javascripts/modules/control.js
+++ b/assets/javascripts/modules/control.js
@@ -1,0 +1,52 @@
+require('jquery');
+
+/*
+Helper to enable elements to control the value of an input else where on the page specified by a data attribute
+
+Control html markup:
+
+<label class="block-label block-label--inline" for="uk-phone-number-toggle-close">Yes
+    <input type="radio"
+           id="uk-phone-number-toggle-close"
+           class="js-toggle-trigger js-control"
+           value="yes"
+           name="uk-number"
+           required
+           data-control-target="countryCode"
+           data-control-value="44"/>
+</label>
+ */
+var $controlElems;
+
+var setup = function () {
+  $controlElems = $('.js-control');
+};
+
+var controlEvent = function ($controlElem) {
+  var $controlTarget = $('#' + $controlElem.data('controlTarget'));
+  var $controlValue = $controlElem.data('controlValue');
+
+  $controlElem.on('click', function () {
+    $controlTarget.val($controlValue);
+    console.log('--------  ' + $controlTarget.val() + '  --------');
+  });
+};
+
+var addListeners = function () {
+  $controlElems.each(function (index, elem) {
+    controlEvent($(elem));
+  });
+};
+
+var init = function () {
+  setup();
+  if ($controlElems.length) {
+    addListeners();
+  }
+};
+
+module.exports = function () {
+  return {
+    init: init
+  };
+};

--- a/assets/javascripts/modules/control.js
+++ b/assets/javascripts/modules/control.js
@@ -15,6 +15,15 @@ Control html markup:
            data-control-target="countryCode"
            data-control-value="44"/>
 </label>
+
+Target markup example:
+
+<select class="flush--left" id="countryCode" name="countryCode">
+    <option value="0">@Messages("otpfe.enter_mobile.country.default")</option>
+    @for(countryCode <- countryCodes) {
+        <option value="@countryCode.code"@isSelected(countryCode.code)>@countryCode.country</option>
+    }
+</select>
  */
 var $controlElems;
 

--- a/assets/javascripts/modules/control.js
+++ b/assets/javascripts/modules/control.js
@@ -28,7 +28,6 @@ var controlEvent = function ($controlElem) {
 
   $controlElem.on('click', function () {
     $controlTarget.val($controlValue);
-    console.log('--------  ' + $controlTarget.val() + '  --------');
   });
 };
 


### PR DESCRIPTION
# Control Module 

A module to enable an element to control the value of another specified form input on the page.

Helper to enable elements to control the value of an input else where on the page specified by a data attribute

#### Control html markup:
```
<label class="block-label block-label--inline" for="uk-phone-number-toggle-close">Yes
    <input type="radio"
           id="uk-phone-number-toggle-close"
           class="js-toggle-trigger js-control"
           value="yes"
           name="uk-number"
           required
           data-control-target="countryCode"
           data-control-value="44"/>
</label>
```


### Example
In the example you can see (in the console) the yes button sets an input to `44`,
The no button sets an input to `0`

![control](https://cloud.githubusercontent.com/assets/2305016/11530912/78f57880-98f0-11e5-8b77-3b81c9db51a6.gif)
