### PR TITLE
GG-459: Custom suggestion display Template

### DIFF
--- a/assets/javascripts/modules/autoComplete.js
+++ b/assets/javascripts/modules/autoComplete.js
@@ -41,6 +41,7 @@ var $suggestionsData;
 var $suggestionsContainer;
 var $autoCompleteInputElem;
 var $targetInput;
+var suggestionDisplayTemplate;
 var $suggestionsStatusMessage;
 var $clearInputButton;
 
@@ -59,7 +60,10 @@ var displaySuggestions = function ($suggestionsContainer, matches, match) {
     var positionalClassNames = [];
     var li = liHtmlFragment.cloneNode();
     var pattern = new RegExp('^(' + match + ')', 'i');
-    var html = suggestion.title.replace(pattern, '<span class="suggestion__highlight">$1</span>');
+    var html;
+
+    suggestion.title.replace(pattern, '<span class="suggestion__highlight">$1</span>');
+    html = (typeof suggestionDisplayTemplate === 'function') ? suggestionDisplayTemplate(suggestion.title, suggestion.value) : suggestion.title;
 
     if (index === 0) {
       positionalClassNames.push('suggestion--first');
@@ -308,9 +312,10 @@ var suggestionsEvent = function () {
  * @param $elem
  * @param $targetElem
  */
-var setup = function ($elem, $targetElem) {
+var setup = function ($elem, $targetElem, suggestionTemplate) {
   $autoCompleteInputElem = $elem;
   $targetInput = $targetElem;
+  suggestionDisplayTemplate = suggestionTemplate;
   $suggestionsData = $('#suggestions');
   $clearInputButton = $('.js-suggestions-clear');
   $suggestionsContainer = $('.js-suggestions').first();
@@ -333,10 +338,11 @@ var getSuggestions = function () {
  * create the autoComplete
  * @param $autoCompleteInputElem
  * @param $targetInputElem
+ * @param suggestionTemplate
  */
-var build = function ($autoCompleteInputElem, $targetInputElem) {
+var build = function ($autoCompleteInputElem, $targetInputElem, suggestionTemplate) {
   if ($autoCompleteInputElem.length) {
-    setup($autoCompleteInputElem, $targetInputElem);
+    setup($autoCompleteInputElem, $targetInputElem, suggestionTemplate);
     addEventListeners();
   }
 };

--- a/assets/javascripts/modules/autoComplete.js
+++ b/assets/javascripts/modules/autoComplete.js
@@ -41,7 +41,7 @@ var $suggestionsData;
 var $suggestionsContainer;
 var $autoCompleteInputElem;
 var $targetInput;
-var suggestionDisplayTemplate;
+var suggestionDisplayFormat;
 var $suggestionsStatusMessage;
 var $clearInputButton;
 
@@ -63,7 +63,7 @@ var displaySuggestions = function ($suggestionsContainer, matches, match) {
     var html;
 
     suggestion.title.replace(pattern, '<span class="suggestion__highlight">$1</span>');
-    html = (typeof suggestionDisplayTemplate === 'function') ? suggestionDisplayTemplate(suggestion.title, suggestion.value) : suggestion.title;
+    html = (typeof suggestionDisplayFormat === 'function') ? suggestionDisplayFormat(suggestion.title, suggestion.value) : suggestion.title;
 
     if (index === 0) {
       positionalClassNames.push('suggestion--first');
@@ -230,11 +230,17 @@ var inputKeyupEvent = function () {
       $clearInputButton.removeClass('hidden');
 
       $(suggestions).each(function (index, suggestion) {
-        var regEx = new RegExp('^(' + inputVal + ')', 'i');
+        var regEx;
 
-        if (regEx.test(suggestion.title)) {
-          matches.push(suggestion);
+        try {
+          regEx = new RegExp('^(' + inputVal + ')', 'i');
+          if (regEx.test(suggestion.title)) {
+            matches.push(suggestion);
+          }
+        } catch (e) {
+          //TODO add reporting?
         }
+
       });
 
       if (matches.length) {
@@ -312,10 +318,10 @@ var suggestionsEvent = function () {
  * @param $elem
  * @param $targetElem
  */
-var setup = function ($elem, $targetElem, suggestionTemplate) {
+var setup = function ($elem, $targetElem, suggestionFormat) {
   $autoCompleteInputElem = $elem;
   $targetInput = $targetElem;
-  suggestionDisplayTemplate = suggestionTemplate;
+  suggestionDisplayFormat = suggestionFormat;
   $suggestionsData = $('#suggestions');
   $clearInputButton = $('.js-suggestions-clear');
   $suggestionsContainer = $('.js-suggestions').first();
@@ -337,12 +343,17 @@ var getSuggestions = function () {
 /**
  * create the autoComplete
  * @param $autoCompleteInputElem
- * @param $targetInputElem
- * @param suggestionTemplate
+ *
+ * @param $targetInputElem - [optional]
+ * Input element to apply the suggestion.value too when a suggestion is selected. If this is not supplied then the autoComplete input will contain the
+ * suggestion.title which will be sent to the backend as the value of the $autoCompleteInputElem
+ *
+ * @param suggestionFormat - [optional]
+ * Format for the suggestion to be displayed in the suggestion list, this will default to suggestion.title if a format is not supplied
  */
-var build = function ($autoCompleteInputElem, $targetInputElem, suggestionTemplate) {
+var build = function ($autoCompleteInputElem, $targetInputElem, suggestionFormat) {
   if ($autoCompleteInputElem.length) {
-    setup($autoCompleteInputElem, $targetInputElem, suggestionTemplate);
+    setup($autoCompleteInputElem, $targetInputElem, suggestionFormat);
     addEventListeners();
   }
 };

--- a/assets/javascripts/modules/autoCompleteFactory.js
+++ b/assets/javascripts/modules/autoCompleteFactory.js
@@ -11,7 +11,6 @@ var createAutoCompleteCountries = function () {
   autoComplete($chooseCountryAutoCompleteElem.first(), $countryCodeInput, suggestionDisplayTemplate);
 };
 
-// A factory for creating auto complete suggestions
 module.exports = function () {
   createAutoCompleteCountries();
   // add other auto completes here

--- a/assets/javascripts/modules/autoCompleteFactory.js
+++ b/assets/javascripts/modules/autoCompleteFactory.js
@@ -4,8 +4,11 @@ var autoComplete = require('./autoComplete.js');
 var createAutoCompleteCountries = function () {
   var $chooseCountryAutoCompleteElem = $('.js-choose-country-auto-complete');
   var $countryCodeInput = $('#countryCode');
+  var suggestionDisplayTemplate = function (title, value) {
+    return title + ' (+' + value + ')';
+  };
 
-  autoComplete($chooseCountryAutoCompleteElem.first(), $countryCodeInput);
+  autoComplete($chooseCountryAutoCompleteElem.first(), $countryCodeInput, suggestionDisplayTemplate);
 };
 
 // A factory for creating auto complete suggestions


### PR DESCRIPTION
# Send in Custom suggestion display Template

Display the countryCode in the autocomplete (JavaScript working) and the dropdown (JavaScript broken) in the following format: (+355)
This work enables the use of a custom display template which is sent in on creation of the autoComplete.

- added ability to have a template for the suggestion display, 
- send in cutom display template for countries autoComplete

#### AutoComplete
![countrycode-autocomplete](https://cloud.githubusercontent.com/assets/2305016/11928839/8a5d146a-a7ce-11e5-9a1c-174ed41471db.gif)

#### DropDown
![countrycode-autocomplete-no-js](https://cloud.githubusercontent.com/assets/2305016/11928842/8dcab292-a7ce-11e5-8eb5-0fac9aa04da9.gif)