### PR TITLE
Added table modifiers to reset font size and space out top and bottom

### DIFF
--- a/assets/scss/base/_table.scss
+++ b/assets/scss/base/_table.scss
@@ -43,6 +43,20 @@ table {
   }
 }
 
+// resets table cell's font size to base
+.table--font-reset {
+
+  td {
+    @include core-19;
+  }
+
+}
+
+// for tables that need to be spaced from above element
+.table--spaced-top {
+  margin-top: em(30);
+}
+
 .table-cell--light {
   background-color: $highlight-colour;
 }
@@ -120,3 +134,4 @@ table {
     float: left;
   }
 }
+


### PR DESCRIPTION
## Description

* Modifier to reset font size for table TDs. Resets to our base font size of 19px.
* Modifier to space out above and below tables to provide enough gap between elements.

## Before

![screen shot 2016-02-26 at 3 51 43 pm](https://cloud.githubusercontent.com/assets/1764083/13357135/e1810a6a-dca0-11e5-9d24-ba18fc2b8048.png)

## After

![screen shot 2016-02-26 at 3 51 55 pm](https://cloud.githubusercontent.com/assets/1764083/13357144/e72826b0-dca0-11e5-8c16-890508a5fe5c.png)