### PR TITLE
GG-476: Slim modifier for breadcrumb nav

### DIFF
--- a/assets/scss/modules/_breadcrumb.scss
+++ b/assets/scss/modules/_breadcrumb.scss
@@ -4,7 +4,7 @@
 
 /* Usage:
 <nav class="breadcrumb-nav">
-  <ul>
+  <ul class="breadcrumb-nav__list">
     <li class="breadcrumb-nav__item"><a href=""> ... </a></li>
     <li class="breadcrumb-nav__item breadcrumb-nav__item--trail"></li>
   </ul>
@@ -12,7 +12,7 @@
 */
 
 .breadcrumb-nav {
-  padding: 10px 0 40px 0;
+  padding: em(10) 0 em(40) 0;
 }
 
 .breadcrumb-nav__item {
@@ -26,5 +26,18 @@
 
   &:after {
     content: "›";
+  }
+}
+
+.breadcrumb-nav--slim {
+  padding-top: em(5);
+  padding-bottom: em(10);
+
+  .breadcrumb-nav__list {
+    margin: 0;
+  }
+
+  .breadcrumb-nav__item {
+    margin: 0;
   }
 }


### PR DESCRIPTION
# Slim Breadcrumb modifier

- slim version of breadcrumb nav, 
- tidy up pixel values being used

![screen shot 2015-12-22 at 15 10 44](https://cloud.githubusercontent.com/assets/2305016/11958197/543480a8-a8be-11e5-9841-f8b3f42fbf2c.png)