### PR TITLE
GG-569: some markup relies on the error class

### DIFF
--- a/assets/scss/base/form/_errors.scss
+++ b/assets/scss/base/form/_errors.scss
@@ -66,6 +66,7 @@
   
 }
 
+.error,
 .form-field-group--error {
   @include error-box(3px);
   margin: 0 em(-16) em(8) em(-16);


### PR DESCRIPTION
So it turns out that there is some markup that relies on the `.error` class, this is to cover that.