### PR TITLE
[AOSS-1135] Ajax submit and callback updates

### DIFF
--- a/assets/javascripts/modules/ajaxCallbacks.js
+++ b/assets/javascripts/modules/ajaxCallbacks.js
@@ -4,44 +4,51 @@
 require('jquery');
 
 var ajaxCallbacks = {
-  clientAccessResponse: {
+  emailFormResponse: {
     callbacks: {
-      beforeSend: function($element) {
-        $element.prop('disabled', true);
-      },
-
-      success: function(response, $element, data, helpers, container, type) {
-        $('input[name="payeref"]').val('');
-        helpers.insertResponseHtml(helpers, type, data, $(container + ' .form-field:has(>input[name][type="text"])').first(), response);
-      },
-
-      error: function(response, $element, data, helpers, container) {
-
-        // if session has timed out
-        if (response.status === 401 &&
-           response.responseJSON &&
-           response.responseJSON.redirectUri) {
-
-          // go to login page with specified redirect URI
-          document.location.href = response.responseJSON.redirectUri;
-        }
-        else {
-          helpers.insertResponseHtml(helpers, 'before', data, $(container + ' .form-field:has(>input[name][type="text"])'), response);
-        }
-
-      },
-
-      always: function(response, $element, data, helpers, container, type) {
-        if (helpers.hasErrorType !== 'service') {
-          helpers.resetForms(helpers, type, data, container);
-        }
+      success: function(response, $element, data, helpers) {
+        $('input[type="text"][type!="email"][name!="email"]').val('');
+        helpers.base.success.apply(null, arguments);
       }
     }
   },
   helpers: {
+    base: {
+      beforeSend: function($element, data, helpers, targets, container, type, actions) {
+        helpers.utilities.setFormState($element, true);
+      },
+
+      success: function(response, $element, data, helpers, targets, container, type, actions) {
+        helpers.insertResponseHtml(helpers, type, data, $(container + targets.success), response);
+      },
+
+      error: function(response, $element, data, helpers, targets, container, type, actions) {
+        if (helpers.utilities.hasSessionLapsed(response)) {
+          helpers.utilities.redirect(response);
+        }
+        else {
+          helpers.insertResponseHtml(helpers, type, data, $(container + targets.error), response);
+        }
+      },
+
+      always: function(response, $element, data, helpers, targets, container, type, actions) {
+        if (helpers.hasErrorType !== 'service') {
+          helpers.resetForms(helpers, type, data, container);
+        }
+
+        helpers.hasErrorType = undefined;
+      }
+    },
+
     hasErrorType: undefined,
 
     setDomHtml: function(type, $target, $node) {
+      if (!type.indexOf('prependTo') || !type.indexOf('appendTo') || !type.indexOf('insert')) {
+        var $swapNode = $target;
+        $target = $node;
+        $node = $swapNode;
+      }
+
       if ($.isFunction($.fn[type]) && !!$target && !!$node) {
         $.fn[type].apply($target, [$node]);
       }
@@ -54,47 +61,34 @@ var ajaxCallbacks = {
         nodeCount = htmlNodes.length || 0,
         i = 0,
         $node, $errorTarget,
-        isMissingClient = data.indexOf('missingclient=true') > -1,
         isError = !!response.status || response.status === 500;
 
       if (!$.isFunction($.fn[type])) {
         $target.empty();
         type  = 'append';
       }
-      
+
       helpers.resetErrorMessages($target.parent(), $target);
-      
+
       if (helpers.utilities.isFullPageError(helpers, htmlText)) {
         helpers.insertFullPageErrorHtml($target, helpers, htmlText);
       }
       else if (helpers.utilities.isServiceError(helpers, htmlNodes)) {
-        helpers.insertServiceErrorHtml(helpers, htmlText);
+        helpers.insertServiceErrorHtml($target.closest('form'), helpers, htmlText);
       }
       else { // handle 'validation error' or 'success' message & state
-
-        if (!isError) {
-          $target.addClass('js-hidden');
-        }
 
         for (; i < nodeCount; i++) {
           $node = $(htmlNodes[i]);
 
           if (isError) {
-            //helpers.hasErrorType = 'validation';
-            $errorTarget = $target.find('>input[name="' + $node.attr('data-input-for') +  '"]');
-            $errorTarget.addClass("error-field");
+            $errorTarget = $target.find('>input[name="' + $node.data('input-for') +  '"]');
+            $errorTarget.addClass('error-field');
             $errorTarget.closest('.form-field').addClass('form-field--error');
             $errorTarget.blur();
           }
 
-          helpers.setDomHtml(type, $errorTarget || $target, $node);
-        }
-
-        if (isMissingClient && !isError) {
-          helpers.bindEvents($target, data);
-        }
-        else {
-          $target.removeClass('js-hidden');
+          helpers.setDomHtml(type, !!$errorTarget && $errorTarget.length ? $errorTarget : $target, $node);
         }
       }
     },
@@ -105,34 +99,22 @@ var ajaxCallbacks = {
 
       helpers.resetErrorMessages($target.parent(), $target);
 
-      $button.parent('.form-field').addClass('error');
+      $button.parent('.form-field').addClass('form-field--error');
 
-      helpers.setDomHtml('insertBefore',
-        $('<div class="alert alert--failure" data-input-for="email" id="service--error">' +
-          '<span class="error-message">' + $heading.text() + '</span>' +
-        '</div>'),
-        $button);
+      helpers.setDomHtml('insertBefore', $button,
+        $('<div class="alert alert--borderless alert--failure soft--ends soft--sides" data-input-for="email" id="service--error">' +
+          '<span class="alert__message"><strong>' + $heading.text() + '</strong></span>' +
+        '</div>'));
     },
 
-    insertServiceErrorHtml: function(helpers, htmlText) {
-      var $missingClientForm = $('#missing-client-form'),
-          $clientAccessForms = $('.client-access-details');
-
-      // replace missing client form
-      $missingClientForm.empty();
-      helpers.setDomHtml('prepend', $missingClientForm, htmlText);
-
-      // insert into client access request forms & disable elements
-      $clientAccessForms.each(function(i, e) {
-        var $form = $(e);
-        $form.find('input, button[type=submit]').prop('disabled', true);
-        helpers.resetErrorMessages($form, $form.find('.form-field.error'));
-        helpers.setDomHtml('before', $form.find('.form-field:first'), htmlText);
-      });
+    insertServiceErrorHtml: function($form, helpers, htmlText) {
+      // replace form with Service Error message
+      $form.empty();
+      helpers.setDomHtml('prepend', $form, htmlText);
     },
 
     resetErrorMessages: function($target, $error) {
-      $target.find('.error').andSelf().removeClass('error');
+      $target.find('.form-field--error').andSelf().removeClass('form-field--error');
       $target.find('.form-field:has(*[data-id="service--error"]), .alert--success, .alert--failure').remove();
     },
 
@@ -159,23 +141,31 @@ var ajaxCallbacks = {
       return emailValue || decodeURIComponent(emailMatch).replace(reEmail, '$1') || '';
     },
 
-    bindEvents: function($container) {
-      $('#another-missing-client').one('click keydown', function(event) {
-        event.preventDefault();
-
-        var $this = $(event.target);
-
-        $this.parent().find('.error').removeClass('error');
-        $this.parent().find('.alert--success, .alert--failure').remove();
-        $this.parent().find('input[name="payeref"]').prop('value', null);
-
-        $this.remove();
-
-        $container.removeClass('js-hidden');
-      });
-    },
-
     utilities: {
+      hasSessionLapsed: function(response) {
+        // if session has timed out
+        return response.status && response.status === 401 && response.responseJSON && response.responseJSON.redirectUri;
+      },
+
+      redirect: function(response) {
+        // go to login page with specified redirect URI
+        if (response && response.responseJSON && response.responseJSON.redirectUri) {
+          document.location.href = response.responseJSON.redirectUri;
+        }
+      },
+
+      setFormState: function($element, isDisabled) {
+        if ($element.prop('tagName') === 'FORM') {
+          $element.find('input, button, textarea').each(function(index, formElement) {
+            $(formElement).prop('disabled', isDisabled);
+            $(formElement).attr('aria-disabled', isDisabled);
+          });
+        } else {
+          $element.prop('disabled', isDisabled);
+          $element.attr('aria-disabled', isDisabled);
+        }
+      },
+
       getElementInnerHtml: function(html, nodeName) {
         var re = new RegExp('^(.*)<' + nodeName + '[^>]*>(.+?)<\/' + nodeName + '>(.*)$', 'gi');
         return re.test(html) ? $($.parseHTML(html.replace(re, '$2'))) : '';

--- a/assets/javascripts/modules/ajaxCallbacks.js
+++ b/assets/javascripts/modules/ajaxCallbacks.js
@@ -12,6 +12,51 @@ var ajaxCallbacks = {
       }
     }
   },
+  dataTableSubmitResponse: {
+    callbacks: {
+      beforeSend: function($element, data, helpers) {
+        $('.js-datatable-submit').prop('disabled', true); // disable all data-table submit elements
+
+        helpers.base.beforeSend.apply(null, arguments);
+      },
+
+      success: function(response, $element, data, helpers, targets, container, type) {
+        var $container = $(container);
+
+        $container
+          .empty()
+          .closest('tbody').find('tr.status--confirm-success').each(function (index, element) {
+          $(element).removeClass('status--confirm-success');
+        });
+
+        $container.closest('tr').removeClass('status--unconfirmed').addClass('status--confirm-success confirmed');
+
+        helpers.base.success.apply(null, arguments);
+      },
+
+      error: function(response, $element, data, helpers, targets, container, type) {
+        $('button.js-datatable-submit').prop('disabled', false);
+
+        if (response.status === 500) { // a service-error, disable all submit buttons
+          $element.find('button.js-datatable-submit').each(function (index, element) {
+            $(element).prop('disabled', true);
+          });
+        }
+
+        $(container).closest('tr').addClass('form--field--error');
+
+        helpers.base.error.apply(null, arguments);
+      },
+
+      always: function(response, $element, data, helpers) {
+        if (response.status !== 500) { // not a service-error
+          $('.js-datatable-submit').prop('disabled', false);  // re-enable all data-table submit elements
+        }
+
+        helpers.base.always.apply(null, arguments);
+      }
+    }
+  },
   helpers: {
     base: {
       beforeSend: function($element, data, helpers, targets, container, type, actions) {

--- a/assets/test/specs/ajaxCallbacks.spec.js
+++ b/assets/test/specs/ajaxCallbacks.spec.js
@@ -396,6 +396,118 @@ describe('AjaxCallbacks', function() {
         });
 
       });
+      
+      describe('.hasSessionLapsed', function() {
+        var response = { 'status': 401, 'responseJSON': { 'redirectUri': '#' } };
+        it('returns true if status in specified in valid response object is 401 ("Unauthorized")', function() {
+          helpers.utilities.redirect(response);
+          expect(/#$/.test(window.location.href)).toBe(true);
+        });
+        
+        it('returns false if status is not 401', function() {
+          response.status = 200;
+          helpers.utilities.redirect(response);
+          expect(window.location.href).toBe(window.location.href);
+        });
+
+        it('returns false if response object is invalid', function() {
+          var currentUri = window.location.href;
+          
+          response.status = undefined;
+          helpers.utilities.redirect(response);
+          expect(window.location.href).toBe(currentUri);
+
+          response.status = 401;
+
+          response.responseJSON.redirectUri = undefined;
+          helpers.utilities.redirect(response);
+          expect(window.location.href).toBe(currentUri);
+
+          response.responseJSON = {};
+          helpers.utilities.redirect(response);
+          expect(window.location.href).toBe(currentUri);
+
+          response = {};
+          helpers.utilities.redirect(response);
+          expect(window.location.href).toBe(currentUri);
+
+          helpers.utilities.redirect(undefined);
+          expect(window.location.href).toBe(currentUri);
+        });
+      });
+      
+      describe('.redirect', function() {
+        var response = { 'responseJSON': { 'redirectUri': '#' } };  
+
+        it('loads page at ".responseJSON.redirectUri" specified in valid response object', function() {
+          helpers.utilities.redirect(response);
+          expect(/#$/.test(window.location.href)).toBe(true);
+        });
+
+        it('ignores invalid response object', function() {
+          var currentUri = window.location.href;
+
+          response.responseJSON.redirectUri = undefined;
+          helpers.utilities.redirect(response);
+          expect(window.location.href).toBe(currentUri);
+
+          response.responseJSON = {};
+          helpers.utilities.redirect(response);
+          expect(window.location.href).toBe(currentUri);
+
+          response = {};
+          helpers.utilities.redirect(response);
+          expect(window.location.href).toBe(currentUri);
+
+          helpers.utilities.redirect(undefined);
+          expect(window.location.href).toBe(currentUri);
+        });
+      });
+      
+      describe('.setFormState', function() {
+        var $form = $('<form style="visibility:hidden">' +
+          '<input name="value1" value="something 1"/>' +
+          '<input name="email" type="email" value="test@test.com"/>' +
+          '<textarea>test</textarea>' +
+          '<input name="value2" value="something 2"/><button type="submit" class="button" value="go" />' +
+          '</form>'),
+          $button = $('<button type="submit" class="button" value="go" />');
+
+        it('disables form fields', function() {
+          helpers.utilities.setFormState($form, true);
+          
+          $form.find('input, textarea, button').each(function(idx, element) {
+            expect($(element).prop('disabled')).toBe(true);
+            expect($(element).attr('aria-disabled')).toBe('true');
+          });
+        });
+          
+        it('enables disabled form fields', function() {
+          helpers.utilities.setFormState($form, true);
+          helpers.utilities.setFormState($form, false);
+
+          $form.find('input , button').each(function(idx, element) {
+            expect($(element).prop('disabled')).toBe(false);
+            expect($(element).attr('aria-disabled')).toBe('false');
+          });
+        });
+        
+        it('disables form button', function() {
+
+          helpers.utilities.setFormState($button, false);
+
+          expect($button.prop('disabled')).toBe(false);
+          expect($button.attr('aria-disabled')).toBe('false');
+        });
+
+        it('enables disabled form button', function() {
+          helpers.utilities.setFormState($button, false);
+          helpers.utilities.setFormState($button, true);
+          
+          expect($button.prop('disabled')).toBe(true);
+          expect($button.attr('aria-disabled')).toBe('true');
+        });
+      });      
     });
   });
 });

--- a/assets/test/specs/ajaxFormSubmit.spec.js
+++ b/assets/test/specs/ajaxFormSubmit.spec.js
@@ -69,7 +69,7 @@ describe('AjaxFormSubmit', function() {
         expect(new RegExp("#" + $fp.attr('id'),"i").test($button.attr('data-container'))).toBe(true);
 
         expect($button.attr('data-callback-name').length).toBeTruthy();
-        expect($button.attr('data-callback-name')).toBe('clientAccessResponse.callbacks');
+        expect($button.attr('data-callback-name')).toBe('emailFormResponse.callbacks');
 
         expect($button.attr('data-callback-args').length).toBeTruthy();
 

--- a/assets/test/specs/fixtures/ajax-form-client-access-request.html
+++ b/assets/test/specs/fixtures/ajax-form-client-access-request.html
@@ -17,7 +17,7 @@
                         formaction="#client-access-request" data-ajax-submit="true"
                         data-formaction="#client-access-request-xhr" 
                         data-container="#client_000Z000_notes"
-                        data-callback-name="clientAccessResponse.callbacks"
+                        data-callback-name="emailFormResponse.callbacks"
                         data-callback-args="#client_000Z000_notes,insert">
                     Send
                 </button>
@@ -43,7 +43,7 @@
                         formaction="#client-access-request" data-ajax-submit="true"
                         data-formaction="#client-access-request-xhr"
                         data-container="#client_111Z111_notes"
-                        data-callback-name="clientAccessResponse.callbacks"
+                        data-callback-name="emailFormResponse.callbacks"
                         data-callback-args="#client_111Z111_notes,insert">
                     Send
                 </button>
@@ -78,7 +78,7 @@
                     data-ajax-submit="true" 
                     data-container="#missing-client-form" 
                     data-journey-click="missing-client:Click:Ask for access for missing 64-8 clients (form submit)" 
-                    data-callback-name="clientAccessResponse.callbacks" 
+                    data-callback-name="emailFormResponse.callbacks" 
                     data-callback-args="#missing-client-form,before">
             </div>
         </form>


### PR DESCRIPTION
[AOSS-1135] Ajax submit and callback updates

- ajaxFormSubmit.js
  - replace .attr('data-...') references to .data('...')
  - add 'data-target-success' add 'data-target-error' attributes
    -  selector of elements found within the element specified in data-container and are used by the relative  callbacks
  - add reference to [ajaxCallbacks.helpers.]base object, defined in ajaxCallbacks.js

 ajaxCallbacks.js
  - add "dataTableSubmitResponse" callback
  - rename clientAccessResponse callback to 'emailFormResponse'
     - update success callback to reset form values to empty on elements which aren't "email" type (not just explicit for  name=payeref)
  - refactor clientAccessResponse callback to use [ajaxCallbacks.helpers.]base objects for common code

  - update .helpers:
     - general:
        - change .error class references to use .form-field--error
     - update 'setDomHtml':
        - swap target and node order for prependTo, appendTo and insertXxx methods
     - update 'insertResponseHtml' :
        - remove redundant references to missing client form
     - update 'insertFullPageErrorHtml' :
        - full page error response markup
     - update 'insertServiceErrorHtml'
        - remove redundant references to client access form
     - remove redundant 'bindEvents' helper

  - update .helpers.utilities
     - add 'hasSessionLapsed' to encapsulate common code for session time-out state
     - add 'showLogin' to encapsulate common code for redirection to login page
     - add 'setFormState' to disable/enable element(s) of all form(s) or button object
     - add tests for above .helpers.utilities additions

![aoss-1135 missing client request access](https://cloud.githubusercontent.com/assets/5468091/12886948/fcd3dedc-ce68-11e5-9167-49c47c306ee5.gif)
