### PR TITLE
GG-359: Visibility Module

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -7,6 +7,7 @@ require('govuk-template');
 window._gaq = window._gaq || [];
 
 var sso = require('./modules/sso.js'),
+    visibility = require('./modules/visibility.js'),
     contentNudge = require('./modules/contentNudge.js'),
     tableRowClick = require('./modules/tableRowClick.js'),
     feedbackForms = require('./modules/feedbackForms.js'),
@@ -126,6 +127,7 @@ $(function() {
   }
 
   sso().init();
+  visibility().init();
   toggleDynamicFormFields();
 
   //TODO: replace toggleDynamicFormField usage in all exemplars and rename this function

--- a/assets/javascripts/modules/visibility.js
+++ b/assets/javascripts/modules/visibility.js
@@ -1,0 +1,47 @@
+require('jquery');
+
+/*
+Show or hide elements by changing respective aria-hidden attribute
+The visual styles can be controlled by using the .visible-javascript-on and .hidden-javascript-on CSS selectors
+
+Used for displaying markup and altering aria details dependant on browser JavaScript ability
+*/
+var $showElements;
+var $hideElements;
+
+var updateAriaHiddenStatus = function ($elems, show) {
+  $elems.each(function (index, elem) {
+    $(elem).attr('aria-hidden', show);
+  });
+};
+
+var show = function () {
+  updateAriaHiddenStatus($showElements, false);
+};
+
+var hide = function () {
+  updateAriaHiddenStatus($hideElements, true);
+};
+
+var setup = function () {
+  $showElements = $('.js-aria-show');
+  $hideElements = $('.js-aria-hide');
+};
+
+var init = function () {
+  setup();
+
+  if ($showElements.length) {
+    show();
+  }
+
+  if ($hideElements.length) {
+    hide();
+  }
+};
+
+module.exports = function () {
+  return {
+    init: init
+  };
+};


### PR DESCRIPTION
# Visibility Module

Visibility Module to change aria hidden state dependant on JavaScript capability

Show or hide elements by changing respective aria-hidden attribute
The visual styles can be controlled by using the `.visible-javascript-on` and `.hidden-javascript-on` CSS selectors

Used for displaying markup and altering aria details dependant on browser JavaScript ability