### PR TITLE
[API-430] Character counter module + tests

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -38,7 +38,8 @@ var sso = require('./modules/sso.js'),
     attorneyBanner = require('./modules/attorneyBanner.js'),
     youtubePlayer = require('./modules/youtubePlayer.js'),
     accordion = require('./modules/accordion.js'),
-    tabs = require('./modules/tabs.js');
+    tabs = require('./modules/tabs.js'),
+    charCounter = require('./modules/charCounter.js');
 
 //initialise mdtpf
 fingerprint();
@@ -157,5 +158,6 @@ $(function() {
   ajaxFormSubmit.init(ajaxCallbacks); 
   tabs().init();
   accordion();
+  charCounter();
 
 });

--- a/assets/javascripts/modules/charCounter.js
+++ b/assets/javascripts/modules/charCounter.js
@@ -1,0 +1,107 @@
+/**
+ * Character Counter Module
+ *
+ * Usage:
+ *
+ *  <div class="char-counter" data-char-counter>
+ *    <textarea data-char-field maxLength="250"></textarea>
+ *  </div>
+ *
+ * Known Issue:
+ *
+ * Chrome counts new lines as two characters, while other browser count them as one.
+ * In non-Chrome browsers, sometimes it will say 0 characters remaining but let you type one more.
+ *
+ */
+
+
+
+var counterContainer = '[data-char-counter]',
+    counterField     = '[data-char-field]',
+    counterValue     = '[data-counter]',
+    counterText      = '[data-char-text]';
+
+
+
+/**
+ * If any char counters on page, init
+ *
+ * @param $counters
+ */
+module.exports = function() {
+
+  var $counters = $(counterContainer);
+
+  // only continue if counter html exists
+  if($counters.length === 0) return;
+
+  // for each counter on the page
+  $counters.each(function() {
+
+    var $counter = $(this),
+        $input   = $counter.find(counterField);
+
+    // only proceed if max length is set
+    if(!$input.attr('maxLength')) { return; }
+
+    // add "characters remaining" html
+    addCounterHtml($counter);
+
+    // bind on change of text
+    bindEvents($counter);
+
+    // set initial count
+    setCounterText($counter);
+
+  });
+
+};
+
+/**
+ * Bind on change of input
+ *
+ * @param $counter
+ */
+var bindEvents = function($counter) {
+
+  $counter.find(counterField).on('input onpropertychange', function() {
+    setCounterText($counter);
+  });
+
+};
+
+/**
+ * Add character count text
+ *
+ * @param $counter
+ */
+var addCounterHtml = function($counter) {
+
+  var html = $('<p class="char-counter-text flush--top"><span data-counter></span> remaining <span data-char-text>characters</span></p>');
+
+  $counter.find(counterField).after(html);
+
+};
+
+/**
+ * Set counter text
+ *
+ * @param $counter
+ */
+var setCounterText = function($counter) {
+
+  var $input    = $counter.find(counterField),
+      maxLength = parseInt($input.attr('maxLength'), 10),
+
+      // give carriage returns and newline characters equal weighting cross browser to help accurate calculation
+      count     = $input.val().replace(/\r\n/g, '~~').replace(/\n/g, '~~').length,
+      remaining = maxLength - count;
+
+  // in the scenario where one character is remaining and the user breaks some text onto a new line,
+  // the browser allows this but registers it as two characters giving a count of -1, so need to adjust for this
+  if(remaining < 0) { remaining = 0; }
+
+  $counter.find(counterValue).text(remaining);
+  $counter.find(counterText).text(remaining === 1 ? 'character' : 'characters');
+
+};

--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -73,6 +73,7 @@ $path: "../images/icons/";
 @import "modules/auto-complete";
 @import "modules/toggle";
 @import "modules/_external-markup";
+@import "modules/char-counter";
 
 // Page Specific Styles
 @import "pages/messages";

--- a/assets/scss/modules/_char-counter.scss
+++ b/assets/scss/modules/_char-counter.scss
@@ -1,0 +1,20 @@
+
+.char-counter {
+  position: relative;
+  margin-bottom: 1.5em;
+  display: block;
+
+  [data-char-field] {
+    height: 70px;
+  }
+
+  @include media(tablet) {
+    display: inline-block;
+  }
+
+}
+
+.char-counter-text {
+  color: #6f777b;
+  text-align: right;
+}

--- a/assets/test/specs/charCounter.spec.js
+++ b/assets/test/specs/charCounter.spec.js
@@ -1,0 +1,61 @@
+/**
+ * Character Counter Module Tests
+ */
+
+require('jquery');
+
+describe("Given I have two empty textarea elements set up with a char counter", function() {
+
+  jasmine.getFixtures().fixturesPath = "base/specs/fixtures/";
+  var charCounter = require('../../javascripts/modules/charCounter.js');
+
+  describe("When I load the page", function() {
+
+    beforeEach(function() {
+      loadFixtures('charCounter-fixtures.html');
+      charCounter();
+    });
+
+    it("The first counter should read 10 remaining characters", function() {
+      expect($('#fieldContainer1 [data-counter]').text()).toBe("10");
+    });
+
+    it("The second counter should read 2 remaining characters", function() {
+      expect($('#fieldContainer2 [data-counter]').text()).toBe("2");
+    });
+
+  });
+
+  describe("When I type some text in the first field", function() {
+
+    beforeEach(function() {
+      loadFixtures('charCounter-fixtures.html');
+      charCounter();
+      $('#fieldContainer1 [data-char-field]').val('Some text').trigger('input');
+    });
+
+    it("The first counter should read 1 remaining character", function() {
+      expect($('#fieldContainer1 [data-counter]').text()).toBe("1");
+    });
+
+    it("The first counter text should read 'character'", function() {
+      expect($('#fieldContainer1 [data-char-text]').text()).toBe("character");
+    });
+
+  });
+
+  describe("When I type two characters in the second field", function() {
+
+    beforeEach(function() {
+      loadFixtures('charCounter-fixtures.html');
+      charCounter();
+      $('#fieldContainer1 [data-char-field]').val('AB').trigger('input');
+    });
+
+    it("The counter text should read 'characters'", function() {
+      expect($('#fieldContainer1 [data-char-text]').text()).toBe("characters");
+    });
+
+  });
+
+});

--- a/assets/test/specs/fixtures/charCounter-fixtures.html
+++ b/assets/test/specs/fixtures/charCounter-fixtures.html
@@ -1,0 +1,7 @@
+<div id="fieldContainer1" data-char-counter>
+  <textarea data-char-field maxLength="10"></textarea>
+</div>
+
+<div id="fieldContainer2" data-char-counter>
+  <textarea data-char-field maxLength="20">Pre-populated text</textarea>
+</div>


### PR DESCRIPTION
# Usage

```html
<div class="char-counter" data-char-counter>
  <textarea data-char-field maxLength="250"></textarea>
</div>
```

### Example

![charcountervideo](https://cloud.githubusercontent.com/assets/1764083/11896411/fa359594-a57d-11e5-94d8-9bdbd6baf569.gif)

### Known Issues

 * Chrome counts new lines as two characters, while other browser count them as one. In non-Chrome browsers, sometimes it will say 0 characters remaining but let you type one more.

 * In the scenario where one character is remaining and the user breaks the middle of some text onto a new line, the browser allows this but registers it as two characters giving a count of -1, so I've accounted for this showing a count of 0.
