### PR TITLE
[API-634] Added styles to position BETA banner within nav

### DIFF
--- a/assets/scss/_shame.scss
+++ b/assets/scss/_shame.scss
@@ -67,10 +67,6 @@ div.email {
   overflow: hidden;
 }
 
-.phase-tag.beta  {
-  color: #fff;
-}
-
 .inline-form  .form-field {
   line-height: 1.3em;
   margin: 0.2em 0 0 0;

--- a/assets/scss/modules/_phase-beta.scss
+++ b/assets/scss/modules/_phase-beta.scss
@@ -5,3 +5,11 @@
 .beta-banner {
   @include phase-banner(beta);
 }
+
+.header__menu {
+  .beta {
+    vertical-align: top;
+    margin: em(3) 0 0 em(5);
+    color: $white;
+  }
+}


### PR DESCRIPTION
Added styles to position BETA banner within nav
Moved BETA colour into correct selector, removed from shame.scss

<img width="667" alt="screen shot 2015-12-09 at 12 39 31 p m" src="https://cloud.githubusercontent.com/assets/1764083/11685563/f51b679a-9e71-11e5-9524-1311783f8318.png">
