### PR TITLE
GG-627: Summary validation causing a jump when an inline error is shown

### DIFF
--- a/assets/javascripts/validation/form.js
+++ b/assets/javascripts/validation/form.js
@@ -88,7 +88,7 @@ Summary Error Markup example:
 
 var $forms;
 
-var displayGlobalErrorSummary = function (validator, errorMessages) {
+var renderGlobalErrorSummary = function (validator, errorMessages) {
   var $template = $('<li role="tooltip"><a></a></li>');
   var $errorSummaryListElement;
 
@@ -142,12 +142,20 @@ var handleErrors = function (validator, submitted) {
 
   flushHiddenElementErrors(validator.invalid);
 
+  // on submit or the error summary is already displayed
   if (submitted || $errorSummary.is(':visible')) {
     if (errorMessages.length) {
-      displayGlobalErrorSummary(validator, errorMessages, $errorSummary);
-      $errorSummary.addClass('error-summary--show');
+      renderGlobalErrorSummary(validator, errorMessages, $errorSummary);
+      $errorSummary.addClass('error-summary--show').removeClass('visuallyhidden');
     } else {
       $errorSummary.removeClass('error-summary--show');
+    }
+  } else { // inline error
+    if (errorMessages.length) {
+      renderGlobalErrorSummary(validator, errorMessages, $errorSummary);
+      $errorSummary.addClass('visuallyhidden');
+    } else {
+      $errorSummary.removeClass('visuallyhidden');
     }
   }
 };

--- a/assets/javascripts/validation/form.js
+++ b/assets/javascripts/validation/form.js
@@ -129,7 +129,7 @@ var flushHiddenElementErrors = function (invalidInputs) {
 };
 
 
-var handleErrors = function (validator) {
+var handleErrors = function (validator, submitted) {
   var $currentForm = $(validator.currentForm);
   var $errorSummary = $('.error-summary', $currentForm);
   var errorSummaryContainer = $errorSummary.find('.js-error-summary-messages');
@@ -142,11 +142,13 @@ var handleErrors = function (validator) {
 
   flushHiddenElementErrors(validator.invalid);
 
-  if (errorMessages.length) {
-    displayGlobalErrorSummary(validator, errorMessages, $errorSummary);
-    $errorSummary.addClass('error-summary--show');
-  } else {
-    $errorSummary.removeClass('error-summary--show');
+  if (submitted || $errorSummary.is(':visible')) {
+    if (errorMessages.length) {
+      displayGlobalErrorSummary(validator, errorMessages, $errorSummary);
+      $errorSummary.addClass('error-summary--show');
+    } else {
+      $errorSummary.removeClass('error-summary--show');
+    }
   }
 };
 
@@ -180,6 +182,7 @@ var getErrorMessages = function () {
 
 
 var setupForm = function ($formElem) {
+  var submitted = false;
   var validator = $formElem.validate({
     errorPlacement: function ($error, $element) {
       var $formFieldGroup = $element.closest('.form-field-group');
@@ -192,12 +195,14 @@ var setupForm = function ($formElem) {
       $(element).closest('.form-field-group').removeClass('form-field-group--error');
     },
     showErrors: function () {
-      handleErrors(validator);
+      handleErrors(validator, submitted);
+      submitted = false;
     },
     submitHandler: function (form) {
       form.submit();
     },
     invalidHandler: function() {
+      submitted = true;
       // When invalid submission, re-enable the submit button as the preventDoubleSubmit module disables the submit onSubmit
       $formElem.find('.button[type=submit]').prop('disabled', false);
     }

--- a/assets/test/specs/fixtures/form-fixture.html
+++ b/assets/test/specs/fixtures/form-fixture.html
@@ -7,7 +7,7 @@
 
   <fieldset class="form-field-group">
     <label class="form-element-bold" for="text-input-example">Text input example
-    <span class="error-notification" role="tooltip" data-input-name="text-input-example">
+    <span id="text-input-example-error-message" class="error-notification" role="tooltip" data-input-name="text-input-example">
         Required text
     </span>
     <input type="text"
@@ -26,7 +26,7 @@
 
 
   <fieldset class="form-field-group" id="radio-example">
-    <span class="error-notification" role="tooltip" data-input-name="radio-example">
+    <span id="radio-example-error-message" class="error-notification" role="tooltip" data-input-name="radio-example">
         Required selection
     </span>
 

--- a/assets/test/specs/form.spec.js
+++ b/assets/test/specs/form.spec.js
@@ -102,7 +102,7 @@ describe('Form Validation', function () {
     });
 
 
-    describe('When I enter the wrong pattern on text input', function () {
+    describe('When I enter the wrong pattern on text input and submit', function () {
 
       beforeEach(function () {
         // select radio button, add wrong format value to text input
@@ -131,7 +131,7 @@ describe('Form Validation', function () {
       });
     });
 
-    describe('When I enter value below min length', function () {
+    describe('When I enter value below min length and submit', function () {
 
       beforeEach(function () {
         // select radio button, add value below min length to text input
@@ -160,7 +160,7 @@ describe('Form Validation', function () {
       });
     });
 
-    describe('When I do not select a radio input', function () {
+    describe('When I do not select a radio input and submit', function () {
 
       beforeEach(function () {
         // do not select radio button, add correct value for text input
@@ -187,5 +187,33 @@ describe('Form Validation', function () {
         expect($errorMessages.eq(0).text()).toBe($radioYesElement.attr('data-msg-required'));
       });
     });
+
+    describe('When I enter value below min length and blur', function () {
+
+      beforeEach(function () {
+        // select radio button, add value below min length to text input
+        $radioYesElement.click();
+        $textInputExample.val('55').blur();
+      });
+
+      it('The error summary should not be visible', function () {
+        expect($errorSummary).not.toHaveClass('error-summary--show');
+      });
+
+      it('The error summary should contain 0 errors', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+        expect($errorMessages.length).toBe(0);
+      });
+
+      it('The form should have 1 error', function () {
+        expect(form.getErrorMessages().length).toBe(1);
+      });
+
+      it('The form should have the invalid pattern inline error message', function () {
+        var $inlineErrorMessage = $('#text-input-example-error-message');
+        expect($inlineErrorMessage.text()).toBe($textInputExample.attr('data-msg-minlength'));
+      });
+    });
+
   });
 });

--- a/assets/test/specs/form.spec.js
+++ b/assets/test/specs/form.spec.js
@@ -200,9 +200,14 @@ describe('Form Validation', function () {
         expect($errorSummary).not.toHaveClass('error-summary--show');
       });
 
-      it('The error summary should contain 0 errors', function () {
+      it('The error summary should be visible for accessibility users', function () {
+        expect($errorSummary).toHaveClass('visuallyhidden');
+      });
+
+      it('The error summary should contain 1 errors', function () {
         var $errorMessages = $errorSummaryMessages.find('> li');
-        expect($errorMessages.length).toBe(0);
+        expect($errorMessages.length).toBe(1);
+        expect($errorMessages.eq(0).text()).toBe($textInputExample.attr('data-msg-minlength'));
       });
 
       it('The form should have 1 error', function () {


### PR DESCRIPTION
# Summary validation causing a jump when an inline error is shown

#### Explanation
For the front end validation due to having a summary added to the page we suffer from an undesirable movement when users invoke an error on the form (keyup, blur, submit), this is magnified on mobile. 

#### Example of Jump
![flick-validation](https://cloud.githubusercontent.com/assets/2305016/12984352/345c17c4-d0e5-11e5-9a2e-64819fa8f854.gif)

Working with UX to find a solution,

We have considered:
- taking the summary out of document flow (absolute, fixed)
- removing the summary (needed for Accessibility)
- making the front end validation work only on submit (I feel this removes the value front end validation gives you)
- hiding/removing the summary for JavaScript (gets tricky with Server side errors)
- locking the scroll position or compensating for an element added at the top of the page (gets tricky)

## Solution
After trying many different options we have decided on:

- Don't show error summary when inline errors are invoked
- Show error summary for submit only (JavaScript)
- Adjust errors in Error Summary if it is shown and inline errors are invoked
- The full summary is shown when using server side errors

This means there is only a jump when the user submits the page and not when they invoke inline errors 

#### Of Note
There is potential to add a smaller version of the summary when an inline error is invoked just displaying: **Your form has errors**

#### Example
![form-refactor-no-summray](https://cloud.githubusercontent.com/assets/2305016/12984796/6194709a-d0e7-11e5-9bc6-b14ab2d13517.gif)
