### PR TITLE
GG-453: Link list component

### DIFF
--- a/assets/govuk_elements/public/sass/elements/_forms.scss
+++ b/assets/govuk_elements/public/sass/elements/_forms.scss
@@ -3,7 +3,6 @@
 
 // Form group is used to wrap label and input pairs
 .form-group {
-  float: left;
   width: 100%;
   clear: both;
   @include contain-floats;

--- a/assets/scss/base/_links.scss
+++ b/assets/scss/base/_links.scss
@@ -39,4 +39,3 @@ a[rel="external"].external-link-19-bold-no-hover {
     text-decoration: underline;  
   }
 }
-

--- a/assets/scss/base/_lists.scss
+++ b/assets/scss/base/_lists.scss
@@ -210,3 +210,12 @@ ul {
   }
 
 }
+
+.link-list {
+  margin-bottom: $gutter-half;
+}
+
+.link-list__item {
+  display: block;
+  margin-bottom: $gutter-half;
+}


### PR DESCRIPTION
Added `.link-list` component class to support links in a list format

#### Markup Agnositic

```html
<div class="link-list">
    <a class="link-list__item"> ... </a>
    <a class="link-list__item"> ... </a>
</div>
```

#### Screenshot
![screen shot 2015-12-17 at 12 44 47](https://cloud.githubusercontent.com/assets/2305016/11870024/12cd2986-a4bc-11e5-936d-02451c85fc44.png)
