### PR TITLE
Added modifier for smaller form hints

### DIFF
--- a/assets/scss/base/form/_hint.scss
+++ b/assets/scss/base/form/_hint.scss
@@ -9,6 +9,10 @@
   }
 }
 
+.form-hint--small {
+  @include core-16;
+}
+
 .form-element-bold {
   @include bold-24;
   display: block;


### PR DESCRIPTION
## Description

Added `form-hint--small` modifier to allow for smaller font (16px) hints.

## Before

![screen shot 2016-02-26 at 3 48 16 pm](https://cloud.githubusercontent.com/assets/1764083/13357036/65a4be32-dca0-11e5-94d7-30a3e55b7794.png)

## After

![screen shot 2016-02-26 at 3 48 23 pm](https://cloud.githubusercontent.com/assets/1764083/13357047/6dbe034e-dca0-11e5-8e26-df49f75bb261.png)