### PR TITLE
TAI-1139 added table--blue-header

### DIFF
--- a/assets/scss/base/_form.scss
+++ b/assets/scss/base/_form.scss
@@ -344,6 +344,14 @@ label {
   @include ie-lte(9){
     top: 38%;
   }
+
+  // to align radio button with top line of content, not centred
+  &.top-aligned-input {
+    top: em(31);
+    @include media(tablet) {
+      top: em(29);
+    }
+  }
 }
 
 // Use inline, to sit block labels next to each other

--- a/assets/scss/base/_table.scss
+++ b/assets/scss/base/_table.scss
@@ -104,6 +104,11 @@ table {
     font-weight: 400;
   }
 }
+
+.table--heavy-header {
+    border-bottom: em(2) solid $govuk-blue-colour;
+}
+
 .table--heavy-footer{
   border-bottom: 3px solid $grey-6;
 }


### PR DESCRIPTION
Added a variant for child of table element with a blue border.

![table--blue-header](https://cloud.githubusercontent.com/assets/10420657/12821483/824e8f6e-cb5b-11e5-8234-047fb3f7ed91.png)
