### PR TITLE
[AOSS-1057] add modal-dialog module

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -43,7 +43,8 @@ var sso = require('./modules/sso.js'),
     accordion = require('./modules/accordion.js'),
     tabs = require('./modules/tabs.js'),
     charCounter = require('./modules/charCounter.js'),
-    addRemove = require('./modules/addRemove.js');
+    addRemove = require('./modules/addRemove.js'),
+    modalDialog = require('./modules/modalDialog.js');
 
 //initialise mdtpf
 fingerprint();
@@ -167,5 +168,6 @@ $(function() {
   accordion();
   charCounter();
   addRemove();
+  modalDialog();
 
 });

--- a/assets/javascripts/modules/modalDialog.js
+++ b/assets/javascripts/modules/modalDialog.js
@@ -1,0 +1,337 @@
+/**
+ * @name modalDialog
+ * @module javascripts/modules/modaldialog
+ * @author  Matthew Pepper
+ * @requires jquery
+ * @requires stageprompt
+ * @requires scss/modules/_modal-dialog.scss
+ *
+ * @summary An accessible modal-dialog component module consisting of:
+ * - outer container masking element, covering the page
+ * - inner container for content, with auto scrolling if content exceeds inner container height
+ * - content(s) with visibility toggle
+ * - Tested on: IE8+, MSEdge, Safari 9.0.3, Google Chrome 48.0.2564.1, Firefox 44.0.2,
+ * - Responsive resolutions: 1920x1080, 1280x800, 768x1024, 750x1334, 600x800, 320x568, 320x480
+ *
+ * @see @link{https://designpatterns.hackpad.com/Modal-dialog-boxes-ZJNqssq4Dll|Modal dialog boxes - designpatterns.hackpad.com}
+ * @see @link{https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_dialog_role|Using the dialog role}
+ * @see @link{https://www.nczonline.net/blog/2013/02/12/making-an-accessible-dialog-box/|Making an accessible dialog box - NCZOnline}
+ * @see @link{https://www.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/|HTML5 Accessibility Chops: hidden and aria-hidden}
+ * @see @link{'Tab key does not select menus or buttons|https://support.mozilla.org/en-US/kb/Pressing%20Tab%20key%20does%20not%20select%20menus%20or%20buttons}
+ *
+ * @example:
+ * - include "modal-dialog" & "modal-dialog__container" in page or page template
+ * - include "modal-dialog__content" inner html markup in partial views
+ *
+ *  <div class="modal-dialog">
+ *    <div class="modal-dialog__inner">
+ *      <div id="content-1" class="modal-dialog__content" data-ga-open-event="category:Event:id" tabindex="1" role="dialog"
+ *          aria-labelledby="heading-id" aria-describedby="message-id" hidden>
+ *        <div id="message-id">
+ *          <h2 id="heading-id">content 1 heading</h2>
+ *          ....
+ *          <button role="button" class="button button--secondary" data-journey-click="category:Event:id"
+ *            data-modaldialog-action="close" tabindex="1">close</button>
+ *        </div>
+ *      </div>
+ *      <div id="content-2" class="modal-dialog__content" data-ga-open-event="category:Event:id" tabindex="1" role="dialog"
+ *        aria-labelledby="heading-id-2" aria-describedby="message-id-2">
+ *        <div id="message-id-2">
+ *          <h2 i fd="heading-id-2">content 2 heading</h2>
+ *          ...
+ *          <a href="#" data-modaldialog-action="close" tabindex="1" data-journey-click="category:Event:id">...</a>
+ *        </div>
+ *      </div>
+ *    </div>
+ *  </div>
+ *
+ *  // to display modal-dialog on a link's click event:
+ *  <a class="" href="#" data-modaldialog-action="id-selector-of-content" data-journey-click="category:Event:id">click to open</a>
+ *
+ */
+require('jquery');
+var GOVUK = require('stageprompt');
+
+module.exports = function() {
+  var $modalDialog = $('.modal-dialog'),
+    $container = $modalDialog.find('.modal-dialog__inner'),
+    $modalContents = $container.find('.modal-dialog__content'),
+    contentShowing = '.modal-dialog__content:not([hidden])',
+    $doc = $(document),
+    $body = $('body'),
+    $returnFocus;
+
+  /**
+   * Hide modal-dialog and return focus to previously active element.
+   */
+  function hide() {
+    // set showing content "hidden" attr
+    setHidden($(contentShowing), true);
+
+    // un-fix body the position so that it can scroll
+    $body.removeClass('scroll-off');
+
+    // 'hide' $modalDialog
+    $modalDialog.addClass('modal-dialog--hidden');
+
+    // return focus to the active element before modal was shown
+    if ($returnFocus && $returnFocus.length) {
+      $returnFocus.focus();
+    }
+  }
+
+  /**
+   * Show modal-dialog, container & content.
+   * @param {Event} e - optional event (not passed in init()...
+   *                    passed by dom elements which display / close modal-dialog
+   *                    using data-modaldialog-action=[open|close] and data-modaldialog-target="modal-dialog__content-id"
+   */
+  function show(e) {
+    // get content to be shown - from event if it is passed, or from element with attribute hidden=false
+    var $content = !e ? $modalContents.filter(function() { return getHidden($(this)); }) : getContentToShow(e);
+
+    if (!!$content && $content.length) {
+      // set currently focussed element for return focus on modal-dialog hide
+      $returnFocus = $(document.activeElement);
+
+      // fix body position
+      $body.addClass('scroll-off');
+
+      // 'show' $modalDialog
+      $modalDialog.removeClass('modal-dialog--hidden');
+
+      // set $modalDialog size (with height dimension relative to content height)
+      setDimensions($content);
+
+      // shift focus to showing content
+      $(contentShowing).focus();
+
+      // send google analytics event
+      if ($(contentShowing).length) {
+        fireEventTracking($(contentShowing).data('gaOpenEvent'));
+      }
+    }
+  }
+
+  /**
+   * Get the content element to be shown in the modal-dialog
+   * @param {Event} e - optional event passed by dom event trigger from element with [data-modaldialog-action="open | close"] attribute)
+   * @returns {HTMLElement}
+   */
+  function getContentToShow(e) {
+    var $content, $target;
+
+    // if event is passed by dom event trigger
+    // from element with [data-modaldialog-action="open | close"] and [data-modaldialog-target] attributes
+    if (e && e.target && $(e.target).data('modaldialogTarget') && $(e.target).data('modaldialogAction')) {
+      // get element which triggered the event
+      $target = $(e.target);
+
+      // get target element to be opened /closed
+      $content = $('#' + $target.data('modaldialogTarget'));
+
+      // if the target element exists
+      if ($content.length) {
+        // set the target element hidden attribute
+        setHidden($content, $target.data('modaldialogAction') !== 'open');
+      }
+    }
+
+    // return the target element or undefined
+    return $content;
+  }
+
+  /**
+   * Set the dimensions of the modal dialog's inner container to fit the view-port, with scrolling for smaller resolutions.
+   * @param {HTMLElement} $element - content element
+   */
+  function setDimensions($element) {
+    // distance from top of view-port (less the top and bottom border)
+    var offset = Math.floor($container.offset().top) - ($container.css('border-width').replace('px', '') * 2),
+
+        // iterate modal content to calc the max height of required for tallest content
+        maxHeight = Math.max.apply(null, $modalContents.map(
+          function() {
+            // content height
+            var thisHeight = Math.min.apply(null, [$(this).outerHeight(false), $element.outerHeight(false)]);
+
+            // return the greater of the content or modal dialog height
+            return thisHeight > $modalDialog.outerHeight(false) ? $modalDialog.outerHeight(false) : thisHeight;
+          }).get()),
+
+        // if maxHeight is less than the window height less the offset, use maxHeight, else use maxHeight less offset
+        containerHeight = maxHeight < $(window).height() - offset ? maxHeight : maxHeight - offset;
+
+    // if calc height is > 0
+    if (containerHeight) {
+      $container.css({'max-height': containerHeight + 'px'});
+    }
+  }
+
+  /**
+   * Set the dimensions of the modal dialog element to fit the view-port
+   */
+  function setModalDialogDimensions() {
+    // set height and width to mask to fill up the whole document
+    $modalDialog.css({width: $doc.width() + 'px', height: $doc.height() + 'px'});
+  }
+
+  /**
+   * Window resize event handler to re-calculate the modal-dialog element's dimensions
+   * @param {Function} setMaskDimensions - callback function
+   */
+  $(window).on('resize', function() {
+    // stretch opacity mask to fit page
+    setModalDialogDimensions();
+  });
+
+  /**
+   * Event handler to capture [esc] key press in modal-dialog
+   **/
+  $modalDialog.on('keyup', contentShowing, function(e) {
+    // escape key press to close modal-dialog
+    if ($(contentShowing).length && e.which === 27) {
+      // send google analytics event - assume the same value data-journey-click value as the close button
+      var $closeButton = $(contentShowing).find('[data-modaldialog-action="close"]');
+
+      // if the close button exists
+      if ($closeButton.length) {
+        // use the close button / links data-journey-click attribute value to fire a GA event
+        fireEventTracking($closeButton.data('journeyClick'));
+      }
+
+      hide();
+    }
+  });
+
+  /**
+   * Event handler to capture tab key press in modal-dialog - needs to be in doc context to capture tab outside modal-dialog.
+   */
+  $doc.on('keydown', function(e) {
+    // if there is showing content in the modal dialog and the tab key is pressed
+    if ($(contentShowing).length && e.which === 9) {
+      e.preventDefault();
+
+      var $src = $(e.target), // the element losing focus by the tab key press
+        isBack = e.shiftKey, // is the shift key being held down (is the focus moving to previous or next element in tab order)
+        $tabs = $(contentShowing).find('[tabindex="1"]').addBack(), // the elements in the content's tab order
+        inc = $tabs.index($src) + (isBack ? -1 : 1), // incremental value to move through the tab order by
+        $focus; // element to move focus to
+
+      // if focus has moved out of modal-dialog bring it back
+      if (inc < 0) {
+        // if increment is negative move back in tab order, move to last element in the tab order
+        $focus = $tabs.last();
+      }
+      else if (inc > $tabs.length - 1) {
+        // if increment is greater than the number of elements in the tab order, move to first element in the tab order
+        $focus = $tabs.first();
+        $container.scrollTop(0);
+      }
+      else {
+        // else use the increment to move to the element in the tab order by index
+        $focus = $tabs.eq(inc);
+      }
+
+      $focus.focus();
+    }
+  });
+
+  /**
+   * Event handler for document click to return focus to modal-dialog when content showing.
+   */
+  $doc.on('click', function(e) {
+    // if content is showing in the modal, and doesn't contain the element clicked on
+    if ($(contentShowing).length && !$(contentShowing).find($(e.target)).length) {
+
+      // if the shown content contains a element which is in the tab order
+      if ($(contentShowing).find('[tabindex="1"]:focus').length) {
+        // move the focus to it
+        $(contentShowing).find('[tabindex="1"]:focus').focus();
+      } else {
+        // move the focus to the content element itself
+        $(contentShowing).focus();
+        e.stopPropagation();
+      }
+    }
+  });
+
+  /**
+   * Event handler for hiding modal-dialog & content.
+   */
+  $body.find($modalContents).addBack().on('click', '[data-modaldialog-action="close"]', function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    // hide the modal
+    hide();
+  });
+
+  /**
+   * Event handler for showing modal-dialog & content.
+   */
+  $body.find($modalContents).addBack().on('click', '[data-modaldialog-action="open"]', function(e) {
+    // stop default event and propagation
+    e.preventDefault();
+    e.stopPropagation();
+
+    // hide the content showing in the modal
+    setHidden($(contentShowing), true);
+
+    //show the modal
+    show(e);
+  });
+
+  /**
+   * Fire Google Analytics event tracking
+   */
+  function fireEventTracking(gaEvent) {
+    // get the GA event fields
+    var gaEventFields = gaEvent.split(':');
+
+    // if three GA fields defined
+    if (gaEventFields.length === 3) {
+      // fire a GA event
+      GOVUK.performance.sendGoogleAnalyticsEvent(gaEventFields[0], gaEventFields[1], gaEventFields[2]);
+    }
+  }
+
+  /**
+   * Set the value of the "hidden" attributes
+   * @param {HTMLElement} $el
+   * @param {boolean} isHidden
+   */
+  function setHidden($el, isHidden) {
+    // if not hidden
+    if (!isHidden) {
+      // remove the "hidden" attribute
+      $el.removeAttr('hidden');
+    }
+    else {
+      // set the "hidden" attribute (as string for IE compat)
+      $el.attr('hidden', 'true');
+    }
+
+    // set the aria-hidden attribute
+    $el.attr('aria-hidden', isHidden);
+  }
+
+  /**
+   * Get the value of the "hidden" attribute
+   * @returns {boolean|string}
+   */
+  function getHidden($el) {
+    return $el.attr('hidden');
+  }
+
+  // initialize if the modal dialog and modal dialog content exist
+  if ($modalDialog.length && $modalContents.length) {
+    // set the dimensions of the modal dialog element
+    setModalDialogDimensions();
+
+    // if there is modal content to show (when page loads)
+    if ($(contentShowing).length) {
+      show();
+    }
+  }
+};

--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -77,7 +77,7 @@ $path: "../images/icons/";
 @import "modules/add-remove";
 @import "modules/toggle-button";
 @import "modules/tabs";
-
+@import "modules/modal-dialog";
 
 // Page Specific Styles
 @import "pages/messages";

--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -25,3 +25,11 @@
     padding: 0 em(30) em($paddingBottom) em(30);
   }
 }
+
+@mixin set-square-clip($for-ie: false, $px-value: 0) {
+  @if $for-ie == true {
+    clip: rect(em($px-value) em($px-value) em($px-value) em($px-value));
+  } @else {
+    clip: rect(em($px-value), em($px-value), em($px-value), em($px-value));
+  }
+}

--- a/assets/scss/base/_colours.scss
+++ b/assets/scss/base/_colours.scss
@@ -35,5 +35,8 @@ $light-grey: #bfc1c3;
 
 $govuk-blue-colour: #005ea5;
 
+$mask-opacity: rgba(89, 89, 89, .7);
+$modal-dialog-yellow: $attorney-yellow;
+
 // NOTE this is a grey from govuk_elements, which will be removed, so adding a version of it here
 $govuk-grey-3: #DEE0E2;

--- a/assets/scss/modules/_modal-dialog.scss
+++ b/assets/scss/modules/_modal-dialog.scss
@@ -11,7 +11,14 @@ Experimental:  An accessibility compliant & responsive modal dialog box module.
 Markup:
 <div class="modal-dialog">
   <div class="modal-dialog__inner">
-    <div id="removing-clients" class="modal-dialog__content" tabindex="1" data-ga-open-event="client-list:Open:Removing clients dialog" role="dialog" aria-labelledby="removing-clients--heading" aria-describedby="removing-clients--description" hidden>
+    <div id="removing-clients" 
+         class="modal-dialog__content" 
+         tabindex="1" 
+         data-ga-open-event="client-list:Open:Removing clients dialog" 
+         role="dialog" 
+         aria-labelledby="removing-clients--heading" 
+         aria-describedby="removing-clients--description" 
+         hidden>
       <h2 id="removing-clients--heading">What does removing a client do?</h2>
       <div id="removing-clients--description">
         <p>When you remove a client you give up the authorisation this client has given you to act for them.</p>
@@ -26,10 +33,21 @@ Markup:
         </p>
       </div>
       <p>
-        <button class="button button--secondary" role="button" data-modaldialog-action="close" type="button" tabindex="1" data-journey-click="client-list:Click:Removing clients dialog close">Close</button>
+        <button class="button button--secondary" 
+                role="button" 
+                data-modaldialog-action="close" 
+                type="button" 
+                tabindex="1" 
+                data-journey-click="client-list:Click:Removing clients dialog close">Close</button>
       </p>
     </div>
-    <div id="deleting-client" class="modal-dialog__content" tabindex="1" role="dialog" data-ga-open-event="client-list:Open:Deleting clients dialog" aria-labelledby="deleting-clients--heading" aria-describedby="deleting-clients--description">
+    <div id="deleting-client" 
+         class="modal-dialog__content" 
+         tabindex="1" 
+         role="dialog" 
+         data-ga-open-event="client-list:Open:Deleting clients dialog" 
+         aria-labelledby="deleting-clients--heading" 
+         aria-describedby="deleting-clients--description">
       <h2 id="deleting-clients--heading">Before you access your clients' accounts</h2>
       <div id="deleting-clients--description">
         <p>You must:</p>
@@ -42,8 +60,19 @@ Markup:
         </div>
       </div>
       <p>
-        <button class="button" role="button" data-modaldialog-action="close" tabindex="1" data-journey-click="client-list:Click:Deleting clients dialog close">Continue</button>
-        <a href="#" class="button button--link" role="button" data-journey-click="::" data-modaldialog-action="open" data-modaldialog-target="removing-clients" tabindex="1">More...</a>
+        <button class="button" 
+                role="button" 
+                data-modaldialog-action="close"
+                type="button" 
+                tabindex="1" 
+                data-journey-click="client-list:Click:Deleting clients dialog close">Continue</button>
+        <a href="#" 
+           class="button button--link" 
+           role="button" 
+           data-journey-click="client-list:Click:Deleting clients dialog more..." 
+           data-modaldialog-action="open" 
+           data-modaldialog-target="removing-clients" 
+           tabindex="1">More...</a>
       </p>
     </div>
   </div>

--- a/assets/scss/modules/_modal-dialog.scss
+++ b/assets/scss/modules/_modal-dialog.scss
@@ -1,39 +1,27 @@
-/*
+/* 
 Modal Dialog
+
 
 An accessibility compliant & responsive modal dialog box module.
 
-<table style="border-left: 4px solid #AF1324; background-color: rgba(173, 19, 37, 0.1);">
-    <tr>
-        <td style="border-bottom-width: 0;padding-left: 4px;font-size: 19px;font-weight: bold;color: #AF1324;line-height: 1.31579;">Experimental</td>
-    </tr>
-    <tr>
-        <td style="border-bottom-width: 0;padding-left: 8px;font-size: 19px;line-height: 1.31579;">
-          Before considering a [modal dialog box](https://designpatterns.hackpad.com/Modal-dialog-boxes-ZJNqssq4Dll]), *make sure that you have strong evidence* that:
-        </td>
-    </tr>
-    <tr>
-        <td style="border-bottom-width: 0;padding-left: 16px;font-size: 19px;line-height: 1.31579;">
-          <ul>
-              <li>There is a real user need to have attention focused on a single piece of content.</li>
-              <li>That need cannot be met by taking the user to a new page in the same flow that contains the crucial piece of content.</li>
-            </ul>
-        </td>
-    </tr>
-</table>
 
-* Add a `.modal-dialog` container, with a `.modal-dialog__inner` content container.
-* Add one or more `.modal-dialog__content` container blocks
-* Add a 'close' element in each `.modal-dialog__content`
-  * `<button data-modaldialog-action="close">...</button>`
-  * `<a href="#" data-modaldialog-action="close">...</a>`
-* Add the following attributes to each `.modal-dialog__content`
-  * `role="..."` - value can be "dialog" or "alertdialog".
-  * `tabindex="1"` - value *must* be "1".
-  * `aria-labelledby="..."` - apply the id value for the content's heading.
-  * `aria-describedby="..."` - apply the id value for the block element containing text describing the dialog purpose / message.
-  * `data-ga-open-event` - google analytics 'open' event is fired when dialog content becomes visible.
+Experimental: **Before considering a [modal dialog box](https://designpatterns.hackpad.com/Modal-dialog-boxes-ZJNqssq4Dll), make sure that you have strong evidence that:**
+* There is a real user need to have attention focused on a single piece of content;
+* That need cannot be met by taking the user to a new page in the same flow that contains the crucial piece of content;
 
+
+To create and use the experimental modal dialog component:
+  * Add a `.modal-dialog` container, with a `.modal-dialog__inner` content container.
+  * Add one or more `.modal-dialog__content` container blocks
+  * Add a 'close' element in each `.modal-dialog__content`
+    * `<button data-modaldialog-action="close">...</button>`
+    * `<a href="#" data-modaldialog-action="close">...</a>`
+  * Add the following attributes to each `.modal-dialog__content`
+    * `role="..."` - value can be "dialog" or "alertdialog".
+    * `tabindex="1"` - value *must* be "1".
+    * `aria-labelledby="..."` - apply the id value for the content's heading.
+    * `aria-describedby="..."` - apply the id value for the block element containing text describing the dialog purpose / message.
+    * `data-ga-open-event` - google analytics 'open' event is fired when dialog content becomes visible.
 
 
 | *Required libraries / modules*: |  |  | 
@@ -54,16 +42,16 @@ Markup:
        <div id="content-1" class="modal-dialog__content" data-ga-open-event="::" tabindex="1" role="dialog" aria-labelledby="heading-id" aria-describedby="message-id">
          <div id="message-id">
            <h2 id="heading-id">content 1 heading</h2>
-           <p>&lt;!-- content here --></p>
+           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at egestas ex. Fusce vulputate semper nisl sit amet imperdiet. Praesent hendrerit ac lorem eleifend vehicula. Nunc tincidunt sagittis purus feugiat volutpat. Cras a arcu odio. Praesent aliquet, tellus at commodo sagittis, odio ligula pulvinar leo, et fringilla nisl massa in metus. Vivamus sollicitudin lacus dolor, dapibus sodales ex pulvinar et. Proin scelerisque venenatis congue. Praesent sit amet velit ut mauris fringilla mattis vel a risus. Proin lobortis vestibulum leo sit amet commodo. Maecenas non urna nisi.</p> 
            <button role="button" class="button button" data-journey-click="::"
              data-modaldialog-action="close" tabindex="1">Close</button>
             <button role="button" class="button button--secondary" data-journey-click="::" data-modaldialog-action="open" data-modaldialog-target="content-2" tabindex="1">Open other dialog</button>
-       </div>
+          </div>
        </div>
        <div id="content-2" class="modal-dialog__content" data-ga-open-event="::" tabindex="1" role="dialog" aria-labelledby="heading-id-2" aria-describedby="message-id-2" hidden>
          <div id="message-id-2">
            <h2 id="heading-id-2">content 2 heading</h2>
-           <p>&lt;!-- content here --></p>
+            <p>Phasellus sapien mi, rutrum eu lacinia et, pulvinar sit amet risus. Donec mi odio, tincidunt eu malesuada at, elementum at nunc. Donec lobortis massa sed sollicitudin malesuada. Suspendisse mattis ultrices tristique. Aenean et sollicitudin odio. Morbi varius ultrices neque, ut tincidunt sapien imperdiet nec. Pellentesque bibendum sem sit amet elit condimentum facilisis. In ornare sapien lorem, a molestie lectus blandit sit amet.</p> 
            <a href="#" data-modaldialog-action="close" tabindex="1" data-journey-click="::">Close</a>
          </div>
        </div>

--- a/assets/scss/modules/_modal-dialog.scss
+++ b/assets/scss/modules/_modal-dialog.scss
@@ -1,0 +1,137 @@
+/*
+Modal Dialog
+
+An accessibility compliant & responsive modal dialog box module.
+
+<table style="border-left: 4px solid #AF1324; background-color: rgba(173, 19, 37, 0.1);">
+    <tr>
+        <td style="border-bottom-width: 0;padding-left: 4px;font-size: 19px;font-weight: bold;color: #AF1324;line-height: 1.31579;">Experimental</td>
+    </tr>
+    <tr>
+        <td style="border-bottom-width: 0;padding-left: 8px;font-size: 19px;line-height: 1.31579;">
+          Before considering a [modal dialog box](https://designpatterns.hackpad.com/Modal-dialog-boxes-ZJNqssq4Dll]), *make sure that you have strong evidence* that:
+        </td>
+    </tr>
+    <tr>
+        <td style="border-bottom-width: 0;padding-left: 16px;font-size: 19px;line-height: 1.31579;">
+          <ul>
+              <li>There is a real user need to have attention focused on a single piece of content.</li>
+              <li>That need cannot be met by taking the user to a new page in the same flow that contains the crucial piece of content.</li>
+            </ul>
+        </td>
+    </tr>
+</table>
+
+* Add a `.modal-dialog` container, with a `.modal-dialog__inner` content container.
+* Add one or more `.modal-dialog__content` container blocks
+* Add a 'close' element in each `.modal-dialog__content`
+  * `<button data-modaldialog-action="close">...</button>`
+  * `<a href="#" data-modaldialog-action="close">...</a>`
+* Add the following attributes to each `.modal-dialog__content`
+  * `role="..."` - value can be "dialog" or "alertdialog".
+  * `tabindex="1"` - value *must* be "1".
+  * `aria-labelledby="..."` - apply the id value for the content's heading.
+  * `aria-describedby="..."` - apply the id value for the block element containing text describing the dialog purpose / message.
+  * `data-ga-open-event` - google analytics 'open' event is fired when dialog content becomes visible.
+
+
+
+| *Required libraries / modules*: |  |  | 
+| ------- | ----------- | ------------- |
+| javascript/modules/modal-dialog.js |  jquery | stageprompt | 
+
+| *References*: |
+| ------- | 
+| [Modal dialog boxes - designpatterns.hackpad.com](https://designpatterns.hackpad.com/Modal-dialog-boxes-ZJNqssq4Dll) |
+| [Using the dialog role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_dialog_role) |
+| [Making an accessible dialog box - NCZOnline](https://www.nczonline.net/blog/2013/02/12/making-an-accessible-dialog-box/) |
+| [HTML5 Accessibility Chops: hidden and aria-hidden](https://www.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/) |
+
+
+Markup:
+<div class="modal-dialog">
+    <div class="modal-dialog__inner">
+       <div id="content-1" class="modal-dialog__content" data-ga-open-event="::" tabindex="1" role="dialog" aria-labelledby="heading-id" aria-describedby="message-id">
+         <div id="message-id">
+           <h2 id="heading-id">content 1 heading</h2>
+           <p>&lt;!-- content here --></p>
+           <button role="button" class="button button" data-journey-click="::"
+             data-modaldialog-action="close" tabindex="1">Close</button>
+            <button role="button" class="button button--secondary" data-journey-click="::" data-modaldialog-action="open" data-modaldialog-target="content-2" tabindex="1">Open other dialog</button>
+       </div>
+       </div>
+       <div id="content-2" class="modal-dialog__content" data-ga-open-event="::" tabindex="1" role="dialog" aria-labelledby="heading-id-2" aria-describedby="message-id-2" hidden>
+         <div id="message-id-2">
+           <h2 id="heading-id-2">content 2 heading</h2>
+           <p>&lt;!-- content here --></p>
+           <a href="#" data-modaldialog-action="close" tabindex="1" data-journey-click="::">Close</a>
+         </div>
+       </div>
+   </div>
+ </div>
+
+
+Style guide: Modal Dialog
+*/
+
+body {
+  &.scroll-off {
+    position: fixed;
+    width: 100%;
+  }
+}
+.modal-dialog {
+  &.modal-dialog--hidden {
+    @include set-square-clip(true, 1);
+    @include set-square-clip(false, 1);
+    border: 0;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+    z-index: 0;
+    &:focus {
+      clip: auto;
+      height: auto;
+      overflow: auto;
+      position: relative;
+      width: auto;
+    }
+  }
+  background-color: $mask-opacity;
+  left: 0;
+  overflow: scroll;
+  position: fixed;
+  top: 0;
+  z-index: 1;
+}
+.modal-dialog__content {
+  &:focus {
+    outline: 3px solid $modal-dialog-yellow;
+  }
+  padding: em(7) em(32);
+  position: static;
+  @include media(mobile) {
+    [role="button"][data-modaldialog-action="close"] {
+      width: 100%;
+    }
+  }
+}
+.modal-dialog__inner {
+  background-color: $white;
+  border: em(5) solid $black;
+  left: 0;
+  margin: em(130) auto 0;
+  max-width: 90%;
+  overflow-y: auto;
+  padding: em(8);
+  position: fixed;
+  right: 0;
+  top: 0;
+  @include media(desktop) {
+    margin: em(130) 25% 0;
+    max-width: em(720);
+  }
+}

--- a/assets/scss/modules/_modal-dialog.scss
+++ b/assets/scss/modules/_modal-dialog.scss
@@ -1,66 +1,53 @@
 /* 
 Modal Dialog
 
+Experimental:  An accessibility compliant & responsive modal dialog box module.
 
-An accessibility compliant & responsive modal dialog box module.
-
-
-Experimental: 
 **Before considering a [modal dialog box](https://designpatterns.hackpad.com/Modal-dialog-boxes-ZJNqssq4Dll), make sure that you have strong evidence that:**
 * There is a real user need to have attention focused on a single piece of content;
 * That need cannot be met by taking the user to a new page in the same flow that contains the crucial piece of content;
 
 
-To create and use the experimental modal dialog component:
-  * Add a `.modal-dialog` container, with a `.modal-dialog__inner` content container.
-  * Add one or more `.modal-dialog__content` container blocks
-  * Add a 'close' element in each `.modal-dialog__content`
-    * `<button data-modaldialog-action="close">...</button>`
-    * `<a href="#" data-modaldialog-action="close">...</a>`
-  * Add the following attributes to each `.modal-dialog__content`
-    * `role="..."` - value can be "dialog" or "alertdialog".
-    * `tabindex="1"` - value *must* be "1".
-    * `aria-labelledby="..."` - apply the id value for the content's heading.
-    * `aria-describedby="..."` - apply the id value for the block element containing text describing the dialog purpose / message.
-    * `data-ga-open-event` - google analytics 'open' event is fired when dialog content becomes visible.
-
-
-| *Required libraries / modules*: |  |  | 
-| ------- | ----------- | ------------- |
-| javascript/modules/modal-dialog.js |  jquery | stageprompt | 
-
-| *References*: |
-| ------- | 
-| [Modal dialog boxes - designpatterns.hackpad.com](https://designpatterns.hackpad.com/Modal-dialog-boxes-ZJNqssq4Dll) |
-| [Using the dialog role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_dialog_role) |
-| [Making an accessible dialog box - NCZOnline](https://www.nczonline.net/blog/2013/02/12/making-an-accessible-dialog-box/) |
-| [HTML5 Accessibility Chops: hidden and aria-hidden](https://www.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/) |
-
-
 Markup:
 <div class="modal-dialog">
-    <div class="modal-dialog__inner">
-       <div id="content-1" class="modal-dialog__content" data-ga-open-event="::" tabindex="1" role="dialog" aria-labelledby="heading-id" aria-describedby="message-id">
-           <h2 id="heading-id">content 1 heading</h2>
-           <div id="message-id">
-             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at egestas ex. Fusce vulputate semper nisl sit amet imperdiet. Praesent hendrerit ac lorem eleifend vehicula. Nunc tincidunt sagittis purus feugiat volutpat. Cras a arcu odio. Praesent aliquet, tellus at commodo sagittis, odio ligula pulvinar leo, et fringilla nisl massa in metus. Vivamus sollicitudin lacus dolor, dapibus sodales ex pulvinar et.</p> 
-          </div>
-          <div>
-            <button role="button" class="button button" data-journey-click="::"
-               data-modaldialog-action="close" tabindex="1">Close</button>
-            <button role="button" class="button button--secondary" data-journey-click="::" data-modaldialog-action="open" data-modaldialog-target="content-2" tabindex="1">Open other dialog</button>
-          </div>
-       </div>
-       <div id="content-2" class="modal-dialog__content" data-ga-open-event="::" tabindex="1" role="dialog" aria-labelledby="heading-id-2" aria-describedby="message-id-2" hidden>
-        <h2 id="heading-id-2">content 2 heading</h2>
-        <div id="message-id-2">
-          <p>Proin scelerisque venenatis congue. Praesent sit amet velit ut mauris fringilla mattis vel a risus. Proin lobortis vestibulum leo sit amet commodo. Maecenas non urna nisi. Phasellus sapien mi, rutrum eu lacinia et, pulvinar sit amet risus. Donec mi odio, tincidunt eu malesuada at, elementum at nunc. Donec lobortis massa sed sollicitudin malesuada. Suspendisse mattis ultrices tristique. Aenean et sollicitudin odio. Morbi varius ultrices neque, ut tincidunt sapien imperdiet nec. Pellentesque bibendum sem sit amet elit condimentum facilisis. In ornare sapien lorem, a molestie lectus blandit sit amet.</p> 
+  <div class="modal-dialog__inner">
+    <div id="removing-clients" class="modal-dialog__content" tabindex="1" data-ga-open-event="client-list:Open:Removing clients dialog" role="dialog" aria-labelledby="removing-clients--heading" aria-describedby="removing-clients--description" hidden>
+      <h2 id="removing-clients--heading">What does removing a client do?</h2>
+      <div id="removing-clients--description">
+        <p>When you remove a client you give up the authorisation this client has given you to act for them.</p>
+        <p>Your authorisation will be removed from both HMRC’s services and the Government Gateway.</p>
+        <p>This means you won’t be able to:</p>
+        <ul class="bullets">
+          <li>act for this client online, in writing or on the phone</li>
+          <li>see this client’s information online</li>
+        </ul>
+        <p>
+          You can use the <a id="online-auth-service" href="https://www.gov.uk/guidance/payecis-for-agents-online-service" class="link" rel="external" target="_blank" tabindex="1" data-journey-click="modal-removing-clients:Click:online-auth-service">online authorisation service</a>, if you want to restore your authorisation.
+        </p>
+      </div>
+      <p>
+        <button class="button button--secondary" role="button" data-modaldialog-action="close" type="button" tabindex="1" data-journey-click="client-list:Click:Removing clients dialog close">Close</button>
+      </p>
+    </div>
+    <div id="deleting-client" class="modal-dialog__content" tabindex="1" role="dialog" data-ga-open-event="client-list:Open:Deleting clients dialog" aria-labelledby="deleting-clients--heading" aria-describedby="deleting-clients--description">
+      <h2 id="deleting-clients--heading">Before you access your clients' accounts</h2>
+      <div id="deleting-clients--description">
+        <p>You must:</p>
+        <ul class="bullets">
+          <li>confirm the clients you represent</li>
+          <li>remove anyone you no longer represent</li>
+        </ul>
+        <div class="highlight-message highlight-message--light highlight-message--indent alert--borderless soft--ends">
+          <p id="deleting-clients--message" class="bold-small flush--ends">You may be in breach of the Data Protection Act if you dont remove old clients you no longer represent.</p>
         </div>
-        <div><a href="#" data-modaldialog-action="close" tabindex="1" data-journey-click="::">Close</a></div>
-     </div>
-   </div>
- </div>
-
+      </div>
+      <p>
+        <button class="button" role="button" data-modaldialog-action="close" tabindex="1" data-journey-click="client-list:Click:Deleting clients dialog close">Continue</button>
+        <a href="#" class="button button--link" role="button" data-journey-click="::" data-modaldialog-action="open" data-modaldialog-target="removing-clients" tabindex="1">More...</a>
+      </p>
+    </div>
+  </div>
+</div>
 
 Style guide: Modal Dialog
 */

--- a/assets/scss/modules/_modal-dialog.scss
+++ b/assets/scss/modules/_modal-dialog.scss
@@ -5,7 +5,8 @@ Modal Dialog
 An accessibility compliant & responsive modal dialog box module.
 
 
-Experimental: **Before considering a [modal dialog box](https://designpatterns.hackpad.com/Modal-dialog-boxes-ZJNqssq4Dll), make sure that you have strong evidence that:**
+Experimental: 
+**Before considering a [modal dialog box](https://designpatterns.hackpad.com/Modal-dialog-boxes-ZJNqssq4Dll), make sure that you have strong evidence that:**
 * There is a real user need to have attention focused on a single piece of content;
 * That need cannot be met by taking the user to a new page in the same flow that contains the crucial piece of content;
 
@@ -40,21 +41,23 @@ Markup:
 <div class="modal-dialog">
     <div class="modal-dialog__inner">
        <div id="content-1" class="modal-dialog__content" data-ga-open-event="::" tabindex="1" role="dialog" aria-labelledby="heading-id" aria-describedby="message-id">
-         <div id="message-id">
            <h2 id="heading-id">content 1 heading</h2>
-           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at egestas ex. Fusce vulputate semper nisl sit amet imperdiet. Praesent hendrerit ac lorem eleifend vehicula. Nunc tincidunt sagittis purus feugiat volutpat. Cras a arcu odio. Praesent aliquet, tellus at commodo sagittis, odio ligula pulvinar leo, et fringilla nisl massa in metus. Vivamus sollicitudin lacus dolor, dapibus sodales ex pulvinar et. Proin scelerisque venenatis congue. Praesent sit amet velit ut mauris fringilla mattis vel a risus. Proin lobortis vestibulum leo sit amet commodo. Maecenas non urna nisi.</p> 
-           <button role="button" class="button button" data-journey-click="::"
-             data-modaldialog-action="close" tabindex="1">Close</button>
+           <div id="message-id">
+             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at egestas ex. Fusce vulputate semper nisl sit amet imperdiet. Praesent hendrerit ac lorem eleifend vehicula. Nunc tincidunt sagittis purus feugiat volutpat. Cras a arcu odio. Praesent aliquet, tellus at commodo sagittis, odio ligula pulvinar leo, et fringilla nisl massa in metus. Vivamus sollicitudin lacus dolor, dapibus sodales ex pulvinar et.</p> 
+          </div>
+          <div>
+            <button role="button" class="button button" data-journey-click="::"
+               data-modaldialog-action="close" tabindex="1">Close</button>
             <button role="button" class="button button--secondary" data-journey-click="::" data-modaldialog-action="open" data-modaldialog-target="content-2" tabindex="1">Open other dialog</button>
           </div>
        </div>
        <div id="content-2" class="modal-dialog__content" data-ga-open-event="::" tabindex="1" role="dialog" aria-labelledby="heading-id-2" aria-describedby="message-id-2" hidden>
-         <div id="message-id-2">
-           <h2 id="heading-id-2">content 2 heading</h2>
-            <p>Phasellus sapien mi, rutrum eu lacinia et, pulvinar sit amet risus. Donec mi odio, tincidunt eu malesuada at, elementum at nunc. Donec lobortis massa sed sollicitudin malesuada. Suspendisse mattis ultrices tristique. Aenean et sollicitudin odio. Morbi varius ultrices neque, ut tincidunt sapien imperdiet nec. Pellentesque bibendum sem sit amet elit condimentum facilisis. In ornare sapien lorem, a molestie lectus blandit sit amet.</p> 
-           <a href="#" data-modaldialog-action="close" tabindex="1" data-journey-click="::">Close</a>
-         </div>
-       </div>
+        <h2 id="heading-id-2">content 2 heading</h2>
+        <div id="message-id-2">
+          <p>Proin scelerisque venenatis congue. Praesent sit amet velit ut mauris fringilla mattis vel a risus. Proin lobortis vestibulum leo sit amet commodo. Maecenas non urna nisi. Phasellus sapien mi, rutrum eu lacinia et, pulvinar sit amet risus. Donec mi odio, tincidunt eu malesuada at, elementum at nunc. Donec lobortis massa sed sollicitudin malesuada. Suspendisse mattis ultrices tristique. Aenean et sollicitudin odio. Morbi varius ultrices neque, ut tincidunt sapien imperdiet nec. Pellentesque bibendum sem sit amet elit condimentum facilisis. In ornare sapien lorem, a molestie lectus blandit sit amet.</p> 
+        </div>
+        <div><a href="#" data-modaldialog-action="close" tabindex="1" data-journey-click="::">Close</a></div>
+     </div>
    </div>
  </div>
 

--- a/assets/scss/modules/_notifications.scss
+++ b/assets/scss/modules/_notifications.scss
@@ -167,8 +167,17 @@
 }
 
 .highlight-message--dark {
+  .highlight-message--dark-text {
+    color: $white;
+  }
+  
   background-color: $govuk-blue-colour;
-  color: #fff;
+  color: $white;
   padding-bottom: em(30);
 }
 
+.highlight-message--light {
+  background-color: $white;
+  color: $black;
+  padding-bottom: em(30);
+}

--- a/assets/test/specs/fixtures/modal-dialog.html
+++ b/assets/test/specs/fixtures/modal-dialog.html
@@ -1,0 +1,31 @@
+<body>
+    <p tabindex="1">tab index test dummy para</p>
+    <a href="#">tab index test dummy link</a>
+    <button role="button">tab index dummy button</button>
+    <div class="modal-dialog" role="dialog">
+        <div class="modal-dialog__inner">
+            <div id="content-1" class="modal-dialog__content" data-ga-open-event="modal-dialog:Open:content-1 dialog" tabindex="1" role="dialog" aria-labelledby="heading-id" aria-describedby="message-id" hidden>
+                <div id="message-id">
+                    <h2 id="heading-id">content 1 heading</h2>
+                    <button role="button" class="button button--secondary" data-modaldialog-action="close" tabindex="1">close</button>
+                    <a tabindex="1" href="#" data-journey-click="modal-dialog:Click:content-2 dialog open content-1" data-modaldialog-action="open" data-modaldialog-target="content-2">open content 2</a>
+                </div>
+            </div>
+            <div id="content-2" class="modal-dialog__content" data-ga-open-event="modal-dialog:Open:content-2 dialog" tabindex="1" role="dialog" aria-labelledby="heading-id-2" aria-describedby="message-id-2">
+                <div id="message-id-2">
+                    <h2 id="heading-id-2">content 2 heading</h2>
+                    <a href="#" data-modaldialog-action="close" tabindex="1" data-journey-click="modal-dialog:Click:content-2 dialog close">...</a>
+                    <button role="button" class="button button--secondary">fake button (no tabindex)</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="document-actions" id="content-1-actions">
+        <a class="" href="#" data-journey-click="modal-dialog:Click:content-1 dialog document open control" data-modaldialog-action="open" data-modaldialog-target="content-1">open content 1</a>
+        <button role="button" class="button" data-journey-click="modal-dialog:Click:content-1 dialog document close control" data-modaldialog-action="close" data-modaldialog-target="content-1">close content 1</button>
+    </div>
+    <div class="document-actions" id="content-2-actions">
+        <a class="" href="#" data-journey-click="modal-dialog:Click:content-2 dialog document close control" data-modaldialog-action="close" data-modaldialog-target="content-2">close content 2</a>
+        <button role="button" class="button" data-journey-click="modal-dialog:Click:content-2 dialog document open control" data-modaldialog-action="open" data-modaldialog-target="content-2">open content 2</button>
+    </div>
+</body>

--- a/assets/test/specs/modalDialog.spec.js
+++ b/assets/test/specs/modalDialog.spec.js
@@ -1,0 +1,229 @@
+require('jquery');
+window._gaq = [];
+var modalDialog, $body, $actions, $modalDialog, $inner,  $content1, $content2, $actions1, $actions2;
+
+describe('Given I have a modal-dialog module on the page', function() {
+
+  beforeEach(function() {
+    jasmine.getFixtures().fixturesPath = 'base/specs/fixtures/';
+    loadFixtures('modal-dialog.html');
+    
+    modalDialog = require('../../javascripts/modules/modalDialog.js');
+    
+    $body = $('body');
+    $actions = $('.document-actions');
+    $modalDialog = $('.modal-dialog');
+    $inner = $('.modal-dialog__inner');
+    $content1 = $('#content-1');
+    $content2 = $('#content-2');
+    $actions1 = $('#content-1-actions');
+    $actions2 = $('#content-2-actions');
+  });
+
+  // open / close
+  describe('loading the page', function() {
+    beforeEach(function() {
+      modalDialog();
+    });
+    it('should show content 1 is hidden, and content 2 is visible', function() {
+      expect($content1.is(':not(:visible)')).toBe(true);
+      expect($content2.is(':visible')).toBe(true);
+    });
+  });
+
+  describe('closing the modal-dialog', function() {
+    beforeEach(function() {
+      modalDialog();
+    });
+
+    describe('by clicking a [data-modaldialog-action="close"] control in modal-dialog content', function() {
+      var $contentCloseLink;
+
+      beforeEach(function() {
+        $contentCloseLink = $content2.find('a[data-modaldialog-action="close"]');
+        expect($contentCloseLink.length).toBe(1);
+        $contentCloseLink.click();
+      });
+      
+      it('should hide content', function() {
+        expect($content2.is(':not(:visible)')).toBe(true);
+        expect($content1.is(':not(:visible)')).toBe(true);
+      });
+      
+      it("should make the body scroll-able", function(){
+        expect($body.hasClass('scroll-off')).toBe(false);
+      });
+
+      it("should hide the modal-dialog", function(){
+        expect($modalDialog.hasClass('modal-dialog--hidden')).toBe(true);
+      });
+    });
+
+    describe('by clicking a [data-modaldialog-action="close"] control in document content', function() {
+      var $documentCloseLink;
+
+      beforeEach(function() {
+        $documentCloseLink = $actions.find('[data-modaldialog-action="close"][data-modaldialog-target="content-2"]');
+        expect($documentCloseLink.length).toBe(1);
+        $documentCloseLink.click();
+      });
+
+      it('should hide content', function() {
+        expect($content2.is(':not(:visible)')).toBe(true);
+        expect($content1.is(':not(:visible)')).toBe(true);
+      });
+
+      it("should make the body scroll-able", function(){
+        expect($body.hasClass('scroll-off')).toBe(false);
+      });
+
+      it("should hide the modal-dialog", function(){
+        expect($modalDialog.hasClass('modal-dialog--hidden')).toBe(true);
+      });
+    });
+    
+    it('should occur when user uses escape key', function() {
+      $documentOpenLink = $actions.find('[data-modaldialog-action="open"][data-modaldialog-target="content-1"]');
+      
+      simulateKeyEvent($content2, 'keyup', 27);
+      
+      expect($content2.is(':not(:visible)')).toBe(true);
+      expect($content1.is(':not(:visible)')).toBe(true);
+      expect($body.hasClass('scroll-off')).toBe(false);
+      expect($modalDialog.hasClass('modal-dialog--hidden')).toBe(true);
+    });
+  });
+
+  describe('opening the modal-dialog', function() {
+    beforeEach(function() {
+      modalDialog();
+    });
+
+    describe('by clicking a [data-modaldialog-action="open"] control in modal-dialog content', function() {
+      beforeEach(function() {
+        $content2.find('a[data-modaldialog-action="close"]').click();
+        expect($content2.is(':not(:visible)')).toBe(true);
+        expect($content1.is(':not(:visible)')).toBe(true);
+        $actions.find('[data-modaldialog-action="open"][data-modaldialog-target="content-1"]').click();
+      });
+
+      it('should make content visible', function() {
+        expect($content2.is(':not(:visible)')).toBe(true);
+        expect($content1.is(':visible')).toBe(true);
+
+        var $contentOpen = $content1.find('[data-modaldialog-action="open"][data-modaldialog-target="content-2"]');
+        expect($contentOpen.length).toBe(1);
+        $contentOpen.click();
+
+        expect($content1.is(':not(:visible)')).toBe(true);
+        expect($content2.is(':visible')).toBe(true);
+
+        expect($body.hasClass('scroll-off')).toBe(true);
+        expect($modalDialog.hasClass('modal-dialog--hidden')).toBe(false);
+      });
+    });
+  
+    describe('by clicking a [data-modaldialog-action="open"] control in document content', function () {
+      var $documentOpenLink;
+
+      beforeEach(function () {
+        // close the modal-dialog
+        $actions.find('[data-modaldialog-action="close"][data-modaldialog-target="content-2"]').click();
+        expect($content2.is(':not(:visible)')).toBe(true);
+        expect($content1.is(':not(:visible)')).toBe(true);
+
+        $documentOpenLink = $actions.find('[data-modaldialog-action="open"][data-modaldialog-target="content-1"]');
+        expect($documentOpenLink.length).toBe(1);
+
+        $documentOpenLink.click();
+      });
+
+      it('should make content visible', function() {
+        expect($content2.is(':not(:visible)')).toBe(true);
+        expect($content1.is(':visible')).toBe(true);
+      });
+
+      it("should make the body not scroll-able", function(){
+        expect($body.hasClass('scroll-off')).toBe(true);
+      });
+
+      it("should show the modal-dialog", function(){
+        expect($modalDialog.hasClass('modal-dialog--hidden')).toBe(false);
+      });
+
+    });
+  });  
+  
+  
+  // tabbing 
+  describe("the open modal-dialog", function() {
+    beforeEach(function() {
+      modalDialog();
+    });
+    
+    it("should retain focus when the user clicks elsewhere on the page", function() {
+      expect($(document.activeElement).is($content2)).toBe(true);
+      $('body').click();
+      expect($(document.activeElement).is($content2)).toBe(true);
+    });
+    
+    describe("when content is navigated with tab key", function() {
+      var $documentOpenLink;
+    
+      beforeEach(function() {
+        $documentOpenLink = $actions.find('[data-modaldialog-action="open"][data-modaldialog-target="content-1"]');
+        expect($documentOpenLink.length).toBe(1);
+
+        $documentOpenLink.click();
+      });
+
+      it("should return to the first tab-indexed item after the last", function() {
+        // item in focus is modal-dialog__content block
+        expect($(document.activeElement).is($content1)).toBe(true);
+        expect($(document.activeElement).hasClass('modal-dialog__content')).toBe(true);
+        
+        simulateKeyEvent($(document.activeElement), 'keydown', 9);
+        // item in focus is <button/> content close control link
+        expect($content1.find($(document.activeElement)).length).toBe(1);
+        expect($(document.activeElement).data('modaldialogAction')).toBe('close');
+        
+        simulateKeyEvent($(document.activeElement), 'keydown', 9);
+        // item in focus is <a/> content open control link
+        expect($content1.find($(document.activeElement)).length).toBe(1);
+        expect($(document.activeElement).data('modaldialogAction')).toBe('open');
+        
+        simulateKeyEvent($(document.activeElement), 'keydown', 9);
+        expect($(document.activeElement).is($content1)).toBe(true);
+        expect($(document.activeElement).hasClass('modal-dialog__content')).toBe(true);
+      });
+
+      it("should move to the last tab-indexed item after the first when shift key is used, ", function() {
+        // item in focus is modal-dialog__content block
+        expect($(document.activeElement).is($content1)).toBe(true);
+        expect($(document.activeElement).hasClass('modal-dialog__content')).toBe(true);
+
+        simulateKeyEvent($(document.activeElement), 'keydown', 9, true);
+        // item in focus is <a/> content open control link
+        expect($content1.find($(document.activeElement)).length).toBe(1);
+        expect($(document.activeElement).data('modaldialogAction')).toBe('open');
+        
+        simulateKeyEvent($(document.activeElement), 'keydown', 9, true);
+        // item in focus is <button/> content close control link
+        expect($content1.find($(document.activeElement)).length).toBe(1);
+        expect($(document.activeElement).data('modaldialogAction')).toBe('close');
+
+        simulateKeyEvent($(document.activeElement), 'keydown', 9, true);
+        expect($(document.activeElement).is($content1)).toBe(true);
+        expect($(document.activeElement).hasClass('modal-dialog__content')).toBe(true);
+        
+      });
+    });
+  });
+});
+
+function simulateKeyEvent($dom, type, keyCode, shiftKey) {
+  var e = $.Event(type);
+  e.which = keyCode;
+  e.shiftKey = shiftKey || false;
+  return $dom.trigger(e);
+}


### PR DESCRIPTION
[AOSS-1057]
 - adds accessible & responsive modal-dialog module CSS and JavaScript (_modal-dialog.scss, modalDialog.js)
 - adds modal dialog module test specs and fixture
 - includes update to modules/_notifications.scss
   - adds '.highlight-message--light' variant
      - black message on white background
   - updates  '.highlight-message--dark' variant
      - adds '.highlight-message--dark-text' to enable specific styling of child elements


![Modal Dialog module](https://cloud.githubusercontent.com/assets/5468091/13431081/beba1cfc-dfbf-11e5-8d5f-b8759301ad21.gif)

![Modal Dialog module - with VoiceOver utility output](https://cloud.githubusercontent.com/assets/5468091/13431140/fad2d4e0-dfbf-11e5-8b5c-67944c7831a8.gif)
