### PR TITLE
Modifiers for buttons that sit inline and buttons with short text

### DIFF
--- a/assets/scss/base/_buttons.scss
+++ b/assets/scss/base/_buttons.scss
@@ -55,6 +55,18 @@ button, .button {
   box-shadow: 0 0 0 $grey-4;
 }
 
+// adds margin on left and right of button for situations
+// where button is sitting inline with other elements
+.button--spaced {
+  margin: 0 em(10) 0 em(10);
+}
+
+// adds left and right padding for buttons whose text is extremely short
+.button--padded {
+  padding-left: em(30);
+  padding-right: em(30);
+}
+
 /**
  * For links that need to be positioned beside buttons
  * Used in conjunction with button class
@@ -106,3 +118,4 @@ button, .button {
     background-color: transparent;
   }
 }
+


### PR DESCRIPTION
## Description

* Modifiers to space out sides of buttons that sit inline beside other elements.
* Modifiers to pad out sides of buttons with extremely short text.

## Before

![screen shot 2016-02-26 at 3 42 19 pm](https://cloud.githubusercontent.com/assets/1764083/13356915/bd24324c-dc9f-11e5-94e8-117da6ea22ca.png)

## After

![screen shot 2016-02-26 at 3 41 01 pm](https://cloud.githubusercontent.com/assets/1764083/13356920/c2641c2c-dc9f-11e5-885f-c78e1dba8c0a.png)