### PR TITLE
[API-689] Bug fix and minor refactoring

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -157,7 +157,7 @@ $(function() {
   attorneyBanner();
   youtubePlayer().init();
   ajaxFormSubmit.init(ajaxCallbacks); 
-  tabs().init();
+  tabs();
   accordion();
   charCounter();
   addRemove();

--- a/assets/javascripts/modules/tabs.js
+++ b/assets/javascripts/modules/tabs.js
@@ -39,33 +39,39 @@ require('jquery');
 
  */
 
-var activeTabClass,
-    inactiveTabClass,
+var activeTabClass = 'tabs-nav__tab--active',
+    inactiveTabClass = 'tabs-nav__tab',
     $tabElems,
-    $firstTab,
     selectActiveTabWithJs;
 
 // for each set of tabs in the page
-var initialiseTabs = function() {
+module.exports = function() {
+
+  $tabElems = $('[data-tabs]');
+
+  if($tabElems.length === 0) return;
+
   $tabElems.each(function() {
 
     var $tabs = $(this),
         activeTab;
 
+    selectActiveTabWithJs = $tabs.hasClass('js-hash-selected-tab');
+
+    // active tab is either first or based on url hash
+    activeTab = findActiveTab($tabs);
+
+    // initial setting of tab links state
+    updateTabLinks.call(activeTab, $tabs);
+
     // initial setting of tab content to be visible/hidden
-    if (selectActiveTabWithJs) {
-      activeTab = findActiveTabFromHash();
-      updateTabLinks.call(activeTab, $tabs);
-      updateTabContents($tabs, activeTab);
-    } else {
-      updateTabContents($tabs);
-    }
+    updateTabContents($tabs, activeTab);
 
     // for each tab link
     $tabs.on('click', '[data-tab-link]', function(e) {
 
       // add tab hash to URL if enabled
-      if (!selectActiveTabWithJs) {
+      if(!selectActiveTabWithJs) {
         e.preventDefault();
       }
 
@@ -74,26 +80,31 @@ var initialiseTabs = function() {
 
       // update state of tab links
       updateTabLinks.call(this, $tabs);
+
     });
 
   });
+
 };
 
 /**
  * Determine which tab to open at the start.
  * The open tab will be that matching the URL hash,
  * or the first tab if no hash present.
+ *
  * @returns {string} jQuery object for the tab to open
  */
-var findActiveTabFromHash = function() {
-  var activeTabLink = '',
+var findActiveTab = function($tabs) {
+
+  var $firstTab = $tabs.find('[data-tab-link]:first'),
       tab;
 
-  if (selectActiveTabWithJs) {
+  // only check hash if tabs instance specifies to do so
+  if(selectActiveTabWithJs) {
     tab = findTabByLinkAttr(window.location.hash);
-    activeTabLink = tab || $firstTab;
   }
-  return activeTabLink;
+
+  return tab || $firstTab;
 };
 
 /**
@@ -144,7 +155,7 @@ var updateTabContents = function($tabs, $tabLink) {
 var updateTabLinks = function($tabs) {
 
   var $clickedTab = $(this),
-    $tabLinks = $tabs.find('[data-tab-link]');
+      $tabLinks   = $tabs.find('[data-tab-link]');
 
   $tabLinks.each(function() {
 
@@ -157,7 +168,9 @@ var updateTabLinks = function($tabs) {
 
     // switch markup of tab link as needed
     $tabLink = updateLinkMarkup($tabLink, clickable);
+
   });
+
 };
 
 /**
@@ -222,26 +235,3 @@ var updateLinkMarkup = function($tabLink, clickable) {
 
   return $tabLink;
 };
-
-/**
- * if tabs present on page, initialise behaviour
- */
-var init = function() {
-
-  activeTabClass = 'tabs-nav__tab--active';
-  inactiveTabClass = 'tabs-nav__tab';
-  $tabElems = $('[data-tabs]');
-  $firstTab = $('a[data-tab-link]:first');
-  selectActiveTabWithJs = $('.js-hash-selected-tab').length > 0;
-
-  if ($tabElems.length) {
-    initialiseTabs();
-  }
-};
-
-module.exports = function() {
-  return {
-    init: init
-  };
-};
-

--- a/assets/test/specs/tabs.spec.js
+++ b/assets/test/specs/tabs.spec.js
@@ -28,7 +28,7 @@ describe("Given I have a tabs module on the page", function() {
       $('[data-tab-link="2"]').click();
     });
 
-    it("Then only the 1st tab content is visible", function() {
+    it("Then only the 2nd tab content is visible", function() {
       expect($('[data-tab-content="1"]')).toHaveClass('hidden');
       expect($('[data-tab-content="2"]')).not.toHaveClass('hidden');
       expect($('[data-tab-content="3"]')).toHaveClass('hidden');

--- a/assets/test/specs/tabs.spec.js
+++ b/assets/test/specs/tabs.spec.js
@@ -20,7 +20,7 @@ describe("Given I have a tabs module on the page", function() {
 
   });
 
-  describe("When I click the first tab link", function() {
+  describe("When I click the 2nd tab link", function() {
 
     beforeEach(function() {
       loadFixtures('tabs-fixtures.html');

--- a/assets/test/specs/tabs.spec.js
+++ b/assets/test/specs/tabs.spec.js
@@ -9,12 +9,12 @@ describe("Given I have a tabs module on the page", function() {
 
     beforeEach(function() {
       loadFixtures('tabs-fixtures.html');
-      tabs().init(); // init tabs module
+      tabs(); // init tabs module
     });
 
-    it("Then only the 2nd tab content is visible", function() {
-      expect($('[data-tab-content="1"]')).toHaveClass('hidden');
-      expect($('[data-tab-content="2"]')).not.toHaveClass('hidden');
+    it("Then only the first tab content is visible", function() {
+      expect($('[data-tab-content="1"]')).not.toHaveClass('hidden');
+      expect($('[data-tab-content="2"]')).toHaveClass('hidden');
       expect($('[data-tab-content="3"]')).toHaveClass('hidden');
     });
 
@@ -24,13 +24,13 @@ describe("Given I have a tabs module on the page", function() {
 
     beforeEach(function() {
       loadFixtures('tabs-fixtures.html');
-      tabs().init(); // init tabs module
-      $('[data-tab-link="1"]').click();
+      tabs(); // init tabs module
+      $('[data-tab-link="2"]').click();
     });
 
     it("Then only the 1st tab content is visible", function() {
-      expect($('[data-tab-content="1"]')).not.toHaveClass('hidden');
-      expect($('[data-tab-content="2"]')).toHaveClass('hidden');
+      expect($('[data-tab-content="1"]')).toHaveClass('hidden');
+      expect($('[data-tab-content="2"]')).not.toHaveClass('hidden');
       expect($('[data-tab-content="3"]')).toHaveClass('hidden');
     });
 
@@ -44,7 +44,7 @@ describe("Given I have a tabs module on the page", function() {
 
         beforeEach(function() {
           loadFixtures('tabs-fixtures-auto-open.html');
-          tabs().init();
+          tabs();
         });
 
         it("should have the first tab selected", function() {
@@ -63,7 +63,7 @@ describe("Given I have a tabs module on the page", function() {
         beforeEach(function() {
           loadFixtures('tabs-fixtures-auto-open.html');
           window.history.replaceState(null, null, '#three');
-          tabs().init();
+          tabs();
         });
 
         it("should have the tab matching the hash selected", function() {


### PR DESCRIPTION
### Bug Fix:

Fixed issue where default tab is not selected correctly. This was due to the :first selector always targeting anchors when it should be element agnostic to consider spans.

### Refactoring:

 * Removed init to keep things simpler (less code/boilerplate) and be consistent with other modules.
 * Some jQuery selectors were global, so I scoped them within their $tabs instance.
 * Clean up of logic in initial tabs setup. The "selectActiveTabWithJs" property doesn't need to be checked here as a fallback to the first tab is already written in the "findActiveTabFromHash" method (renamed to findActiveTab).
 * Updated tests accordingly.
