### PR TITLE
API-691 - Removed core-16 mixin call, added line height

### DIFF
--- a/assets/scss/modules/_toggle-button.scss
+++ b/assets/scss/modules/_toggle-button.scss
@@ -1,7 +1,7 @@
 .toggle-btn {
-  @include core-16;
-  padding: em(3) em(10) em(3) em(10);
+  padding: em(5) em(10) em(3) em(10);
   display: inline-block;
+  line-height: 1.4em;
 }
 
 .toggle-btn--on {


### PR DESCRIPTION
Fixed issue where buttons were not evenly padded across breakpoints.