### PR TITLE
GG 448 | BUG - cannot amend number

### DIFF
--- a/assets/javascripts/modules/masker.js
+++ b/assets/javascripts/modules/masker.js
@@ -1,36 +1,44 @@
 require('jquery');
+var caret = require('../utils/caret.js');
 
 /**
+ Input Masker
 
-Masker
+ Only allow specified characters to be entered into an input. Masking is enabled using the .js-masker className
+ and the masker pattern is specified by the data-masker-rule attribute. Only characters that match the data-masker-rule
+ will be accepted by the specified input.
+ ---------------------------
 
-Mask characters that have been entered into an input by removing. Masking is enabled using the .js-masker className
-and the masker pattern is specified by the data-masker-rule attribute
----------------------------
+ Example:
 
-
-Example:
-
-<input type="text"
-       name="phoneNumber"
-       id="phoneNumber"
-       value="@registrationForm("phoneNumber").value"
-       class="form-control js-masker"
-       data-masker-rule="[^\d]"
-       required
-       aria-required="true"
- />
+ <input type="text"
+        name="phoneNumber"
+        id="phoneNumber"
+        value="@registrationForm("phoneNumber").value"
+        class="form-control js-masker"
+        data-masker-rule="\d"
+        required
+        aria-required="true"
+        />
  */
 var $maskedElems;
 
-var maskerEvent = function ($input) {
-  $input.on('keyup', function (event) {
-    var $elem = $(event.target);
-    var rulePattern = $elem.data('maskerRule');
-    var regEx = new RegExp(rulePattern, 'g');
+var masker = function () {
+  var cursorPosition;
+  return function () {
+    var rule = this.getAttribute('data-masker-rule');
+    var regEx = new RegExp(rule, 'g');
+    var matches = this.value.match(regEx);
+    var returnValue = matches && matches.join('') || '';
 
-    $elem.val($elem.val().replace(regEx, ''));
-  });
+    cursorPosition = caret().getPosition(this);
+    this.value = returnValue;
+    caret().setPosition(this, cursorPosition);
+  };
+};
+
+var maskerEvent = function ($input) {
+  $input.on('keyup', masker());
 };
 
 var addListeners = function () {

--- a/assets/javascripts/utils/caret.js
+++ b/assets/javascripts/utils/caret.js
@@ -1,0 +1,42 @@
+require('jquery');
+
+/**
+ * Cross browser helpers for getting and setting the caret position in input elements
+ */
+
+/**
+ * get current caret position
+ * @param element
+ * @returns {*}
+ */
+var getPosition = function (element) {
+  if (typeof element.selectionEnd !== 'undefined') {
+    return element.selectionEnd;
+  } else if (document.selection) { // < IE9
+    return Math.abs(document.selection.createRange().moveEnd('character', -1000000));
+  }
+};
+
+/**
+ * set caret position on specified element
+ * @param element
+ * @param position
+ */
+var setPosition = function (element, position) {
+  if (typeof element.selectionEnd !== 'undefined') {
+    element.selectionEnd = position;
+  } else if (element.createTextRange) { // < IE9
+    var range = element.createTextRange();
+    range.collapse(true);
+    range.moveEnd('character', position);
+    range.moveStart('character', position);
+    range.select();
+  }
+};
+
+module.exports = function () {
+  return {
+    getPosition: getPosition,
+    setPosition: setPosition
+  };
+};


### PR DESCRIPTION
A bug has been raised where the user could not amend a number when masking was applied.

- Change the way masking is fundamentally done
- `data-masker-rule` now sends in what is accepted rather than what is not
- Added cross browser utils for caret position

#### Chrome
![amend-mobile](https://cloud.githubusercontent.com/assets/2305016/11838613/16717f4c-a3e0-11e5-9991-c0f72c1e9d2d.gif)

#### IE8
![amend-mobile-ie](https://cloud.githubusercontent.com/assets/2305016/11838616/1d3531de-a3e0-11e5-8d78-22be605d14e3.gif)

