### PR TITLE
Preventing our list module styles being overridden by govuk elements

### DIFF
--- a/assets/scss/base/_lists.scss
+++ b/assets/scss/base/_lists.scss
@@ -7,7 +7,7 @@
 * @requires     N/A
 */
 
-ul {
+ul, nav ul {
 	list-style-type: none;
 	li {
     @include core-19();


### PR DESCRIPTION
Our `lists.scss` module contains an element selector `ul` which sets `list-style-type:none`.

If one wraps a `nav` tag around a `ul`, styles from `govuk-template.scss` override the `list-style-type`, causing list items to have be bullet pointed, as below:

![screen shot 2016-02-15 at 3 42 30 pm](https://cloud.githubusercontent.com/assets/1764083/13053140/cb6eadf8-d3fa-11e5-92c3-a019886d689b.png)

I've updated our list module, adding a `nav ul` to the existing `ul` selector to prevent this happening, giving the follow:

![screen shot 2016-02-15 at 3 42 42 pm](https://cloud.githubusercontent.com/assets/1764083/13053150/da987264-d3fa-11e5-94af-07e98196e985.png)

Like many things we do with the SASS in its current state, the above is a symptom of a deeper problem. Technically, this problem is caused by govuk elements overriding our styles. This CSS is in the todo list to be removed.