### PR TITLE
GG-492: Add matching two inputs form hint helper module.

### DIFF
--- a/assets/javascripts/modules/formHintHelper.js
+++ b/assets/javascripts/modules/formHintHelper.js
@@ -1,37 +1,44 @@
 require('jquery');
 
 /*
-Form Hint Helper is a visual aid to guide users on requirements for inputs it allows rules with a regex and flags to be
-associated with an input. When the input matches the specified regex the rule will display a tick, otherwise it will
-display as a list element with a list bullet.
-- apply the .js-form-hint-helper to your input
-- associate the rules with the input via the data attribute data-hint-rules="js-hint-example-rule"
-- define the rules on your rule elements associated with your input via the data attribute data-hint-rule="^\w{8,12}$"
-- use the relevant markup and classes
+ Form Hint Helper is a visual aid to guide users on requirements for inputs it allows rules with a regex and flags to be
+ associated with an input, and to confirm that the values of two fields match, e.g. passwords.
+ When the input matches the specified regex, or the two fields match, the rule will display a tick, otherwise it will
+ display as a list element with a list bullet.
+ - apply the .js-form-hint-helper to your input for regex matches.
+ - associate the rules with the input via the data attribute data-hint-rules="js-hint-example-rule"
+ - define the rules on your rule elements associated with your input via the data attribute data-hint-rule="^\w{8,12}$"
+ - define which input fields must be equal with the data-hint-confirm data attribute, e.g. data-hint-confirm="password,password-confirm".
+ - use the relevant markup and classes
 
-Password input markup example:
+ Password input markup example:
 
  <input type="password" name="password" id="password" class="js-form-hint-helper" data-hint-rules="js-hint-example-rule"/>
 
-Form Hint Helper markup example:
+ <input type="password" name="passwordConfirm" id="password-confirm" data-hint-confirm-rule="js-confirm-example-rule"/>
+
+ Form Hint Helper markup example:
 
  <p class="form-hint">Your input must:</p>
  <ul class="form-hint-list">
-  <li class="form-hint-list-item js-hint-example-rule"
-      id="password-hint-rule-one"
-      data-hint-rule="^\w{8,12}$"
-      data-hint-rule-flag="i">
-    <span class="form-hint-list-item__indicator"></span>be between 8 and 12 characters
-  </li>
-  <li class="form-hint-list-item js-hint-example-rule"
-      id="password-hint-rule-four"
-      data-hint-rule="^((?!password)[\S])+$"
-      data-hint-rule-flag="i">
-    <span class="form-hint-list-item__indicator"></span>should not contain the word 'password'
-  </li>
+   <li class="form-hint-list-item js-hint-example-rule"
+       data-hint-rule="^\w{8,12}$"
+       data-hint-rule-flag="i">
+          <span class="form-hint-list-item__indicator">be between 8 and 12 characters</span>
+   </li>
+   <li class="form-hint-list-item js-hint-example-rule"
+       data-hint-rule="^((?!password)[\S])+$"
+       data-hint-rule-flag="i">
+          <span class="form-hint-list-item__indicator">should not contain the word 'password'</span>
+   </li>
+   <li class="form-hint-list-item js-confirm-example-rule"
+       data-hint-confirm="password,password-confirm">
+          <span class="form-hint-list-item__indicator">match the password confirmation</span>
+   </li>
  </ul>
  */
-var $formHintHelperInputs;
+var validClass;
+var matchInputsAttr;
 
 var buildRules = function ($ruleElements) {
   var rules = [];
@@ -58,6 +65,14 @@ var buildRules = function ($ruleElements) {
   return rules;
 };
 
+var setValidClass = function (isValid, $element) {
+  if (isValid) {
+    $element.addClass(validClass);
+  } else {
+    $element.removeClass(validClass);
+  }
+};
+
 var $formHintHelperEvent = function ($formHintHelperInput) {
   var $ruleElements = $('.' + $formHintHelperInput.attr('data-hint-rules'));
   var rules = buildRules($ruleElements);
@@ -65,32 +80,50 @@ var $formHintHelperEvent = function ($formHintHelperInput) {
   $formHintHelperInput.on('keyup', function () {
     var inputValue = $formHintHelperInput.val();
 
-    for(var value in rules) {
+    for (var value in rules) {
       var rule = rules[value];
-
-      if (rule.pattern.test(inputValue)) {
-        rule.$elem.addClass('form-hint-list-item--valid');
-      } else {
-        rule.$elem.removeClass('form-hint-list-item--valid');
-      }
+      setValidClass(rule.pattern.test(inputValue), rule.$elem);
     }
   });
 };
 
+var valuesEqualAndNotEmpty = function($inputA, $inputB) {
+  return $inputA.val() && $inputB.val() && $inputA.val() === $inputB.val();
+};
+
+var $formHintHelperConfirmEvent = function ($ruleElement) {
+  var inputsToCompare = $ruleElement.attr(matchInputsAttr).split(',');
+  if (inputsToCompare.length === 2) {
+    var $inputA = $('#' + inputsToCompare[0]);
+    var $inputB = $('#' + inputsToCompare[1]);
+
+    if ($inputA && $inputB) {
+      $inputA.on('keyup', function () {
+        setValidClass(valuesEqualAndNotEmpty($inputA, $inputB), $ruleElement);
+      });
+      $inputB.on('keyup', function () {
+        setValidClass(valuesEqualAndNotEmpty($inputA, $inputB), $ruleElement);
+      });
+    }
+  }
+};
+
 var addListeners = function () {
-  $formHintHelperInputs.each(function (index, formHintHelperInput) {
+  $('.js-form-hint-helper').each(function (index, formHintHelperInput) {
     $formHintHelperEvent($(formHintHelperInput));
+  });
+
+  $('['+matchInputsAttr+']').each(function (index, confirmRuleElement) {
+    $formHintHelperConfirmEvent($(confirmRuleElement));
   });
 };
 
-var setup = function () {
-  $formHintHelperInputs = $('.js-form-hint-helper');
+var setup = function() {
+  validClass = 'form-hint-list-item--valid';
+  matchInputsAttr = 'data-hint-confirm-inputs';
 };
 
 module.exports = function () {
   setup();
-
-  if ($formHintHelperInputs.length) {
-    addListeners();
-  }
+  addListeners();
 };

--- a/assets/test/specs/fixtures/form-hint-helper-fixture.html
+++ b/assets/test/specs/fixtures/form-hint-helper-fixture.html
@@ -1,3 +1,4 @@
+<!-- example one -->
 <ul>
   <li class="js-hint-example-rule" id="example-hint-rule-one" data-hint-rule="^\w{8,12}$" data-hint-rule-flag="i">
     be between 8 and 12 characters
@@ -17,8 +18,7 @@
        name="example"
        id="example"
        class="js-form-hint-helper"
-       data-hint-rules="js-hint-example-rule">
-</div>
+       data-hint-rules="js-hint-example-rule"/>
 
 <!-- example two -->
 <ul>
@@ -31,5 +31,27 @@
        name="example-two"
        id="example-two"
        class="js-form-hint-helper"
-       data-hint-rules="js-hint-example-two-rule">
-</div>
+       data-hint-rules="js-hint-example-two-rule"/>
+
+
+<!-- example three -->
+<ul>
+  <li class="js-hint-example-three-rule-one" id="example-three-hint-rule-one" data-hint-rule="[A-Za-z]+">
+    contain at least one letter (a-z)
+  </li>
+  <li class="js-confirm-example-rule" id="example-three-hint-rule-two" data-hint-confirm-inputs="example-three,example-three-confirm">
+    Passwords must match
+  </li>
+</ul>
+
+<input type="text"
+       name="example-three"
+       id="example-three"
+       class="js-form-hint-helper"
+       data-hint-rules="js-hint-example-three-rule-one"/>
+
+<input type="password"
+       name="example-three-confirm"
+       id="example-three-confirm"
+       class="js-form-hint-helper-confirm"/>
+

--- a/assets/test/specs/formHintHelper.spec.js
+++ b/assets/test/specs/formHintHelper.spec.js
@@ -6,8 +6,13 @@ var $exampleOneRuleTwoElem;
 var $exampleOneRuleThreeElem;
 var $exampleOneRuleFourElem;
 var $exampleTwoRuleOneElem;
+var $exampleThreeRuleOneElem;
+var $exampleThreeRuleTwoElem;
 var $exampleOneInputElem;
 var $exampleTwoInputElem;
+var $exampleThreeInputOneElem;
+var $exampleThreeInputTwoElem;
+
 var assertRulesAreNotValid = function (rules) {
   rules.map(function ($elem) {
     expect($elem).not.toHaveClass('form-hint-list-item--valid');
@@ -23,6 +28,10 @@ var setup = function () {
   $exampleTwoRuleOneElem = $('#example-two-hint-rule-one');
   $exampleOneInputElem = $('#example');
   $exampleTwoInputElem = $('#example-two');
+  $exampleThreeInputOneElem = $('#example-three');
+  $exampleThreeInputTwoElem = $('#example-three-confirm');
+  $exampleThreeRuleOneElem = $('#example-three-hint-rule-one');
+  $exampleThreeRuleTwoElem = $('#example-three-hint-rule-two');
 };
 
 describe('Form Hint Helper', function () {
@@ -123,5 +132,68 @@ describe('Form Hint Helper', function () {
         $exampleOneRuleFourElem,
       ]);
     });
+  });
+
+  describe('matching field verification', function() {
+
+    it('should not be ticked when both inputs are empty', function(){
+
+      expect($exampleThreeRuleTwoElem).not.toHaveClass('form-hint-list-item--valid');
+
+    });
+
+    it('should not be ticked when both inputs are different', function(){
+
+      $exampleThreeInputOneElem.val('starwars');
+      $exampleThreeInputTwoElem.val('iloveyou').trigger('keyup');
+
+      expect($exampleThreeRuleTwoElem).not.toHaveClass('form-hint-list-item--valid');
+
+    });
+
+    it('should be ticked when both inputs are non-empty and the same', function(){
+
+      $exampleThreeInputOneElem.val('starwars');
+      $exampleThreeInputTwoElem.val('starwars').trigger('keyup');
+
+      expect($exampleThreeRuleTwoElem).toHaveClass('form-hint-list-item--valid');
+
+    });
+
+    it('should be ticked when both inputs are non-empty and the same, entered in either order', function(){
+
+      $exampleThreeInputTwoElem.val('starwars');
+      $exampleThreeInputOneElem.val('starwars').trigger('keyup');
+
+      expect($exampleThreeRuleTwoElem).toHaveClass('form-hint-list-item--valid');
+
+    });
+
+    it('should not be ticked when both inputs are empty', function(){
+
+      $exampleThreeInputTwoElem.val('');
+      $exampleThreeInputOneElem.val('').trigger('keyup');
+
+      expect($exampleThreeRuleTwoElem).not.toHaveClass('form-hint-list-item--valid');
+
+    });
+
+    it('should not interfere with a regex rule on one input field', function(){
+
+      $exampleThreeInputOneElem.val('123').trigger('keyup');
+      $exampleThreeInputTwoElem.val('123').trigger('keyup');
+
+      expect($exampleThreeRuleOneElem).not.toHaveClass('form-hint-list-item--valid');
+      expect($exampleThreeRuleTwoElem).toHaveClass('form-hint-list-item--valid');
+
+      $exampleThreeInputOneElem.val('abc').trigger('keyup');
+      $exampleThreeInputTwoElem.val('123').trigger('keyup');
+
+      expect($exampleThreeRuleOneElem).toHaveClass('form-hint-list-item--valid');
+      expect($exampleThreeRuleTwoElem).not.toHaveClass('form-hint-list-item--valid');
+
+    });
+
+
   });
 });


### PR DESCRIPTION
The form hint helper module needs password confirmation functionality.

A hint label can name two input fields by ID.
If both are non-empty and have the same content, the hint will show the form-hint-list-item--valid class.
If both are empty, the hint will stay invalid.

<img width="489" alt="screenshot 2016-02-02 14 48 18" src="https://cloud.githubusercontent.com/assets/11385498/12752950/ae30d8da-c9bc-11e5-9472-c89e3ccb455d.png">
