### PR TITLE
[API-684] Removed hard-coded 100% width from grid-column-table mixin

### DIFF
--- a/assets/govuk_frontend_toolkit/stylesheets/_grid_layout.scss
+++ b/assets/govuk_frontend_toolkit/stylesheets/_grid_layout.scss
@@ -150,6 +150,5 @@ $site-width: 960px;
   }
   vertical-align: top;
   display: table-cell;
-  width: 100%;
   @include box-sizing(border-box);
 }

--- a/assets/scss/base/_grid.scss
+++ b/assets/scss/base/_grid.scss
@@ -44,3 +44,6 @@ Usage:
 .grid-layout__column--3-4 {
   @include grid-column-table(3/4); 
 }
+
+
+


### PR DESCRIPTION
Removed 100% width from grid-column-table mixin as it was overriding the width for non-media query browsers such as IE8.

![screen shot 2016-01-27 at 12 16 49 pm](https://cloud.githubusercontent.com/assets/1764083/12613202/feab12e8-c4ef-11e5-9ec4-493902e240fe.png)

