### PR TITLE
Added text underline option summary tag

### DIFF
--- a/assets/scss/base/_details-summary.scss
+++ b/assets/scss/base/_details-summary.scss
@@ -71,6 +71,10 @@
   }
 }
 
+.summary--underline {
+  text-decoration: underline;
+}
+
 .no-details details {
   summary {
     .arrow-closed {
@@ -92,6 +96,7 @@
     }
   }
 }
+
 .details {
   .details__inner {
     padding-bottom: 2em;


### PR DESCRIPTION
Example usage:

![screen shot 2016-02-29 at 3 26 12 pm](https://cloud.githubusercontent.com/assets/1764083/13400475/cd6cf2d0-deff-11e5-8a6f-1620ffdd6b1d.png)
