### PR TITLE
[API-913] Added no-border modifier class to beta banner

### DIFF
--- a/assets/scss/modules/_phase-beta.scss
+++ b/assets/scss/modules/_phase-beta.scss
@@ -6,6 +6,10 @@
   @include phase-banner(beta);
 }
 
+.beta-banner--borderless {
+  border: none;
+}
+
 .header__menu {
   .beta {
     vertical-align: top;


### PR DESCRIPTION
There are cases where the BETA banner should not have its default bottom grey border. This PR adds a modifier class to remove borders from the banner. Here's what I made earlier:

![screen shot 2016-01-28 at 2 24 40 pm](https://cloud.githubusercontent.com/assets/1764083/12647056/47094042-c5cb-11e5-9551-6173a5084787.png)
