### PR TITLE
GG-490: remove float block-label

### DIFF
--- a/assets/scss/base/_form.scss
+++ b/assets/scss/base/_form.scss
@@ -324,9 +324,7 @@ label {
   cursor: pointer; // Encourage clicking on block labels
 
   @include media(tablet) {
-    float: left;
-    margin-top: 5px;
-    margin-bottom: 5px;
+    margin-bottom: em(10);
   }
 }
 


### PR DESCRIPTION
# Remove float 

This float was causing issues with element width.

- Remove float,
- Remove top margin that due to collapsing margins wasn't being used

#### Before
![screen shot 2016-01-20 at 15 29 19](https://cloud.githubusercontent.com/assets/2305016/12453466/3da49be6-bf8b-11e5-9f09-41a9854c1d6b.png)


#### After
![screen shot 2016-01-20 at 15 36 33](https://cloud.githubusercontent.com/assets/2305016/12453552/9e586990-bf8b-11e5-8248-7da6d1daf3c8.png)
