### PR TITLE
Button component modifier for stacked buttons and links in mobile

### DIFF
--- a/assets/scss/base/_buttons.scss
+++ b/assets/scss/base/_buttons.scss
@@ -77,6 +77,9 @@ button, .button {
   text-decoration: underline;
   color: $link-colour;
   border: none;
+  margin-top: em(10);
+  text-align: center;
+  box-sizing: border-box;
 
   &.button--link-table {
     color: $black;
@@ -97,10 +100,10 @@ button, .button {
     color: $link-active-colour;
   }
 
-  @include media(mobile) {
-    margin-top: 10px;
-    text-align: center;
-    box-sizing: border-box;
+  @include media(tablet) {
+    margin-top: 0;
+    text-align: left;
+    box-sizing: content-box;
   }
 
 }

--- a/assets/scss/base/_buttons.scss
+++ b/assets/scss/base/_buttons.scss
@@ -99,7 +99,10 @@ button, .button {
 
   @include media(mobile) {
     margin-top: 10px;
+    text-align: center;
+    box-sizing: border-box;
   }
+
 }
 
 /* Transforms button into a link */


### PR DESCRIPTION
There are links that sit beside buttons in a form, which use the class `button.button--link` to align correctly with the buttons.

In mobile, these links currently look like this:

![screen shot 2016-02-29 at 11 12 55 am](https://cloud.githubusercontent.com/assets/1764083/13399928/666baa06-defd-11e5-82e3-6554730cd805.png)

Ideally, they should look like this (approved by designers):

![screen shot 2016-02-29 at 11 13 07 am](https://cloud.githubusercontent.com/assets/1764083/13399939/732f1bc4-defd-11e5-8647-4010df596c41.png)