### PR TITLE
[API-758] Added fixed width modifier on truncate helper

### DIFF
--- a/assets/scss/base/_helpers.scss
+++ b/assets/scss/base/_helpers.scss
@@ -84,12 +84,13 @@
 .hard--ends     { padding-top:   0!important; padding-bottom:0!important; }
 .hard--sides    { padding-right: 0!important; padding-left:  0!important; }
 
-
+.align--middle { vertical-align: middle !important; }
 .align--top { vertical-align: top !important; }
 
 .inline-block {
     display: inline-block !important;
 }
+
 .display-block {
   display: block !important;
 }
@@ -224,3 +225,8 @@
   }
 
 }
+
+.truncate--max-width-small {
+  max-width: 125px;
+}
+


### PR DESCRIPTION
A fixed width modifier was necessary to truncate text that sits within a width sensitive container, e.g. the header nav links. I called the modifier "fixed-small" as this could be the smaller of a variety of sizes. However, I can change this to just "fixed" if needs be? Providing a pixel width was done on purpose as the goal here isn't to provide a width relative to the font size, but rather a fixed pixel width.

![screen shot 2016-02-01 at 11 49 09 am](https://cloud.githubusercontent.com/assets/1764083/12716712/6b616af2-c8da-11e5-87bc-6f50a9df1828.png)
