### PR TITLE
Added helper for class for core-19 mixin

### DIFF
--- a/assets/scss/base/_typography.scss
+++ b/assets/scss/base/_typography.scss
@@ -176,3 +176,7 @@ details {
   @include core-14;
 }
 
+.font-small {
+  @include core-19;
+}
+


### PR DESCRIPTION
Added a helper to provide 19px font size (using the `core-19` mixin). In my case, this was needed for a table. Tables are currently 16px font size by default.

![screen shot 2016-02-23 at 1 53 25 pm](https://cloud.githubusercontent.com/assets/1764083/13253670/feeef6d4-da34-11e5-8250-4a791792361b.png)
