### PR TITLE
GG-626: Revert changes form hint helper

### DIFF
--- a/assets/javascripts/modules/formHintHelper.js
+++ b/assets/javascripts/modules/formHintHelper.js
@@ -1,44 +1,37 @@
 require('jquery');
 
 /*
- Form Hint Helper is a visual aid to guide users on requirements for inputs it allows rules with a regex and flags to be
- associated with an input, and to confirm that the values of two fields match, e.g. passwords.
- When the input matches the specified regex, or the two fields match, the rule will display a tick, otherwise it will
- display as a list element with a list bullet.
- - apply the .js-form-hint-helper to your input for regex matches.
- - associate the rules with the input via the data attribute data-hint-rules="js-hint-example-rule"
- - define the rules on your rule elements associated with your input via the data attribute data-hint-rule="^\w{8,12}$"
- - define which input fields must be equal with the data-hint-confirm data attribute, e.g. data-hint-confirm="password,password-confirm".
- - use the relevant markup and classes
+Form Hint Helper is a visual aid to guide users on requirements for inputs it allows rules with a regex and flags to be
+associated with an input. When the input matches the specified regex the rule will display a tick, otherwise it will
+display as a list element with a list bullet.
+- apply the .js-form-hint-helper to your input
+- associate the rules with the input via the data attribute data-hint-rules="js-hint-example-rule"
+- define the rules on your rule elements associated with your input via the data attribute data-hint-rule="^\w{8,12}$"
+- use the relevant markup and classes
 
- Password input markup example:
+Password input markup example:
 
  <input type="password" name="password" id="password" class="js-form-hint-helper" data-hint-rules="js-hint-example-rule"/>
 
- <input type="password" name="passwordConfirm" id="password-confirm" data-hint-confirm-rule="js-confirm-example-rule"/>
-
- Form Hint Helper markup example:
+Form Hint Helper markup example:
 
  <p class="form-hint">Your input must:</p>
  <ul class="form-hint-list">
-   <li class="form-hint-list-item js-hint-example-rule"
-       data-hint-rule="^\w{8,12}$"
-       data-hint-rule-flag="i">
-          <span class="form-hint-list-item__indicator">be between 8 and 12 characters</span>
-   </li>
-   <li class="form-hint-list-item js-hint-example-rule"
-       data-hint-rule="^((?!password)[\S])+$"
-       data-hint-rule-flag="i">
-          <span class="form-hint-list-item__indicator">should not contain the word 'password'</span>
-   </li>
-   <li class="form-hint-list-item js-confirm-example-rule"
-       data-hint-confirm="password,password-confirm">
-          <span class="form-hint-list-item__indicator">match the password confirmation</span>
-   </li>
+  <li class="form-hint-list-item js-hint-example-rule"
+      id="password-hint-rule-one"
+      data-hint-rule="^\w{8,12}$"
+      data-hint-rule-flag="i">
+    <span class="form-hint-list-item__indicator"></span>be between 8 and 12 characters
+  </li>
+  <li class="form-hint-list-item js-hint-example-rule"
+      id="password-hint-rule-four"
+      data-hint-rule="^((?!password)[\S])+$"
+      data-hint-rule-flag="i">
+    <span class="form-hint-list-item__indicator"></span>should not contain the word 'password'
+  </li>
  </ul>
  */
-var validClass;
-var matchInputsAttr;
+var $formHintHelperInputs;
 
 var buildRules = function ($ruleElements) {
   var rules = [];
@@ -65,14 +58,6 @@ var buildRules = function ($ruleElements) {
   return rules;
 };
 
-var setValidClass = function (isValid, $element) {
-  if (isValid) {
-    $element.addClass(validClass);
-  } else {
-    $element.removeClass(validClass);
-  }
-};
-
 var $formHintHelperEvent = function ($formHintHelperInput) {
   var $ruleElements = $('.' + $formHintHelperInput.attr('data-hint-rules'));
   var rules = buildRules($ruleElements);
@@ -80,50 +65,32 @@ var $formHintHelperEvent = function ($formHintHelperInput) {
   $formHintHelperInput.on('keyup', function () {
     var inputValue = $formHintHelperInput.val();
 
-    for (var value in rules) {
+    for(var value in rules) {
       var rule = rules[value];
-      setValidClass(rule.pattern.test(inputValue), rule.$elem);
+
+      if (rule.pattern.test(inputValue)) {
+        rule.$elem.addClass('form-hint-list-item--valid');
+      } else {
+        rule.$elem.removeClass('form-hint-list-item--valid');
+      }
     }
   });
-};
-
-var valuesEqualAndNotEmpty = function($inputA, $inputB) {
-  return $inputA.val() && $inputB.val() && $inputA.val() === $inputB.val();
-};
-
-var $formHintHelperConfirmEvent = function ($ruleElement) {
-  var inputsToCompare = $ruleElement.attr(matchInputsAttr).split(',');
-  if (inputsToCompare.length === 2) {
-    var $inputA = $('#' + inputsToCompare[0]);
-    var $inputB = $('#' + inputsToCompare[1]);
-
-    if ($inputA && $inputB) {
-      $inputA.on('keyup', function () {
-        setValidClass(valuesEqualAndNotEmpty($inputA, $inputB), $ruleElement);
-      });
-      $inputB.on('keyup', function () {
-        setValidClass(valuesEqualAndNotEmpty($inputA, $inputB), $ruleElement);
-      });
-    }
-  }
 };
 
 var addListeners = function () {
-  $('.js-form-hint-helper').each(function (index, formHintHelperInput) {
+  $formHintHelperInputs.each(function (index, formHintHelperInput) {
     $formHintHelperEvent($(formHintHelperInput));
-  });
-
-  $('['+matchInputsAttr+']').each(function (index, confirmRuleElement) {
-    $formHintHelperConfirmEvent($(confirmRuleElement));
   });
 };
 
-var setup = function() {
-  validClass = 'form-hint-list-item--valid';
-  matchInputsAttr = 'data-hint-confirm-inputs';
+var setup = function () {
+  $formHintHelperInputs = $('.js-form-hint-helper');
 };
 
 module.exports = function () {
   setup();
-  addListeners();
+
+  if ($formHintHelperInputs.length) {
+    addListeners();
+  }
 };

--- a/assets/test/specs/fixtures/form-hint-helper-fixture.html
+++ b/assets/test/specs/fixtures/form-hint-helper-fixture.html
@@ -1,4 +1,3 @@
-<!-- example one -->
 <ul>
   <li class="js-hint-example-rule" id="example-hint-rule-one" data-hint-rule="^\w{8,12}$" data-hint-rule-flag="i">
     be between 8 and 12 characters
@@ -18,7 +17,8 @@
        name="example"
        id="example"
        class="js-form-hint-helper"
-       data-hint-rules="js-hint-example-rule"/>
+       data-hint-rules="js-hint-example-rule">
+</div>
 
 <!-- example two -->
 <ul>
@@ -31,27 +31,5 @@
        name="example-two"
        id="example-two"
        class="js-form-hint-helper"
-       data-hint-rules="js-hint-example-two-rule"/>
-
-
-<!-- example three -->
-<ul>
-  <li class="js-hint-example-three-rule-one" id="example-three-hint-rule-one" data-hint-rule="[A-Za-z]+">
-    contain at least one letter (a-z)
-  </li>
-  <li class="js-confirm-example-rule" id="example-three-hint-rule-two" data-hint-confirm-inputs="example-three,example-three-confirm">
-    Passwords must match
-  </li>
-</ul>
-
-<input type="text"
-       name="example-three"
-       id="example-three"
-       class="js-form-hint-helper"
-       data-hint-rules="js-hint-example-three-rule-one"/>
-
-<input type="password"
-       name="example-three-confirm"
-       id="example-three-confirm"
-       class="js-form-hint-helper-confirm"/>
-
+       data-hint-rules="js-hint-example-two-rule">
+</div>

--- a/assets/test/specs/formHintHelper.spec.js
+++ b/assets/test/specs/formHintHelper.spec.js
@@ -6,13 +6,8 @@ var $exampleOneRuleTwoElem;
 var $exampleOneRuleThreeElem;
 var $exampleOneRuleFourElem;
 var $exampleTwoRuleOneElem;
-var $exampleThreeRuleOneElem;
-var $exampleThreeRuleTwoElem;
 var $exampleOneInputElem;
 var $exampleTwoInputElem;
-var $exampleThreeInputOneElem;
-var $exampleThreeInputTwoElem;
-
 var assertRulesAreNotValid = function (rules) {
   rules.map(function ($elem) {
     expect($elem).not.toHaveClass('form-hint-list-item--valid');
@@ -28,10 +23,6 @@ var setup = function () {
   $exampleTwoRuleOneElem = $('#example-two-hint-rule-one');
   $exampleOneInputElem = $('#example');
   $exampleTwoInputElem = $('#example-two');
-  $exampleThreeInputOneElem = $('#example-three');
-  $exampleThreeInputTwoElem = $('#example-three-confirm');
-  $exampleThreeRuleOneElem = $('#example-three-hint-rule-one');
-  $exampleThreeRuleTwoElem = $('#example-three-hint-rule-two');
 };
 
 describe('Form Hint Helper', function () {
@@ -132,68 +123,5 @@ describe('Form Hint Helper', function () {
         $exampleOneRuleFourElem,
       ]);
     });
-  });
-
-  describe('matching field verification', function() {
-
-    it('should not be ticked when both inputs are empty', function(){
-
-      expect($exampleThreeRuleTwoElem).not.toHaveClass('form-hint-list-item--valid');
-
-    });
-
-    it('should not be ticked when both inputs are different', function(){
-
-      $exampleThreeInputOneElem.val('starwars');
-      $exampleThreeInputTwoElem.val('iloveyou').trigger('keyup');
-
-      expect($exampleThreeRuleTwoElem).not.toHaveClass('form-hint-list-item--valid');
-
-    });
-
-    it('should be ticked when both inputs are non-empty and the same', function(){
-
-      $exampleThreeInputOneElem.val('starwars');
-      $exampleThreeInputTwoElem.val('starwars').trigger('keyup');
-
-      expect($exampleThreeRuleTwoElem).toHaveClass('form-hint-list-item--valid');
-
-    });
-
-    it('should be ticked when both inputs are non-empty and the same, entered in either order', function(){
-
-      $exampleThreeInputTwoElem.val('starwars');
-      $exampleThreeInputOneElem.val('starwars').trigger('keyup');
-
-      expect($exampleThreeRuleTwoElem).toHaveClass('form-hint-list-item--valid');
-
-    });
-
-    it('should not be ticked when both inputs are empty', function(){
-
-      $exampleThreeInputTwoElem.val('');
-      $exampleThreeInputOneElem.val('').trigger('keyup');
-
-      expect($exampleThreeRuleTwoElem).not.toHaveClass('form-hint-list-item--valid');
-
-    });
-
-    it('should not interfere with a regex rule on one input field', function(){
-
-      $exampleThreeInputOneElem.val('123').trigger('keyup');
-      $exampleThreeInputTwoElem.val('123').trigger('keyup');
-
-      expect($exampleThreeRuleOneElem).not.toHaveClass('form-hint-list-item--valid');
-      expect($exampleThreeRuleTwoElem).toHaveClass('form-hint-list-item--valid');
-
-      $exampleThreeInputOneElem.val('abc').trigger('keyup');
-      $exampleThreeInputTwoElem.val('123').trigger('keyup');
-
-      expect($exampleThreeRuleOneElem).toHaveClass('form-hint-list-item--valid');
-      expect($exampleThreeRuleTwoElem).not.toHaveClass('form-hint-list-item--valid');
-
-    });
-
-
   });
 });


### PR DESCRIPTION
After discussion with UX and a discussion about Client Side validation it has been decided that this work is taken care of in the validation layer.
The comparison of two inputs is outside the scope of this helper and is something that the validation offers for free. 
Although this could be done in this helper it feels like it is adding specifics to a generic module. Comparing two inputs feels more like a validation concern.

#### Of Note
This work is a straight revert of the password comparison work.

FYI @benaveryee 