### PR TITLE
Indent component modifiers.

### DIFF
--- a/assets/scss/base/_typography.scss
+++ b/assets/scss/base/_typography.scss
@@ -124,6 +124,21 @@ small {
   padding: 0.25em 0.5em;
 }
 
+/* indent an element but do not provide the default left border */
+.indent--no-border {
+  border: none;
+}
+
+/* reset an indented element to the base font of 19px */
+.indent--font-reset {
+  @include core-19;
+}
+
+/* indent an element to align with details tag content link (after the expand/collapse arrow) */
+.indent--align-details {
+  margin-left: 0.75em;
+}
+
 .indent-warning {
   background: transparent no-repeat 0 0;
   background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACMAAAAjCAQAAAC00HvSAAABZklEQVR4Aa3WsWoTUBTG8V9v4yQElywRAlYzJVCQdMrgmKVDce3m3mfI0ofoY7QQfAOngmQIOGgzOGRpQYhLUynHZjb3JtL7/+8f53DhfmfPZlqGjvR1tTUtLXw3c+2LWzsycG4qNjp1bmArHWM3ouiNsY4CIxOxkxMjGU7NxM7OnG4OmYv/cv5v0KgwSWmiEdAAHWd6NvLeHsJXG+g5881PgLHI+RBrHkLOMcCg9MS/Y82y9PwDEk4cyHIPVrIcOCFpOVZgtS2GY61k6PCZMYeGyRFsW+pekaOkzzOnoZ90K8R0k3aFpdpJs8I0zWRZIWaZLCosteBKlNyPF0/uh5JXyUyRR3+efFRk1nCtyBufrFy4U+CalqnI+Tp+xZof8TLknGoltyayfPQKvPVBlonbhEtzGe4A8kvNXW79/RrxOdZc7PD70cn301704l2przoVm6FCT1VozQodXuuiqH/fVLq2/gLNMwwtCpJpLgAAAABJRU5ErkJggg==');


### PR DESCRIPTION
## Modifiers

* `indent--no-border` - this fantabulous little fella removes the big blocky left border that is default on all indent components.
* `indent--font-reset` - this golden boy wonder child of a modifier resets the font size to base (19x).
* `indent--align-details` - this ridiculously useful modifier allows content to be aligned with a summary tag. That is, the summary tag text beyond the expand/collapse arrow (see below)

## Examples

![screen shot 2016-02-29 at 3 26 12 pm](https://cloud.githubusercontent.com/assets/1764083/13401555/77a39958-df04-11e5-927e-10f81eb1b15f.png)
