### PR TITLE
[API-801] Added table modifier for 19px font size

### DIFF
--- a/assets/scss/base/_table.scss
+++ b/assets/scss/base/_table.scss
@@ -120,3 +120,7 @@ table {
     float: left;
   }
 }
+
+.table--font-small {
+  @include core-19;
+}


### PR DESCRIPTION
Added a modifier to the table module for use of font size 19px as some tables need to sit on pages where all other content is 19px, as opposed to the default table font size of 16px.

![screen shot 2016-02-23 at 1 53 25 pm](https://cloud.githubusercontent.com/assets/1764083/13254112/b5db2d70-da37-11e5-912f-1b3ca29285e4.png)
