### PR TITLE
Nisp 1652 skip link focused to content

### DIFF
--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -12,16 +12,16 @@
   padding: 0.75em 1em;
 }
 
-@mixin page-slice () {
+@mixin page-slice ($paddingBottom: 0) {
   @extend %contain-floats;
   display: block;
   max-width: 960px;
   margin: 0 auto;
-  padding: 0 15px;
+  padding: 0 em(15) em($paddingBottom) em(15);
   line-height: 1.5;
   @include core-19();
 
   @include media(tablet) {
-    padding: 0 30px;
+    padding: 0 em(30) em($paddingBottom) em(30);
   }
 }

--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -11,3 +11,17 @@
   border-left: $border-width solid $error-border-color;
   padding: 0.75em 1em;
 }
+
+@mixin page-slice () {
+  @extend %contain-floats;
+  display: block;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 15px;
+  line-height: 1.5;
+  @include core-19();
+
+  @include media(tablet) {
+    padding: 0 30px;
+  }
+}

--- a/assets/scss/base/_layouts.scss
+++ b/assets/scss/base/_layouts.scss
@@ -10,32 +10,21 @@ body {
   counter-reset: section;
 }
 
+#wrapper {
+  text-align: left;
+}
+
 #content {
-  @extend %contain-floats;
-  display: block;
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 0 15px 2em 15px;
-  @include media(tablet) {
-    padding: 0 30px 2em 30px;
-  }
+  @include page-slice(32);
+}
+
+.centered-content {
+  @include page-slice();
 }
 
 .full-width-banner {
   background-color: $govuk-blue-colour;
   position: relative;
-}
-
-.centered-content {    
-  @extend %contain-floats;
-  overflow: auto;
-  display: block;
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 0 15px 0 15px;
-  @include media(tablet) {
-    padding: 0 30px 0 30px;
-  }
 }
 
 .content__body {


### PR DESCRIPTION
# Skip Link Accessibility
On request from Chris Moore so the skip link focuses on#content rather than service info.

> This work is backwardly compatible with teams with older versions of play-ui and new assets-frontend

* Related `play-ui` PR https://github.com/hmrc/play-ui/pull/41
* Related ticket NISP-1652

### Of Note
I have moved common parts into a `@mixin` and added a few overrides for selectors `#wrapper` and `#content` which brings the code into our `.sass` files rather than `govuk_elements`
I have commented, and will raise issues once merged.



## Example
![skip-link](https://cloud.githubusercontent.com/assets/2305016/13470288/6498022c-e0a3-11e5-8f73-a9f0c44ae0aa.gif)

## Example - responsive
![skip-link-repsonsive](https://cloud.githubusercontent.com/assets/2305016/13470302/77816eaa-e0a3-11e5-8f34-24c575327472.gif)

## Example - new play-ui markup
![screen shot 2016-03-02 at 17 43 41](https://cloud.githubusercontent.com/assets/2305016/13470348/ac8c8f9e-e0a3-11e5-8a08-bbbbe34fad77.png)

## Example - old play-ui markup

![screen shot 2016-03-02 at 18 25 40](https://cloud.githubusercontent.com/assets/2305016/13470472/3948970c-e0a4-11e5-9b3b-740ea8542310.png)