### PR TITLE
Flag for pattern validation

### DIFF
--- a/assets/javascripts/validation/customValidations.js
+++ b/assets/javascripts/validation/customValidations.js
@@ -30,7 +30,10 @@ module.exports = function () {
 
   // Use the pattern attribute on your input with a valid regex
   jQuery.validator.addMethod('pattern', function (value, element, pattern) {
-    var regex = new RegExp(pattern);
+    var dataAttributeFlag = element.getAttribute('data-pattern-flags');
+    var flag = dataAttributeFlag || '';
+    var regex = new RegExp(pattern, flag);
+
     return regex.test(value);
   });
   


### PR DESCRIPTION
# Regex flag for pattern validation

Add the ability to send in a flag for pattern validation via a data attribute

#### Usage
You can send in a flag for your regex via the `data-pattern-flags` on the input that has a `pattern` attribute

```html
<input type="password"
       name="password"
       id="password"
       class="form-control--block input--medium"
       aria-required="true"
       required
       pattern="^((?!password1).){8,12}$"
       data-pattern-flags="i"
       data-msg-pattern="Your password is not strong enough. Make sure it follows the rules above."
       data-msg-required="Create your password"/>

```