### PR TITLE
API-916 - Added support for style-agnostic tabs

### DIFF
--- a/assets/javascripts/modules/tabs.js
+++ b/assets/javascripts/modules/tabs.js
@@ -131,16 +131,20 @@ var removeElements = function($activeTab, $tabs) {
 
   $tabs.find('[data-tab-link]').each(function() {
 
-    var $tabLink = $(this),
-      $element = $tabLink.find('.tabs-nav__tab'),
-      attrs    = getAttributes($element),
-      tabText  = $element.text();
+    var $tabLI   = $(this),
+        $element = $tabLI.find('.tabs-nav__tab'),
+        attrs    = getAttributes($element),
+        tabText  = $element.text(),
+        listItemClasses = $tabLI.attr('class');  // save classes on LI that will be overwritten
 
-    if(attrs.class) {
-      $tabLink.addClass(attrs.class);    // put element classes on LI
-    }
+    // set attributes on LI from child element
+    $tabLI.attr(attrs);
 
-    $tabLink.html(tabText);
+    // restore LI classes from before
+    $tabLI.addClass(listItemClasses);
+
+    // text of LI is just tab link text
+    $tabLI.html(tabText);
 
   });
 

--- a/assets/scss/base/_colours.scss
+++ b/assets/scss/base/_colours.scss
@@ -35,3 +35,5 @@ $light-grey: #bfc1c3;
 
 $govuk-blue-colour: #005ea5;
 
+// NOTE this is a grey from govuk_elements, which will be removed, so adding a version of it here
+$govuk-grey-3: #DEE0E2;

--- a/assets/scss/modules/_tabs.scss
+++ b/assets/scss/modules/_tabs.scss
@@ -18,21 +18,21 @@
     &:focus,
     &:hover,
     &:active {
-      background-color: #DEE0E2;
+      background-color: $govuk-grey-3;
     }
 
     &:visited {
-      color: #005ea5;
+      color: $govuk-blue-colour;
     }
 
     .count {
       background-color: $red;
       color: $white;
-      padding: 0 5px;
+      padding: 0 em(5);
     }
 
     @include media(tablet) {
-      height: 53px;
+      height: em(53);
       display: inline-block;
       margin: 0 em(3) 0 0;
       padding: 0.7em 0.8em;
@@ -51,14 +51,14 @@
     &:focus,
     &:hover,
     &:active {
-      background-color: #DEE0E2;
+      background-color: $govuk-grey-3;
     }
 
   }
 
   .tabs-nav__tab--active {
     z-index: 2;
-    color: #000;
+    color: black; // there is a variable for $black but it's in govuk_elements, which will be removed
     background-color: $white;
     transition: none;
 
@@ -69,7 +69,7 @@
     }
 
     @include media(tablet) {
-      height: 54px;
+      height: em(54);
       padding: 0.7em;
       border: 1px solid $border-colour;
       border-bottom: none;
@@ -108,13 +108,13 @@
 }
 
 .tabs-nav__tab {
-  color: #005ea5;
+  color: $govuk-blue-colour;
   text-decoration: underline;
   cursor: pointer;
 }
 
 .tabs-nav__tab--active {
-  color: #000;
+  color: black;
   text-decoration: none;
   cursor: default;
 }

--- a/assets/scss/modules/_tabs.scss
+++ b/assets/scss/modules/_tabs.scss
@@ -58,7 +58,7 @@
 
   .tabs-nav__tab--active {
     z-index: 2;
-    color: black; // there is a variable for $black but it's in govuk_elements, which will be removed
+    color: $black;
     background-color: $white;
     transition: none;
 
@@ -106,7 +106,7 @@
 }
 
 .tabs-nav__tab--active {
-  color: black;
+  color: $black;
   text-decoration: none;
   cursor: default;
 }

--- a/assets/scss/modules/_tabs.scss
+++ b/assets/scss/modules/_tabs.scss
@@ -97,14 +97,6 @@
 
   }
 
-  .tab-content {
-
-    .tab-content__first {
-      margin-top: em(30);
-    }
-
-  }
-
 }
 
 .tabs-nav__tab {
@@ -117,5 +109,13 @@
   color: black;
   text-decoration: none;
   cursor: default;
+}
+
+.tab-content {
+
+  .tab-content__first {
+    margin-top: em(30);
+  }
+
 }
 

--- a/assets/scss/modules/_tabs.scss
+++ b/assets/scss/modules/_tabs.scss
@@ -3,6 +3,80 @@
   overflow: hidden;
   position: relative;
 
+  .tabs-nav__tab {
+    margin-bottom: 0;
+    display: block;
+    padding: 0.5em;
+    white-space: nowrap;
+    outline: none;
+    z-index: 0;
+    box-sizing: border-box;
+    position: relative;
+    border-top: 1px solid $border-colour;
+    transition: background .25s ease-in-out;
+
+    &:focus,
+    &:hover,
+    &:active {
+      background-color: #DEE0E2;
+    }
+
+    &:visited {
+      color: #005ea5;
+    }
+
+    .count {
+      background-color: $red;
+      color: $white;
+      padding: 0 5px;
+    }
+
+    @include media(tablet) {
+      height: 53px;
+      display: inline-block;
+      margin: 0 em(3) 0 0;
+      padding: 0.7em 0.8em;
+      border-top: none;
+      border-bottom: 6px solid white;
+    }
+
+  }
+
+  li.tabs-nav__tab {
+    margin-bottom: 0;
+  }
+
+  a.tabs-nav__tab {
+
+    &:focus,
+    &:hover,
+    &:active {
+      background-color: #DEE0E2;
+    }
+
+  }
+
+  .tabs-nav__tab--active {
+    z-index: 2;
+    color: #000;
+    background-color: $white;
+    transition: none;
+
+    &:focus,
+    &:hover,
+    &:active {
+      background-color: $white;
+    }
+
+    @include media(tablet) {
+      height: 54px;
+      padding: 0.7em;
+      border: 1px solid $border-colour;
+      border-bottom: none;
+    }
+
+  }
+
   &:before {
     content: "";
     position: absolute;
@@ -13,101 +87,35 @@
     width: 100%;
   }
 
+  [data-tab-link] {
+    display: block;
+    margin-bottom: 0 !important;
+
+    @include media(tablet) {
+      display: inline-block;
+    }
+
+  }
+
+  .tab-content {
+
+    .tab-content__first {
+      margin-top: em(30);
+    }
+
+  }
+
 }
 
 .tabs-nav__tab {
-  margin-bottom: 0;
-  display: block;
-  padding: 0.5em;
-  text-decoration: underline;
-  white-space: nowrap;
-  outline: none;
-  cursor: pointer;
-  z-index: 0;
-  box-sizing: border-box;
-  position: relative;
-  border-top: 1px solid $border-colour;
   color: #005ea5;
-  transition: background .25s ease-in-out;
-
-  &:focus,
-  &:hover,
-  &:active {
-    background-color: #DEE0E2;
-  }
-
-  &:visited {
-    color: #005ea5;
-  }
-
-  .count {
-    background-color: $red;
-    color: $white;
-    padding: 0 5px;
-  }
-
-  @include media(tablet) {
-    height: 53px;
-    display: inline-block;
-    margin: 0 em(3) 0 0;
-    padding: 0.7em 0.8em;
-    border-top: none;
-    border-bottom: 6px solid white;
-  }
-
-}
-
-li.tabs-nav__tab {
-  margin-bottom: 0;
-}
-
-a.tabs-nav__tab {
-
-  &:focus,
-  &:hover,
-  &:active {
-    background-color: #DEE0E2;
-  }
-
+  text-decoration: underline;
+  cursor: pointer;
 }
 
 .tabs-nav__tab--active {
-  cursor: default;
-  z-index: 2;
-  text-decoration: none;
   color: #000;
-  background-color: $white;
-  transition: none;
-
-  &:focus,
-  &:hover,
-  &:active {
-    background-color: $white;
-  }
-
-  @include media(tablet) {
-    height: 54px;
-    padding: 0.7em;
-    border: 1px solid $border-colour;
-    border-bottom: none;
-  }
-
+  text-decoration: none;
+  cursor: default;
 }
 
-.tab-content {
-
-  .tab-content__first {
-    margin-top: em(30);
-  }
-
-}
-
-[data-tab-link] {
-  display: block;
-  margin-bottom: 0 !important;
-
-  @include media(tablet) {
-    display: inline-block;
-  }
-
-}


### PR DESCRIPTION
There are situations where the tabs may want to be used with minimal styling. For example, like this:

![screen shot 2016-01-25 at 9 25 08 am](https://cloud.githubusercontent.com/assets/1764083/12547031/b0d9eea0-c345-11e5-86c2-07dfa426d603.png)
