### PR TITLE
API-916 - Refactored tabs for accessibility + updated tests

### DIFF
--- a/assets/javascripts/modules/tabs.js
+++ b/assets/javascripts/modules/tabs.js
@@ -5,33 +5,33 @@ require('jquery');
  *
  * Usage:
 
- <div data-tabs>
+    <div data-tabs>
 
-   <ul class="tabs-nav">
-     <li class="tabs-nav__tab">
-      <a href="#" data-tab-link="1">Tab Link 1</a>
-     </li>
-     <li class="tabs-nav__tab--active">
-      <span data-tab-link="2">Tab Link 2</span>
-     </li>
-     <li class="tabs-nav__tab">
-      <a href="#" data-tab-link="3">Tab Link 3</a>
-     </li>
-   </ul>
+      <ul role="tablist">
+        <li id="tab1" data-tab-link="1" role="tab" aria-selected="true" aria-controls="tabContent1" tabindex="0">
+          <span class="tabs-nav__tab tabs-nav__tab--active">Tab Link 1</span>
+        </li>
+        <li id="tab2" data-tab-link="2" role="tab" aria-selected="false" aria-controls="tabContent2" tabindex="0">
+          <a href="#" class="tabs-nav__tab">Tab Link 2</a>
+        </li>
+        <li id="tab3" data-tab-link="3" role="tab" aria-selected="false" aria-controls="tabContent3" tabindex="0">
+          <a href="#" class="tabs-nav__tab">Tab Link 3</a>
+        </li>
+      </ul>
 
-   <ul>
-     <li data-tab-content="1">
-      <p>Tab Content 1</p>
-     </li>
-     <li data-tab-content="2">
-       <p>Tab Content 2</p>
-     </li>
-     <li data-tab-content="3">
-       <p>Tab Content 3</p>
-     </li>
-   </ul>
+      <ul>
+        <li id="tabContent1" data-tab-content="1" class="tab-content" role="tabpanel" aria-labelledby="tab1">
+          <p>Tab Content 1</p>
+        </li>
+        <li id="tabContent2" data-tab-content="2" class="tab-content" role="tabpanel" aria-labelledby="tab2">
+          <p>Tab Content 2</p>
+        </li>
+        <li id="tabContent3" data-tab-content="3" class="tab-content" role="tabpanel" aria-labelledby="tab3">
+          <p>Tab Content 3</p>
+        </li>
+      </ul>
 
- </div>
+    </div>
 
  * add class to initial div if tabs should open based on URL hash, or 1st tab if not found
  *
@@ -40,9 +40,10 @@ require('jquery');
  */
 
 var activeTabClass = 'tabs-nav__tab--active',
-    inactiveTabClass = 'tabs-nav__tab',
+    ariaSelected   = 'aria-selected',
     $tabElems,
     selectActiveTabWithJs;
+
 
 // for each set of tabs in the page
 module.exports = function() {
@@ -54,34 +55,23 @@ module.exports = function() {
   $tabElems.each(function() {
 
     var $tabs = $(this),
-        activeTab;
+      $activeTabLI;
 
     selectActiveTabWithJs = $tabs.hasClass('js-hash-selected-tab');
 
     // active tab is either first or based on url hash
-    activeTab = findActiveTab($tabs);
+    $activeTabLI = findActiveTab($tabs);
+
+    // remove spans and anchors within tab LIs
+    removeElements($activeTabLI, $tabs);
 
     // initial setting of tab links state
-    updateTabLinks.call(activeTab, $tabs);
+    updateTabLinks($activeTabLI, $tabs);
 
     // initial setting of tab content to be visible/hidden
-    updateTabContents($tabs, activeTab);
+    updateTabContents($activeTabLI, $tabs);
 
-    // for each tab link
-    $tabs.on('click', '[data-tab-link]', function(e) {
-
-      // add tab hash to URL if enabled
-      if(!selectActiveTabWithJs) {
-        e.preventDefault();
-      }
-
-      // set correct tab content to be visible
-      updateTabContents($tabs, $(this));
-
-      // update state of tab links
-      updateTabLinks.call(this, $tabs);
-
-    });
+    bindTabClick($tabs);
 
   });
 
@@ -96,142 +86,203 @@ module.exports = function() {
  */
 var findActiveTab = function($tabs) {
 
-  var $firstTab = $tabs.find('[data-tab-link]:first'),
-      tab;
+  var $firstTab  = $tabs.find('[data-tab-link]:first'),
+    $activeTab = $tabs.find('[data-tab-link] .tabs-nav__tab--active').parent(),
+    $tabFromHash;
 
   // only check hash if tabs instance specifies to do so
   if(selectActiveTabWithJs) {
-    tab = findTabByLinkAttr(window.location.hash);
+    $tabFromHash = findTabByLinkAttr($tabs, window.location.hash);
   }
 
-  return tab || $firstTab;
+  if($activeTab.length === 0) {
+    $activeTab = null;
+  }
+
+  return $tabFromHash || $activeTab || $firstTab;
 };
 
 /**
  * Try to find a present tab matching the URL hash
+ *
+ * @param $tabs
  * @param hash the URL hash
  * @returns the jQuery object for the tab
  */
-var findTabByLinkAttr = function(hash) {
+var findTabByLinkAttr = function($tabs, hash) {
   var $tab;
 
-  if (hash.length > 1) {
-    $tab = $('a[data-tab-link=' + hash.substring(1) + ']');
-    if ($tab.length) {
+  if(hash.length > 1) {
+    $tab = $tabs.find('[data-tab-link=' + hash.substring(1) + ']');
+    if($tab.length) {
       return $tab;
     }
   }
+
+};
+
+/**
+ * Removes span or anchor from within LI, making LI the clickable tab
+ *
+ * @param $activeTab
+ * @param $tabs
+ */
+var removeElements = function($activeTab, $tabs) {
+
+  $tabs.find('[data-tab-link]').each(function() {
+
+    var $tabLink = $(this),
+      $element = $tabLink.find('.tabs-nav__tab'),
+      attrs    = getAttributes($element),
+      tabText  = $element.text();
+
+    if(attrs.class) {
+      $tabLink.addClass(attrs.class);    // put element classes on LI
+    }
+
+    $tabLink.html(tabText);
+
+  });
+
+};
+
+/**
+ *
+ * @param $tabs
+ */
+var bindTabClick = function($tabs) {
+
+  // on click of a tab LI or link
+  $tabs.on('click', '[data-tab-link]', function(e) {
+    onSelectTab(e, $tabs);
+  });
+
+  // on press enter on tab LI or link
+  $tabs.on('keydown', '[data-tab-link]', function(e) {
+    if(e.which === 13) {
+      onSelectTab(e, $tabs);
+    }
+  });
+
+};
+
+/**
+ *
+ * @param e
+ * @param $tabs
+ */
+var onSelectTab = function(e, $tabs) {
+
+  var $tabLI = $(e.currentTarget),
+      hashVal;
+
+  // add tab hash to URL if enabled
+  if(selectActiveTabWithJs) {
+
+    hashVal = $tabLI.data('tab-link');
+
+    if(history.replaceState) {
+      history.replaceState(null, null, '#' + hashVal);
+    }
+    else {
+      // warning: for older browsers, this causes the tab content to be scrolled to
+      location.hash = hashVal;
+    }
+
+  }
+
+  // set correct tab content to be visible
+  updateTabContents($tabLI, $tabs);
+
+  // update state of tab links
+  updateTabLinks($tabLI, $tabs);
+
 };
 
 /**
  * Update visibility of tab contents
  *
+ * @param  {Object} $tabLI    tab link that was just clicked
  * @param  {Object} $tabs     jQuery object for tabs container
- * @param  {Object} $tabLink  tab link that was just clicked
  */
-var updateTabContents = function($tabs, $tabLink) {
+var updateTabContents = function($tabLI, $tabs) {
 
-  var $tabContent;
-
-  // tab link is either tab just clicked or the active tab (on page load)
-  $tabLink = $tabLink || $tabs.find('span[data-tab-link]');
+  var $tabContent,
+    $tabList = $tabs.find('[data-tab-content]');
 
   // find tab content that corresponds to tab link
-  $tabContent = $tabs.find('[data-tab-content="' + $tabLink.data('tab-link') + '"]');
+  $tabContent = $tabs.find('[data-tab-content="' + $tabLI.data('tab-link') + '"]');
 
-  // hide all tabs
-  $tabs.find('[data-tab-content]').addClass('hidden');
+  $tabList.addClass('hidden')               // hide all tabs
+    .attr('aria-hidden', true);       // set tabs as hidden to screen readers
 
-  // reveal selected tab's content
-  $tabContent.removeClass('hidden');
+  $tabContent.removeClass('hidden')         // reveal selected tab's content
+    .attr('aria-hidden', false);   // set selected tab as visible to screen readers
 
 };
 
 /**
  * Update tab link states
  *
+ * @param $clickedTab
  * @param  {Object} $tabs     jQuery object for tabs container
  */
-var updateTabLinks = function($tabs) {
+var updateTabLinks = function($clickedTab, $tabs) {
 
-  var $clickedTab = $(this),
-      $tabLinks   = $tabs.find('[data-tab-link]');
+  var $tabLIs = $tabs.find('[data-tab-link]');
 
-  $tabLinks.each(function() {
-
-    var $tabLink = $(this),
+  $tabLIs.each(function() {
+    var $tabLI = $(this);
 
     // item will be clickable if it's not what was just clicked
-      clickable = $tabLink.data('tab-link') !== $clickedTab.data('tab-link');
+    var clickable = $tabLI.data('tab-link') !== $clickedTab.data('tab-link');
 
-    $tabLink = setActiveClass($tabLink, clickable);
+    $tabLI = setActiveClass($tabLI, clickable);
 
-    // switch markup of tab link as needed
-    $tabLink = updateLinkMarkup($tabLink, clickable);
+    // toggle aria-selected on tab link
+    $tabLI.attr(ariaSelected, !clickable);
 
   });
 
 };
 
 /**
- * add and remove classes for styling active and non active tabs
- * @param $tabLink tab jQuery object
+ * Add and remove classes for styling active and non active tabs
+ *
+ * @param $tabLI
  * @param clickable whether tab is clickable
  * @returns {*} tab jQuery object
  */
-var setActiveClass = function($tabLink, clickable) {
+var setActiveClass = function($tabLI, clickable) {
 
-  if (clickable) {
-    $tabLink.removeClass(activeTabClass);
-    $tabLink.addClass(inactiveTabClass);
+  if(clickable) {
+    $tabLI.removeClass(activeTabClass);
   } else {
-    $tabLink.removeClass(inactiveTabClass);
-    $tabLink.addClass(activeTabClass);
+    $tabLI.addClass(activeTabClass);
   }
-  return $tabLink;
+
+  return $tabLI;
 };
 
 /**
- * Updates a tab link's markup based on whether it should be clickable or not
+ * Return an elements attributes as an object
  *
- * @param  {Object} $tabLink    tab link that will be updated
- * @param  {Object} clickable   whether tab link will be clickable
- * @return {Object} $tabLink    updated tab link
+ * @param $element
+ * @returns {{}}
  */
-var updateLinkMarkup = function($tabLink, clickable) {
+var getAttributes = function($element) {
 
   var attrs = {};
 
-  // save all attributes
-  $.each($tabLink[0].attributes, function(i, attr) {
-    attrs[attr.nodeName] = attr.nodeValue;
-  });
+  if($element.length > 0) {
 
-  // if tabLink should be clickable and is not already an anchor
-  if (clickable) {
-
-    // convert to anchor
-    $tabLink.replaceWith(function() {
-
-      // restore url of anchor from data attribute
-      var hrefAttr = {'href': '#' + attrs['data-tab-link']};
-
-      return $("<a/>", $.extend(attrs, hrefAttr)).append($(this).contents());
-    });
-
-  }
-  // if tabLink is not clickable
-  else {
-
-    // span does not need href attribute
-    delete attrs.href;
-
-    // convert link to span
-    $tabLink.replaceWith(function() {
-      return $("<span/>", attrs).append($(this).contents());
+    // save all attributes of tabLink
+    $.each($element[0].attributes, function(i, attr) {
+      attrs[attr.nodeName] = attr.nodeValue;
     });
 
   }
 
-  return $tabLink;
+  return attrs;
+
 };

--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -77,6 +77,7 @@ $path: "../images/icons/";
 @import "modules/char-counter";
 @import "modules/add-remove";
 @import "modules/toggle-button";
+@import "modules/tabs";
 
 
 // Page Specific Styles

--- a/assets/scss/modules/_navigation.scss
+++ b/assets/scss/modules/_navigation.scss
@@ -103,65 +103,6 @@ a.header__menu__proposition-name {
   }
 }
 
-.tabs-nav {
-  margin: 2em 0;
-  border-bottom: 1px solid #ccc;
-  list-style-type: none;
-  margin-bottom: 1em;
-
-  @include media(tablet) {
-    @extend %contain-floats;
-    display: flex;
-  }
-
-  .tabs-nav__tab {
-    margin-bottom: 0;
-    border-top: 1px solid $border-colour;
-    display: block;
-    padding: 0.5em 0;
-    text-decoration: none;
-    white-space: nowrap;
-
-    .count {
-      background-color: $red;
-      color: $white;
-      padding: 0 5px;
-    }
-
-    @include media(tablet) {
-      float: left;
-      background-color: #dee0e2;
-      border: 0;
-      margin: 0.25em 0.25em 0.25em 0;
-      padding: 0.45em;
-    }
-  }
-
-  .tabs-nav__tab--active {
-    border-top: 1px solid $border-colour;
-    margin-bottom: 0;
-    padding: 0.5em 0;
-    display:block;
-    white-space: nowrap;
-
-    @include media(tablet) {
-      border: 1px solid $border-colour;
-      border-bottom: 1px solid #fff;
-      float: left;
-      margin: 0 0.25em -1px 0;
-      padding: 0.7em;
-    }
-  }
-}
-
-.tab-content {
-
-  .tab-content__first {
-    margin-top: em(30);
-  }
-
-}
-
 .back-link {
   @include core-19();
   border-bottom: 1px solid $black;

--- a/assets/scss/modules/_tabs.scss
+++ b/assets/scss/modules/_tabs.scss
@@ -1,0 +1,113 @@
+.tabs-nav {
+  margin: 2em 0 1em 0;
+  overflow: hidden;
+  position: relative;
+
+  &:before {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    border-bottom: 1px solid #ccc;
+    z-index: 1;
+    width: 100%;
+  }
+
+}
+
+.tabs-nav__tab {
+  margin-bottom: 0;
+  display: block;
+  padding: 0.5em;
+  text-decoration: underline;
+  white-space: nowrap;
+  outline: none;
+  cursor: pointer;
+  z-index: 0;
+  box-sizing: border-box;
+  position: relative;
+  border-top: 1px solid $border-colour;
+  color: #005ea5;
+  transition: background .25s ease-in-out;
+
+  &:focus,
+  &:hover,
+  &:active {
+    background-color: #DEE0E2;
+  }
+
+  &:visited {
+    color: #005ea5;
+  }
+
+  .count {
+    background-color: $red;
+    color: $white;
+    padding: 0 5px;
+  }
+
+  @include media(tablet) {
+    height: 53px;
+    display: inline-block;
+    margin: 0 em(3) 0 0;
+    padding: 0.7em 0.8em;
+    border-top: none;
+    border-bottom: 6px solid white;
+  }
+
+}
+
+li.tabs-nav__tab {
+  margin-bottom: 0;
+}
+
+a.tabs-nav__tab {
+
+  &:focus,
+  &:hover,
+  &:active {
+    background-color: #DEE0E2;
+  }
+
+}
+
+.tabs-nav__tab--active {
+  cursor: default;
+  z-index: 2;
+  text-decoration: none;
+  color: #000;
+  background-color: $white;
+  transition: none;
+
+  &:focus,
+  &:hover,
+  &:active {
+    background-color: $white;
+  }
+
+  @include media(tablet) {
+    height: 54px;
+    padding: 0.7em;
+    border: 1px solid $border-colour;
+    border-bottom: none;
+  }
+
+}
+
+.tab-content {
+
+  .tab-content__first {
+    margin-top: em(30);
+  }
+
+}
+
+[data-tab-link] {
+  display: block;
+  margin-bottom: 0 !important;
+
+  @include media(tablet) {
+    display: inline-block;
+  }
+
+}

--- a/assets/test/specs/fixtures/tabs-fixtures-auto-open.html
+++ b/assets/test/specs/fixtures/tabs-fixtures-auto-open.html
@@ -2,14 +2,14 @@
 <div data-tabs class="js-hash-selected-tab">
 
   <ul>
-    <li>
-      <a href="#one" data-tab-link="one">Tab One</a>
+    <li data-tab-link="one">
+      <a href="#one" class="tabs-nav__tab tabs-nav__tab--active">Tab One</a>
     </li>
-    <li>
-      <a href="#two" data-tab-link="two">Tab Two</a>
+    <li data-tab-link="two">
+      <a href="#two" class="tabs-nav__tab">Tab Two</a>
     </li>
-    <li>
-      <a href="#three" data-tab-link="three">Tab Three</a>
+    <li data-tab-link="three">
+      <a href="#three" class="tabs-nav__tab">Tab Three</a>
     </li>
   </ul>
 

--- a/assets/test/specs/fixtures/tabs-fixtures.html
+++ b/assets/test/specs/fixtures/tabs-fixtures.html
@@ -1,26 +1,26 @@
 
 <div data-tabs>
 
-  <ul>
-    <li>
-      <a href="#" data-tab-link="1">Tab Link 1</a>
+  <ul role="tablist">
+    <li id="tab1" data-tab-link="1" role="tab" aria-controls="tabContent1" tabindex="0">
+      <span class="tabs-nav__tab tabs-nav__tab--active">Tab Link 1</span>
     </li>
-    <li>
-      <span data-tab-link="2">Tab Link 2</span>
+    <li id="tab2" data-tab-link="2" role="tab" aria-controls="tabContent2" tabindex="0">
+      <a href="#" class="tabs-nav__tab">Tab Link 2</a>
     </li>
-    <li>
-      <a href="#" data-tab-link="3">Tab Link 3</a>
+    <li id="tab3" data-tab-link="3" role="tab" aria-controls="tabContent3" tabindex="0">
+      <a href="#" class="tabs-nav__tab">Tab Link 3</a>
     </li>
   </ul>
 
   <ul>
-    <li data-tab-content="1">
+    <li id="tabContent1" data-tab-content="1" class="tab-content" role="tabpanel" aria-labelledby="tab1">
       <p>Tab Content 1</p>
     </li>
-    <li data-tab-content="2">
+    <li id="tabContent2" data-tab-content="2" class="tab-content" role="tabpanel" aria-labelledby="tab2">
       <p>Tab Content 2</p>
     </li>
-    <li data-tab-content="3">
+    <li id="tabContent3" data-tab-content="3" class="tab-content" role="tabpanel" aria-labelledby="tab3">
       <p>Tab Content 3</p>
     </li>
   </ul>


### PR DESCRIPTION
# Tab Accessibility 

I've updated the Tabs JS module to ensure tabs are fully accessible via keyboard and screen readers. 
I've also moved the tabs SASS from navigation.scss into its own module, tabs.scss.

The tabs markup has been updated as shown below. The JS switches the states of the aria-selected attribute on the tab links, and the aria-hidden attribute on the tab panels.

## Usage

```html
    <div data-tabs>

      <ul role="tablist">
        <li id="tab1" data-tab-link="1" role="tab" aria-selected="true" aria-controls="tabContent1" tabindex="0">
          <span class="tabs-nav__tab tabs-nav__tab--active">Tab Link 1</span>
        </li>
        <li id="tab2" data-tab-link="2" role="tab" aria-selected="false" aria-controls="tabContent2" tabindex="0">
          <a href="#" class="tabs-nav__tab">Tab Link 2</a>
        </li>
        <li id="tab3" data-tab-link="3" role="tab" aria-selected="false" aria-controls="tabContent3" tabindex="0">
          <a href="#" class="tabs-nav__tab">Tab Link 3</a>
        </li>
      </ul>

      <ul>
        <li id="tabContent1" data-tab-content="1" class="tab-content" role="tabpanel" aria-labelledby="tab1">
          <p>Tab Content 1</p>
        </li>
        <li id="tabContent2" data-tab-content="2" class="tab-content" role="tabpanel" aria-labelledby="tab2">
          <p>Tab Content 2</p>
        </li>
        <li id="tabContent3" data-tab-content="3" class="tab-content" role="tabpanel" aria-labelledby="tab3">
          <p>Tab Content 3</p>
        </li>
      </ul>

    </div>
```



