### PR TITLE
[YTA-1427] Update tabs markup.

### DIFF
--- a/assets/scss/pages/_business-tax-home.scss
+++ b/assets/scss/pages/_business-tax-home.scss
@@ -60,7 +60,6 @@
   }
 
   article li {
-    padding-left: 0;
     @include media(mobile) {
       margin-left: 0;
     }


### PR DESCRIPTION
* Remove unneeded style for YTA specific scss file, which was causing the tab text to display too far to the left.