### PR TITLE
TAI-1139 added table--heavy-header

### DIFF
--- a/assets/scss/base/_table.scss
+++ b/assets/scss/base/_table.scss
@@ -104,6 +104,11 @@ table {
     font-weight: 400;
   }
 }
+
+.table__header--highlight {
+    border-bottom: em(2) solid $govuk-blue-colour;
+}
+
 .table--heavy-footer{
   border-bottom: 3px solid $grey-6;
 }


### PR DESCRIPTION
Added a variant for child of table element with a blue border.
![table--heavy-header](https://cloud.githubusercontent.com/assets/10420657/12950176/d032c888-d003-11e5-8e18-11d9a69e753c.png)
