### PR TITLE
[PAYM-854] Remove inline styles from Payments pages.

### DIFF
--- a/assets/scss/pages/_payments.scss
+++ b/assets/scss/pages/_payments.scss
@@ -102,6 +102,14 @@
     margin-bottom: 0;
   }
 
+  .hint__details {
+    margin: em(10) 0;
+  }
+
+  .print-download__link {
+    margin-bottom: em(30);
+  }
+
   .user-name {
     margin: em(15) 0 0 0;
     float: right;


### PR DESCRIPTION
* page templates in Payments project had inline styles in a number of places due to no FE devs being available at the time.
* removed all inline styles from payments pages, using existing assets-frontend styles where available.
* added 2 style classes to payments-specific scss file.