### PR TITLE
[API-639] Updated error fields in mobile to not have left red border

### DIFF
--- a/assets/scss/base/_errors.scss
+++ b/assets/scss/base/_errors.scss
@@ -44,6 +44,13 @@
 
   &.fields-aligned {
     margin-left: -22px;
+
+    @include media(mobile) {
+      border-left: none;
+      padding-left: 0;
+      margin-left: 0;
+    }
+
   }
 
   .error-notification {


### PR DESCRIPTION
![screen shot 2015-12-03 at 11 44 27 a m](https://cloud.githubusercontent.com/assets/1764083/11559767/3f481e12-99b3-11e5-9f23-20860ddbbd1d.png)
