### PR TITLE
Form refactor

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -136,7 +136,7 @@ $(function() {
 
   sso().init();
   visibility();
-  form();
+  form.init();
   mask();
   toggle();
   autoCompleteFactory();

--- a/assets/javascripts/modules/toggle.js
+++ b/assets/javascripts/modules/toggle.js
@@ -17,22 +17,18 @@ Toggle markup example:
     <label class="block-label block-label--inline" for="uk-phone-number-toggle-close">Yes
         <input type="radio"
                id="uk-phone-number-toggle-close"
-               class="js-toggle-trigger js-control"
+               class="js-toggle-trigger"
                value="yes"
                name="uk-number"
-               required
-               data-control-target="countryCode"
-               data-control-value="44"/>
+               required />
     </label>
     <label class="block-label block-label--inline" for="uk-phone-number-toggle-open">No
         <input type="radio"
                id="uk-phone-number-toggle-open"
-               class="js-toggle-trigger js-control"
+               class="js-toggle-trigger"
                value="no"
                name="uk-number"
                required
-               data-control-target="countryCode"
-               data-control-value="0"
                aria-controls="uk-phone-number-toggle-target"/>
     </label>
 </fieldset>
@@ -49,13 +45,6 @@ Target markup example:
 </div>
  */
 var $toggleElems;
-
-var flushErrors = function ($targetElem) {
-  var $inputs = $targetElem.find('input');
-  if ($inputs.length) {
-    $($inputs[0].form).validate().showErrors();
-  }
-};
 
 /**
  * Controls for triggering toggle
@@ -77,10 +66,8 @@ var toggleEvent = function ($elem) {
 
       if (target.id === openId) {
         $targetElem.show().attr('aria-expanded', 'true').attr('aria-visible', 'true');
-        flushErrors($targetElem);
       } else if (target.id === closeId) {
         $targetElem.hide().attr('aria-expanded', 'false').attr('aria-visible', 'false');
-        flushErrors($targetElem);
       }
     }
   });

--- a/assets/javascripts/validation/form.js
+++ b/assets/javascripts/validation/form.js
@@ -81,23 +81,25 @@ Summary Error Markup example:
 var $forms;
 
 var displayGlobalErrorSummary = function (validator, errorMessages) {
+  var $template = $('<li role="tooltip"><a></a></li>');
+  var $errorSummaryListElement;
+
   if (errorMessages.length) {
+
     $(errorMessages).each(function (index, errorDetail) {
-      createErrorSummaryListItem(validator, errorDetail.message, errorDetail.name);
+      $errorSummaryListElement = $template.clone();
+      createErrorSummaryListItem($errorSummaryListElement, validator, errorDetail);
     });
   }
 };
 
-var createErrorSummaryListItem = function (validator, error, name) {
+var createErrorSummaryListItem = function ($liElement, validator, errorDetail) {
   var $errorSummaryMessages = $(validator.currentForm).find('.js-error-summary-messages');
-  var $template = $('<li role="tooltip"><a></a></li>');
-  var $errorSummaryListElement = $template.clone();
-  var $anchorElement = $errorSummaryListElement.find('a');
+  var $anchorElement = $liElement.find('a');
 
-  $errorSummaryListElement.attr('data-journey', 'search-page:error:' + name);
-  $anchorElement.attr('data-focuses', name).attr('id', name + '-error').attr('href', '#' + name).text(error);
-
-  $errorSummaryMessages.append($errorSummaryListElement);
+  $liElement.attr('data-journey', 'search-page:error:' + errorDetail.name);
+  $anchorElement.attr('data-focuses', errorDetail.name).attr('id', errorDetail.name + '-error').attr('href', '#' + name).text(errorDetail.message);
+  $errorSummaryMessages.append($liElement);
 }
 
 /**

--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -39,6 +39,7 @@ $path: "../images/icons/";
 @import "base/links";
 @import "base/icons";
 @import "base/details-summary";
+@import "base/form/errors";
 
 // Modules
 @import "modules/header";

--- a/assets/scss/_shame.scss
+++ b/assets/scss/_shame.scss
@@ -101,12 +101,14 @@ div.email {
 /*------------------------------------*\
     form validations
 \*------------------------------------*/
+
+// THIS IS DEPRECATED PLEASE USE THE WORK IN base/form/errors.scss
 .form-field.error , .form-field-group.error{
   @include error-box( 3px );
   margin: 0 -1em 0.5em -1em;
 }
 
-.error-notification,
+// THIS IS DEPRECATED PLEASE USE THE WORK IN base/form/errors.scss
 .client-error-notification {
   color: $error-color;
   display: none;

--- a/assets/scss/base/_helpers.scss
+++ b/assets/scss/base/_helpers.scss
@@ -191,9 +191,7 @@
 // TODO and not use the .js-convention (for javascript hooks) needs tidying up and duplications removed
 .hidden,
 .no-js .js-visible,
-.no-js .visible-javascript-on,
-.js .js-hidden,
-.js .hidden-javascript-on {
+.js .js-hidden {
   display: none !important;
 }
 

--- a/assets/scss/base/form/_errors.scss
+++ b/assets/scss/base/form/_errors.scss
@@ -1,0 +1,25 @@
+.error-summary {
+  display: none;
+}
+
+.error-summary--show {
+  display: block;
+}
+
+.error-notification {
+  color: $error-color;
+  display: none;
+  padding-bottom: em(8);
+  @include core-16;
+}
+
+.form-field-group--error {
+  @include error-box(3px);
+  margin: 0 em(-16) em(8) em(-16);
+
+  .error-notification {
+    display: block;
+  }
+}
+
+

--- a/assets/test/specs/fixtures/form-fixture.html
+++ b/assets/test/specs/fixtures/form-fixture.html
@@ -1,0 +1,51 @@
+<form class="js-form" autocomplete="off" novalidate="novalidate">
+
+  <div class="flash error-summary" id="Search-failure" role="group" aria-labelledby="errorSummaryHeading" tabindex="-1">
+    <h2 id="errorSummaryHeading" class="h3-heading">There are errors on the page.</h2>
+    <ul class="js-error-summary-messages"></ul>
+  </div>
+
+  <fieldset class="form-field-group">
+    <label class="form-element-bold" for="text-input-example">Text input example
+    <span class="error-notification" role="tooltip" data-journey="search-page:error:text-input-example">
+        Required text
+    </span>
+    <input type="text"
+           name="text-input-example"
+           id="text-input-example"
+           class="form-control"
+           minlength="5"
+           maxlength="13"
+           required
+           pattern="^[0-9]{5,13}$"
+           data-msg-pattern="Wrong pattern"
+           data-msg-required="Required text"
+           data-msg-minlength="Min length of 5 is required">
+    </label>
+  </fieldset>
+
+
+  <fieldset class="form-field-group" id="radio-example">
+    <span class="error-notification" role="tooltip" data-journey="search-page:error:radio-example">
+        Required selection
+    </span>
+
+    <label class="block-label block-label--inline" for="radio-yes">Yes
+      <input type="radio"
+             id="radio-yes"
+             value="yes"
+             name="radio-example"
+             required
+             data-msg-required="Required selection"/>
+    </label>
+    <label class="block-label block-label--inline" for="radio-no">No
+      <input type="radio"
+             id="radio-no"
+             value="no"
+             name="radio-example"
+             required/>
+    </label>
+  </fieldset>
+
+  <button id="submit-button" type="submit">Submit</button>
+</form>

--- a/assets/test/specs/form.spec.js
+++ b/assets/test/specs/form.spec.js
@@ -1,0 +1,191 @@
+require('jquery');
+require('validate');
+
+var ERROR_SUMMARY_HEADER_TEXT = 'There are errors on the page.';
+var form;
+var $formElement;
+var customValidations;
+var $errorSummary;
+var $errorSummaryMessages;
+var $submitButton;
+var $errorSummaryHeading;
+var $textInputExample;
+var $radioYesElement;
+var $radioNoElement;
+
+var setup = function () {
+  form.init();
+  $formElement = $('.js-form');
+  customValidations();
+  $errorSummary = $('.error-summary');
+  $errorSummaryMessages = $('.js-error-summary-messages');
+  $submitButton = $('#submit-button');
+  $errorSummaryHeading = $('#errorSummaryHeading');
+  $textInputExample = $('#text-input-example');
+  $radioYesElement = $('#radio-yes');
+  $radioNoElement = $('#radio-no');
+};
+
+describe('Form Validation', function () {
+
+  beforeEach(function () {
+    jasmine.getFixtures().fixturesPath = 'base/specs/fixtures/';
+    loadFixtures('form-fixture.html');
+    form = require('../../javascripts/validation/form.js');
+    customValidations = require('../../javascripts/validation/customValidations.js');
+  });
+
+  describe('', function () {
+    beforeEach(setup);
+
+    describe('When I load the page', function () {
+      it('The error summary should be hidden', function () {
+        expect($errorSummary).not.toHaveClass('error-summary--show');
+      });
+
+      it('The error summary should contain no errors', function () {
+          expect($errorSummaryMessages.find('> li').length).toBe(0);
+      });
+
+      it('The form should have no errors', function () {
+          expect(form.getErrorMessages().length).toBe(0)
+      });
+    });
+
+    describe('When I submit the form without filling it out', function () {
+
+      beforeEach(function () {
+        $submitButton.click();
+      });
+
+      it('The error summary should be visible', function () {
+        expect($errorSummary).toHaveClass('error-summary--show');
+        expect($errorSummaryHeading.text()).toBe(ERROR_SUMMARY_HEADER_TEXT);
+      });
+
+      it('The error summary should contain 2 errors', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+
+        expect($errorMessages.length).toBe(2);
+        expect($errorMessages.eq(0).text()).toBe($textInputExample.attr('data-msg-required'));
+        expect($errorMessages.eq(1).text()).toBe($radioYesElement.attr('data-msg-required'));
+      });
+
+      it('The form should have 2 errors', function () {
+        expect(form.getErrorMessages().length).toBe(2);
+      });
+    });
+
+    describe('When I submit the form with filling it out', function () {
+
+      beforeEach(function () {
+        $textInputExample.val('4567878');
+        $radioYesElement.click();
+        $submitButton.on('click', function (event) {
+            event.preventDefault();
+            // prevent form submission - will cause page reload error in jasmine
+        }).click();
+      });
+
+      it('The error summary should not be visible', function () {
+        expect($errorSummary).not.toHaveClass('error-summary--show');
+      });
+
+      it('The error summary should contain 0 errors', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+        expect($errorMessages.length).toBe(0);
+      });
+
+      it('The form should have 0 errors', function () {
+        expect(form.getErrorMessages().length).toBe(0);
+      });
+    });
+
+
+    describe('When I enter the wrong pattern on text input', function () {
+
+      beforeEach(function () {
+        // select radio button, add wrong format value to text input
+        $textInputExample.val('wrong!');
+        $radioYesElement.click();
+        $submitButton.click();
+      });
+
+      it('The error summary should be visible', function () {
+        expect($errorSummary).toHaveClass('error-summary--show');
+        expect($errorSummaryHeading.text()).toBe(ERROR_SUMMARY_HEADER_TEXT);
+      });
+
+      it('The error summary should contain 1 error', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+        expect($errorMessages.length).toBe(1);
+      });
+
+      it('The form should have 1 error', function () {
+        expect(form.getErrorMessages().length).toBe(1);
+      });
+
+      it('The form should have the invalid pattern error message', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+        expect($errorMessages.eq(0).text()).toBe($textInputExample.attr('data-msg-pattern'));
+      });
+    });
+
+    describe('When I enter value below min length', function () {
+
+      beforeEach(function () {
+        // select radio button, add value below min length to text input
+        $textInputExample.val('55');
+        $radioYesElement.click();
+        $submitButton.click();
+      });
+
+      it('The error summary should be visible', function () {
+        expect($errorSummary).toHaveClass('error-summary--show');
+        expect($errorSummaryHeading.text()).toBe(ERROR_SUMMARY_HEADER_TEXT);
+      });
+
+      it('The error summary should contain 1 error', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+        expect($errorMessages.length).toBe(1);
+      });
+
+      it('The form should have 1 error', function () {
+        expect(form.getErrorMessages().length).toBe(1);
+      });
+
+      it('The form should have the invalid pattern error message', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+        expect($errorMessages.eq(0).text()).toBe($textInputExample.attr('data-msg-minlength'));
+      });
+    });
+
+    describe('When I do not select a radio input', function () {
+
+      beforeEach(function () {
+        // do not select radio button, add correct value for text input
+        $textInputExample.val('55888');
+        $submitButton.click();
+      });
+
+      it('The error summary should be visible', function () {
+        expect($errorSummary).toHaveClass('error-summary--show');
+        expect($errorSummaryHeading.text()).toBe(ERROR_SUMMARY_HEADER_TEXT);
+      });
+
+      it('The error summary should contain 1 error', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+        expect($errorMessages.length).toBe(1);
+      });
+
+      it('The form should have 1 error', function () {
+        expect(form.getErrorMessages().length).toBe(1);
+      });
+
+      it('The form should have the radio required error message', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+        expect($errorMessages.eq(0).text()).toBe($radioYesElement.attr('data-msg-required'));
+      });
+    });
+  });
+});


### PR DESCRIPTION
Refactor of the form work to include the capability of adding different messages for different rules.

- Add messages via `data-msg-<rule_name>`
- remove flushErrors dependency from `toggle.js`
- tidy up styles a bit
- add deprecated notice to styles
- tests

#### Example
![form-validation-refactor](https://cloud.githubusercontent.com/assets/2305016/12391531/5baecf5a-bde0-11e5-8fef-e2f5d2755dcc.gif)
