### PR TITLE
GG-647: remove global p element styles

### DIFF
--- a/assets/scss/base/_typography.scss
+++ b/assets/scss/base/_typography.scss
@@ -1,13 +1,7 @@
 // Why are typography-related styles living here? Looks like this file has become a dumping ground
 // TODO: Move non-typography related styles to relevant SCSS files
 
-p {
-  @include core-19();
 
-  .content__body & {
-    margin: 0.75em 0;
-  }
-}
 ul {
   padding: 0;
   margin: 0;


### PR DESCRIPTION
# Remove global p element styles

It looks like these are being overwritten in a few places, and for me to achieve the correct margin I need to override using a `.flush` helper! Do we actually need this? I suggest no! Thoughts?

rich dropped it in (cant @ him here)