### PR TITLE
[YTA-1250] Convert sidebar to BEM, visible by default on small screens.

### DIFF
--- a/assets/scss/base/_layouts.scss
+++ b/assets/scss/base/_layouts.scss
@@ -66,14 +66,6 @@ body {
 
 }
 
-@include media(mobile) {
-
-  .sidebar {
-    display: none;
-  }
-
-}
-
 .brand-border--top {
   border-top: 10px solid $mainstream-brand;
 }

--- a/assets/scss/modules/_template-sidebar.scss
+++ b/assets/scss/modules/_template-sidebar.scss
@@ -1,4 +1,5 @@
-aside {
+
+.sidebar {
   width: auto;
   margin: 30px 0 0 0;
 
@@ -7,45 +8,45 @@ aside {
     width: 33.333333%;
     margin: 0;
   }
+}
 
-  h2 {
-    @include bold-24;
-    margin-top: 15px;
-  }
-
-  ul {
-    list-style: none;
-    padding: 0;
-
-    li {
-      padding: 0;
-      margin: 0 -15px;
-      padding: 0;
-
-      @include media(tablet) {
-        padding: 0;
-        margin: 0 0 0.75em 0;
-      }
-
-      @include core-16;
-
-      a {
-        display: block;
-        border-top: solid 1px $border-colour;
-        padding: 1em 15px;
-
-        @include media(tablet) {
-          display: inline;
-          border: none;
-          padding: 0;
-        }
-      }
-    }
-  }
-
-  .helpful {
-    color: $secondary-text-colour;
-    @include core-16;
-    margin: 0.5em 0;
+.sidebar--hidden-sm {
+  display: none;
+  @include media(tablet) {
+    display: block;
   }
 }
+
+.sidebar__list {
+  list-style: none;
+  padding: 0;
+  @include core-16;
+}
+
+.sidebar__list-item {
+  padding: 0;
+  margin: 0 0 0.75em 0;
+}
+
+.sidebar__list-item--lined-sm {
+  display: block;
+  border-top: solid 1px $border-colour;
+  padding: 1em 15px;
+
+  @include media(tablet) {
+    border: none;
+    padding: 0;
+  }
+}
+
+.sidebar__heading {
+  @include bold-24;
+  margin-top: 15px;
+}
+
+.sidebar--helpful {
+  color: $secondary-text-colour;
+  @include core-16;
+  margin: 0.5em 0;
+}
+


### PR DESCRIPTION
* BEM classes rather than nested styles using elements.
* old default behaviour was to hide sidebar at mobile breakpoint.
* new behaviour drops content below main article at mobile breakpoint, with optional style to hide.
* move all sidebar behaviour and style into _template-sidebar.scss

This might be a visually breaking change. Some markup conversion is needed to use the new styles. 
Apply the following classes to the markup:
- .sidebar class to the aside element.
- if the sidebar should be hidden at the mobile breakpoint, also apply .sidebar--hidden-sm to the aside.
- .sidebar__list to a ul 
- .sidebar__list-item to an li
- .sidebar__heading to any heading elements
- sidebar__list-item--lined-sm to li elements where a style with top and bottom borders should apply at the mobile breakpoint.