### PR TITLE
GG-483: Remove submit disable work from form.js

### DIFF
--- a/assets/javascripts/modules/preventDoubleSubmit.js
+++ b/assets/javascripts/modules/preventDoubleSubmit.js
@@ -2,11 +2,6 @@ require('jquery');
 
 module.exports = function() {
   $('form').on('submit', function() {
-    if (typeof $.data(this, 'disabledOnSubmit') === 'undefined') {
-      $.data(this, 'disabledOnSubmit', {
-        submited: true
-      });
-
       $('input[type=submit], button[type=submit]', this).each(function() {
         var $button = $(this);
 
@@ -14,12 +9,6 @@ module.exports = function() {
         if (!$button.data('ignore-double-submit')) {
           $button.prop('disabled', true);
         }
-        
       });
-
-      return true;
-    } else {
-      return false;
-    }
   });
 };

--- a/assets/javascripts/validation/form.js
+++ b/assets/javascripts/validation/form.js
@@ -95,12 +95,6 @@ Summary Error Markup example:
 
 var $forms;
 
-var toggleSubmitButtonSate = function(submitButton, disable) {
-  if (submitButton) { //submit not available when focused on input
-    submitButton.disabled = disable;
-  }
-};
-
 var displayErrorSummary = function (validator, $errorSummary) {
   var $errorSummaryMessages = $errorSummary.find('.js-error-summary-messages > li');
   var invalidInputs = validator.invalid;
@@ -151,16 +145,13 @@ var flushErrors = function (invalid, errorList) {
 var handleErrors = function (validator) {
   var $currentForm = $(validator.currentForm);
   var $errorSummary = $('.error-summary', $currentForm);
-  var submitButton = $currentForm.find(':submit')[0];
 
   flushErrors(validator.invalid, validator.errorList);
 
   if (validator.numberOfInvalids()) {
     displayErrorSummary(validator, $errorSummary);
-    toggleSubmitButtonSate(submitButton, true);
   } else {
     $errorSummary.addClass('hidden');
-    toggleSubmitButtonSate(submitButton, false);
   }
 };
 
@@ -182,7 +173,11 @@ var setupForm = function ($formElem) {
     },
     submitHandler: function (form) {
       form.submit();
-    }
+    },
+    invalidHandler: function() {
+      //When invalid submission, re-enable the submit button
+      $formElem.find('.button[type=submit]').prop('disabled', false);
+    },
   });
 };
 


### PR DESCRIPTION
# Remove submit disable work from form.js

The form.js was controlling the submit disabled value, on being made aware of other code we have to take care of this this has now been removed from the form.js work.
Removed conditional from preventDoubleSubmit as this code does not take into account the following scenario:
- fill out a form, 
- that form errors clientSide
- they fix the errors 
- the submit button gets re-enabled because of fixed errors
- they submit again

Due to the conditional wrapped around the disable code [preventDoubleSubmit](https://github.com/hmrc/assets-frontend/blob/master/assets/javascripts/modules/preventDoubleSubmit.js#L5) the submit button is not then re-disabled by this code, which means a user can “pump” the button! 

====================================

#### Work Done
- Remove submit disable work from form.js 
- Remove conditional from preventDoubleSubmit
- added `invalidHandler` function to re-enable the submit button

#### Example 
![disablesubmit](https://cloud.githubusercontent.com/assets/2305016/12088528/f899b40a-b2d3-11e5-8e92-e3a868bbe4e6.gif)
