### PR TITLE
API-688 - Added form-input class to describe input border without being tied to form-control class

### DIFF
--- a/assets/scss/base/_form.scss
+++ b/assets/scss/base/_form.scss
@@ -490,8 +490,15 @@ label {
   @include media(tablet) {
     width: 50%;
   }
+
 }
 
 .form-control--block {
   display: block;
-} 
+}
+
+.form-input {
+  background-color: $white;
+  border: 1px solid $border-colour;  
+}
+

--- a/assets/scss/modules/_navigation.scss
+++ b/assets/scss/modules/_navigation.scss
@@ -119,7 +119,6 @@ a.header__menu__proposition-name {
     border-top: 1px solid $border-colour;
     display: block;
     padding: 0.5em 0;
-    text-decoration: none;
 
     .count {
       background-color: $red;
@@ -128,27 +127,44 @@ a.header__menu__proposition-name {
     }
 
     @include media(tablet) {
-      float: left;
-      background-color: #dee0e2;
+      float: left;      
+      background-color: $white;
       border: 0;
-      margin: 0.25em 0.25em 0.25em 0;
-      padding: 0.45em;
+      margin: 0 0.25em 0em 0.25em;
+      padding: 0.8em 1.25em 0.5em 1.25em;
     }
+
+    &.first {
+      margin-left: 0;
+    }
+
+    &:hover,
+    &:focus {
+      background-color: #dee0e2;
+    }
+
   }
 
   .tabs-nav__tab--active {
     border-top: 1px solid $border-colour;
-    margin-bottom: 0;
+    margin: 0;
     padding: 0.5em 0;
     display:block;
+    font-weight: bold;
 
     @include media(tablet) {
       border: 1px solid $border-colour;
       border-bottom: 1px solid #fff;
       float: left;
-      margin: 0 0.25em -1px 0;
-      padding: 0.7em;
+      margin: 0 0 -1px 0;
+      padding: 0.8em 1.2em 0.7em 1.2em;
     }
+  }
+}
+
+.tab-content {
+  .first { 
+    margin-top: 40px;
   }
 }
 

--- a/assets/scss/modules/_navigation.scss
+++ b/assets/scss/modules/_navigation.scss
@@ -119,6 +119,7 @@ a.header__menu__proposition-name {
     border-top: 1px solid $border-colour;
     display: block;
     padding: 0.5em 0;
+    text-decoration: none;
 
     .count {
       background-color: $red;
@@ -127,44 +128,27 @@ a.header__menu__proposition-name {
     }
 
     @include media(tablet) {
-      float: left;      
-      background-color: $white;
-      border: 0;
-      margin: 0 0.25em 0em 0.25em;
-      padding: 0.8em 1.25em 0.5em 1.25em;
-    }
-
-    &.first {
-      margin-left: 0;
-    }
-
-    &:hover,
-    &:focus {
+      float: left;
       background-color: #dee0e2;
+      border: 0;
+      margin: 0.25em 0.25em 0.25em 0;
+      padding: 0.45em;
     }
-
   }
 
   .tabs-nav__tab--active {
     border-top: 1px solid $border-colour;
-    margin: 0;
+    margin-bottom: 0;
     padding: 0.5em 0;
     display:block;
-    font-weight: bold;
 
     @include media(tablet) {
       border: 1px solid $border-colour;
       border-bottom: 1px solid #fff;
       float: left;
-      margin: 0 0 -1px 0;
-      padding: 0.8em 1.2em 0.7em 1.2em;
+      margin: 0 0.25em -1px 0;
+      padding: 0.7em;
     }
-  }
-}
-
-.tab-content {
-  .first { 
-    margin-top: 40px;
   }
 }
 


### PR DESCRIPTION
The existing "form-control" class forces 50% width on inputs. So to provide the desired border and background colour without forcing width, I've added the "form-input" class.

<img width="618" alt="screen shot 2015-12-17 at 4 22 20 pm" src="https://cloud.githubusercontent.com/assets/1764083/11875016/792deb98-a4da-11e5-8d4b-5644de7890c6.png">
