### PR TITLE
Updates to accordion module + tests

### DIFF
--- a/assets/test/specs/accordion.spec.js
+++ b/assets/test/specs/accordion.spec.js
@@ -2,7 +2,8 @@ require('jquery');
 
 describe("Given I have an accordion module on the page", function() {
 
-  var accordion;
+  var accordion,
+      $acc1, $acc2, $acc3;
 
   beforeEach(function() {
 
@@ -11,58 +12,83 @@ describe("Given I have an accordion module on the page", function() {
 
     accordion = require('../../javascripts/modules/accordion.js');
 
+    $acc1 = $('#accordion1');
+    $acc2 = $('#accordion2');
+    $acc3 = $('#accordion3');
+
   });
 
   describe("When I load the page", function() {
 
-    beforeEach(function() {  
+    beforeEach(function() {
       accordion(); // init accordion module
     });
 
-    it("Then the accordion #1 is collapsed", function() {          
-      expect($('#accordion1 [data-accordion-body]').height()).toBe(0);
+    it("Then the accordion #1 is collapsed", function() {
+      expect($acc1.find('[data-accordion-body]').height()).toBe(0);
     });
 
-    it("Then any content flagged to be revealed is hidden", function() {      
-      expect($('#accordion1 [data-accordion-reveal]')).toHaveClass('hidden');
+    it("Then any content flagged to be revealed is hidden", function() {
+      expect($acc1.find('[data-accordion-reveal]')).toHaveClass('hidden');
     });
 
   });
 
-  describe("When I click on Accordion #1 title", function() {
+  describe("When I click on Accordion #1", function() {
 
     beforeEach(function() {
       accordion(); // init accordion module
-      $('#accordion1 [data-accordion-button]').click();
+      $acc1.find('[data-accordion-button]').click();
     });
 
-    it("Then the accordion is expanded", function() {      
-      expect($('#accordion1 [data-accordion-body]').height() > 0).toBe(true);
-    });
-
-    it("Then any content flagged to be revealed is shown", function() {      
-      expect($('#accordion1 [data-accordion-reveal]')).not.toHaveClass('hidden');
+    it("Then the accordion is expanded and content to be revealed is shown", function() {
+      expect($acc1.find('[data-accordion-body]').height() > 0).toBe(true);
+      expect($acc1.find('[data-accordion-reveal]')).not.toHaveClass('hidden');
     });
 
   });
 
   describe("When Accordion #2 loads", function() {
 
-    beforeEach(function() {  
+    beforeEach(function() {
       accordion(); // init accordion module
     });
 
-    it("Then the accordion is expanded by default", function() {      
-      expect($('#accordion2 [data-accordion-body]').height() > 0).toBe(true);
+    it("Then the accordion is expanded by default", function() {
+      expect($acc2.find('[data-accordion-body]').height() > 0).toBe(true);
     });
 
-    it("Then any content flagged to be revealed is shown", function() {      
-      expect($('#accordion2 [data-accordion-reveal]')).not.toHaveClass('hidden');
+    it("Then any content flagged to be revealed is shown", function() {
+      expect($acc2.find('[data-accordion-reveal]')).not.toHaveClass('hidden');
     });
 
-    it("Then clicking the accordion title collapses the accordion", function() {      
-      $('#accordion2 [data-accordion-button]').click();
-      expect($('#accordion2 [data-accordion-body]').height()).toBe(0);
+    it("Then clicking the accordion title collapses the accordion", function() {
+      $acc2.find('[data-accordion-button]').click();
+      expect($acc2.find('[data-accordion-body]').height()).toBe(0);
+    });
+
+  });
+
+  describe("When Accordion #3 loads", function() {
+
+    beforeEach(function() {
+      window.history.replaceState(null, null, '#accordion3');
+      accordion(); // init accordion module
+    });
+
+    it("Then accordion 3 is expanded because of URL hash", function() {
+      expect($acc3.find('[data-accordion-body]').height() > 0).toBe(true);
+    });
+
+    it("Then clicking accordion 1 updates the URL hash to accordion 1's ID", function() {
+      $acc1.find('[data-accordion-button]').click();
+      expect($acc1.find('[data-accordion-body]').height() > 0).toBe(true);
+      expect(window.location.hash).toBe('#accordion1');
+    });
+
+    it("Then clicking accordion 2 does not affect the URL (accordion not configured to do so)", function() {
+      $acc2.find('[data-accordion-button]').click();
+      expect(window.location.hash).toBe('#accordion3');
     });
 
   });

--- a/assets/test/specs/fixtures/accordion-fixtures.html
+++ b/assets/test/specs/fixtures/accordion-fixtures.html
@@ -1,13 +1,13 @@
 
 <ul>
 
-  <li id="accordion1" class="accordion" data-accordion>
+  <li id="accordion1" class="accordion" data-accordion data-accordion-set-hash>
 
     <div class="accordion__row">     
       <i class="arrow arrow--right" data-accordion-arrow></i>
       <a href="#" data-accordion-button>Accordion #1 Title</a>
       <div data-accordion-reveal>
-        <p>Content to reveal on expand</p>
+        <p>Content to reveal on expand - accordion #1</p>
       </div>
     </div>
 
@@ -19,16 +19,32 @@
 
   <li id="accordion2" class="accordion" data-accordion data-accordion-expanded>
 
-    <div class="accordion__row">     
+    <div class="accordion__row">
       <i class="arrow arrow--right" data-accordion-arrow></i>
       <a href="#" data-accordion-button>Accordion #2 Title</a>
       <div data-accordion-reveal>
-        <p>Content to reveal on expand</p>
+        <p>Content to reveal on expand - accordion #2</p>
       </div>
     </div>
 
-    <div class="accordion__body hidden" data-accordion-body>                        
+    <div class="accordion__body hidden" data-accordion-body>
       <p>Accordion #2 Body</p>
+    </div>
+
+  </li>
+
+  <li id="accordion3" class="accordion" data-accordion data-accordion-set-hash>
+
+    <div class="accordion__row">
+      <i class="arrow arrow--right" data-accordion-arrow></i>
+      <a href="#" data-accordion-button>Accordion #3 Title</a>
+      <div data-accordion-reveal>
+        <p>Content to reveal on expand - accordion #3</p>
+      </div>
+    </div>
+
+    <div class="accordion__body hidden" data-accordion-body>
+      <p>Accordion #3 Body</p>
     </div>
 
   </li>


### PR DESCRIPTION
## Changes:

* On expand of an accordion, the URL hash is updated with the accordion's ID, if the accordion is configured to do so with the `data-accordion-set-hash` attribute.
* On page load, if the URL hash matches an accordion's ID, that accordion will be expanded.
* Improved jQuery selector usage in jasmine tests.
* Added a new suite of tests to cover this new functionality.

![s6o5tk0qrr](https://cloud.githubusercontent.com/assets/1764083/12754896/05266792-c9c5-11e5-85fa-2579f6656a02.gif)

## Updated Usage:

```
<div id="accordion1" class="accordion" data-accordion data-accordion-expanded data-accordion-set-hash>
 
  <div class="accordion__row">     
    <i class="arrow arrow--right" data-accordion-arrow></i>
    <a href="#" data-accordion-button>Accordion Title</a>  
    <div data-accordion-reveal>
      <p>Optionally reveal content on expand that is not part of the body</p>
    </div>
  </div>
 
  <div class="accordion__body hidden" data-accordion-body>                        
    <p>Accordion Body</p>
  </div>
 
</div>
 ```

### NOTES:
  
- Mandatory attributes:
    - `id`:                                       unique identifier used for anchoring to accordion based on URL hash
    - `data-accordion`:                  main hook into accordion, placed on outer-most container
    - `data-accordion-button`:       expand/collapse event will be bound to this element
    - `data-accordion-body`:         element contains content that will be expanded/collapsed
- Optional attributes:
    - `data-accordion-arrow`:         arrow icon element which will be animated on state change
    - `data-accordion-reveal`:        any sections outside of the body that should be revealed on expand
    - `data-accordion-expanded`:  hard-code to expand on init, useful for server-side rendering
    - `data-accordion-set-hash`:    will cause URL hash to be updated accordion ID upon expand
- Mandatory classes:                  `accordion`, `accordion__body`, `hidden`
- Optional classes:                     `arrow`, `arrow--right`
- Column classes:                      there are additional classes in `_accordion.scss` for accordions whose 
                                                   layout demands left and right columns both at the button level and 
                                                   within the body
