### PR TITLE
[AOSS-1082] Updated DOM manipulation for new Missing Client Request p…

### DIFF
--- a/assets/javascripts/modules/ajaxCallbacks.js
+++ b/assets/javascripts/modules/ajaxCallbacks.js
@@ -11,7 +11,8 @@ var ajaxCallbacks = {
       },
 
       success: function(response, $element, data, helpers, container, type) {
-        helpers.insertResponseHtml(helpers, type, data, $(container), response);
+        $('input[name="payeref"]').val('');
+        helpers.insertResponseHtml(helpers, type, data, $(container + ' .form-field:has(>input[name][type="text"])').first(), response);
       },
 
       error: function(response, $element, data, helpers, container) {
@@ -60,7 +61,9 @@ var ajaxCallbacks = {
         $target.empty();
         type  = 'append';
       }
-
+      
+      helpers.resetErrorMessages($target.parent(), $target);
+      
       if (helpers.utilities.isFullPageError(helpers, htmlText)) {
         helpers.insertFullPageErrorHtml($target, helpers, htmlText);
       }
@@ -68,7 +71,6 @@ var ajaxCallbacks = {
         helpers.insertServiceErrorHtml(helpers, htmlText);
       }
       else { // handle 'validation error' or 'success' message & state
-        helpers.resetErrorMessages($target.parent(), $target);
 
         if (!isError) {
           $target.addClass('js-hidden');
@@ -129,13 +131,8 @@ var ajaxCallbacks = {
     },
 
     resetErrorMessages: function($target, $error) {
-      if (!!$error) {
-        $error.removeClass('error');
-      }
-
-      $target.find('.form-field:has(*[data-id="service--error"]), .alert--success, .alert--failure')
-        .removeClass('error')
-        .remove();
+      $target.find('.error').andSelf().removeClass('error');
+      $target.find('.form-field:has(*[data-id="service--error"]), .alert--success, .alert--failure').remove();
     },
 
     resetForms: function(helpers, type, data, target) {

--- a/assets/javascripts/modules/ajaxFormSubmit.js
+++ b/assets/javascripts/modules/ajaxFormSubmit.js
@@ -38,7 +38,7 @@ var ajaxFormSubmit = {
 
   init: function(config) {
     var _this = this,
-        $ajaxForm = $('form:has([data-ajax-submit])'),
+        $ajaxForm = $('form[data-ajax-submit], form:has([data-ajax-submit])'),
         ajaxFormCount = $ajaxForm.length,
         a = 0;
 


### PR DESCRIPTION
…age

[AOSS-1082](https://jira.tools.tax.service.gov.uk/browse/AOSS-1082)

* update DOM manipulation for ajax callback(s) injection of errors and success confirmation message

* includes bug fix for form element selector in 'ajaxFormSubmit' init()
   * wasn't picking up form with 'data-...' attributes
   * now picks up both form and/or element (button) with 'data-...' attributes

![AOSS-1082 New Missing Client Access Request Form (64-8) page](https://cloud.githubusercontent.com/assets/5468091/12236269/aa51e928-b870-11e5-8a72-557e02e9a3e6.gif)
