### PR TITLE
Gg 359: toggle module

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -9,6 +9,7 @@ window._gaq = window._gaq || [];
 var sso = require('./modules/sso.js'),
     visibility = require('./modules/visibility.js'),
     form = require('./validation/form.js'),
+    toggle = require('./modules/toggle.js'),
     contentNudge = require('./modules/contentNudge.js'),
     tableRowClick = require('./modules/tableRowClick.js'),
     feedbackForms = require('./modules/feedbackForms.js'),
@@ -130,6 +131,7 @@ $(function() {
   sso().init();
   visibility().init();
   form().init();
+  toggle().init();
   toggleDynamicFormFields();
 
   //TODO: replace toggleDynamicFormField usage in all exemplars and rename this function

--- a/assets/javascripts/modules/toggle.js
+++ b/assets/javascripts/modules/toggle.js
@@ -1,0 +1,102 @@
+require('jquery');
+
+/*
+Helper to enable elements to toggle other elements on the page specified by data attribute
+Attach event to parent as delegate, open close dependant on triggers id.
+
+Toggle markup example:
+
+<fieldset class="form-field-group visible-javascript-on js-aria-show js-toggle"
+          id="uk-number"
+          data-target="uk-phone-number-toggle-target"
+          data-trigger="js-toggle-trigger"
+          data-open="uk-phone-number-toggle-open"
+          data-close="uk-phone-number-toggle-close"
+          aria-hidden="true">
+
+    <label class="block-label block-label--inline" for="uk-phone-number-toggle-close">Yes
+        <input type="radio"
+               id="uk-phone-number-toggle-close"
+               class="js-toggle-trigger js-control"
+               value="yes"
+               name="uk-number"
+               required
+               data-control-target="countryCode"
+               data-control-value="44"/>
+    </label>
+    <label class="block-label block-label--inline" for="uk-phone-number-toggle-open">No
+        <input type="radio"
+               id="uk-phone-number-toggle-open"
+               class="js-toggle-trigger js-control"
+               value="no"
+               name="uk-number"
+               required
+               data-control-target="countryCode"
+               data-control-value="0"
+               aria-controls="uk-phone-number-toggle-target"/>
+    </label>
+</fieldset>
+
+Target markup example:
+
+<div id="uk-phone-number-toggle-target"
+     class="toggle-target"
+     aria-expanded="false"
+     aria-visible="false"
+     aria-labelledby="country-code-legend"
+     aria-describedby="country-code-hint">
+......
+</div>
+ */
+var $toggleElems;
+
+/**
+ * Controls for triggering toggle
+ * 1 (left mouse click)
+ * 32 (space bar)
+ * @param $elem
+ */
+var toggleEvent = function ($elem) {
+  var $triggerElemSelector = $($elem.data('trigger'));
+  var $targetElem = $('#' + $elem.data('target'));
+  var openId = $elem.data('open');
+  var closeId = $elem.data('close');
+  var target;
+
+  $elem.on('click keydown', $triggerElemSelector, function (event) {
+
+    if (event.which === 1 || 32) { //limit to left mouse click and space bar
+      target = event.target;
+
+      if (target.id === openId) {
+        $targetElem.show().attr('aria-expanded', 'true').attr('aria-visible', 'true');
+      } else if (target.id === closeId) {
+        $targetElem.hide().attr('aria-expanded', 'false').attr('aria-visible', 'false');
+      }
+    }
+  });
+};
+
+var addListeners = function () {
+  $toggleElems.each(function (index, elem) {
+    toggleEvent($(elem));
+  });
+};
+
+var setup = function () {
+  $toggleElems = $('.js-toggle');
+};
+
+var init = function () {
+  setup();
+
+  if ($toggleElems.length) {
+    addListeners();
+  }
+};
+
+module.exports = function () {
+  return {
+    init: init
+  };
+};

--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -9,6 +9,9 @@ $path: "../images/icons/";
 @import "../govuk_frontend_toolkit/stylesheets/design-patterns/_alpha-beta";
 @import "../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons";
 
+// Tools
+@import "mixins";
+
 // Reset
 @import "base/normalize";
 
@@ -67,6 +70,7 @@ $path: "../images/icons/";
 @import "modules/breadcrumb";
 @import "modules/accordion";
 @import "modules/youtube-player";
+@import "modules/toggle";
 
 // Page Specific Styles
 @import "pages/messages";

--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -1,0 +1,7 @@
+@mixin vertically-centered() {
+  display: block;
+  top: 50%;
+  -ms-transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
+  transform: translateY(-50%);
+}

--- a/assets/scss/base/_form.scss
+++ b/assets/scss/base/_form.scss
@@ -323,26 +323,26 @@ label {
 }
 
 // Position checkbox within label, to allow text to wrap
-.block-label input {
-  position: absolute;
-  top: 21px;
+.block-label input,
+.vertically-aligned-input {
+  @include vertically-centered();
   left: $gutter-half;
   cursor: pointer;
+
+  @include ie-lte(9){
+    top: 38%;
+  }
 }
 
 // Use inline, to sit block labels next to each other
 .block-label--inline,
 .block-label--inline-right,
 .inline .block-label {
+  margin:0 10px 10px 0;
   clear: none;
-  margin-right: 0;
   @include media(tablet) {
     margin-right: $gutter-half;
   }
-}
-
-.block-label--inline {
-  margin:0 0 10px 0;
 }
 
 

--- a/assets/scss/base/_helpers.scss
+++ b/assets/scss/base/_helpers.scss
@@ -185,9 +185,13 @@
     @include accessibility;
 }
 
+// TODO .visible-javascript-on .hidden-javascript-on are duplicates of .js-visible and .js-hidden to aid with understanding
+// TODO and not use the .js-convention (for javascript hooks) needs tidying up and duplications removed
 .hidden,
 .no-js .js-visible,
-.js .js-hidden {
+.no-js .visible-javascript-on,
+.js .js-hidden,
+.js .hidden-javascript-on {
   display: none !important;
 }
 

--- a/assets/scss/modules/_toggle.scss
+++ b/assets/scss/modules/_toggle.scss
@@ -1,0 +1,3 @@
+.toggle-target {
+  display: none;
+}


### PR DESCRIPTION
# Toggle Module

Helper to enable elements to toggle other elements on the page specified by data attribute
Attach event to parent as delegate, open close dependant on triggers id.

#### Toggle markup example:
```
<fieldset class="form-field-group visible-javascript-on js-aria-show js-toggle"
          id="uk-number"
          data-target="uk-phone-number-toggle-target"
          data-trigger="js-toggle-trigger"
          data-open="uk-phone-number-toggle-open"
          data-close="uk-phone-number-toggle-close"
          aria-hidden="true">

    <label class="block-label block-label--inline" for="uk-phone-number-toggle-close">Yes
        <input type="radio"
               id="uk-phone-number-toggle-close"
               class="js-toggle-trigger js-control"
               value="yes"
               name="uk-number"
               required
               data-control-target="countryCode"
               data-control-value="44"/>
    </label>
    <label class="block-label block-label--inline" for="uk-phone-number-toggle-open">No
        <input type="radio"
               id="uk-phone-number-toggle-open"
               class="js-toggle-trigger js-control"
               value="no"
               name="uk-number"
               required
               data-control-target="countryCode"
               data-control-value="0"
               aria-controls="uk-phone-number-toggle-target"/>
    </label>
</fieldset>
```

#### Target markup example:
```
<div id="uk-phone-number-toggle-target"
     class="toggle-target"
     aria-expanded="false"
     aria-visible="false"
     aria-labelledby="country-code-legend"
     aria-describedby="country-code-hint">
......
</div>
```

#### Example
![toggle](https://cloud.githubusercontent.com/assets/2305016/11531024/7dab5556-98f1-11e5-94bb-5be1af8a22a8.gif)
