### PR TITLE
[API-1086] Update to mask component to add optional timeout

### DIFF
--- a/assets/javascripts/modules/mask.js
+++ b/assets/javascripts/modules/mask.js
@@ -6,7 +6,7 @@ Mask content and show or hide it.
 
 Example:
 
-<div class="js-mask-container">
+<div class="js-mask-container" data-mask-timer="20">
   <span>
     <span class="js-visible js-mask-secret">mask</span>
     <span class="js-hidden js-mask-revealed">secret</span>
@@ -26,24 +26,51 @@ var maskControlEvent = function ($containerElem) {
   var $control = $containerElem.find('.js-mask-control').first();
   var $publicContent = $containerElem.find('.js-mask-revealed').first();
   var $secretContent = $containerElem.find('.js-mask-secret').first();
-  var showText = $control.data('textShow');
-  var hideText = $control.data('textHide');
+  var secondsToTimeout = $containerElem.data('mask-timer');
 
-  $control.on('click', function (event) {
-    event.preventDefault();
-
+  $control.on('click', function(event) {
     var text = $control.text();
 
-    $publicContent.toggleClass('js-visible').toggleClass('js-hidden');
-    $secretContent.toggleClass('js-visible').toggleClass('js-hidden');
-    $control.text(text === showText ? hideText : showText);
+    event.preventDefault();
+
+    toggleState(text, $control, $publicContent, $secretContent);
+
+    // start timer if it's configured
+    if(secondsToTimeout) {
+      startTimer(text, $control, $publicContent, $secretContent, secondsToTimeout);
+    }
+
   });
+
 };
 
 var addListeners = function () {
-  $maskContainerElems.each(function (index, containerElem) {
+  $maskContainerElems.each(function(index, containerElem) {
     maskControlEvent($(containerElem));
   });
+};
+
+var toggleState = function(text, $control, $publicContent, $secretContent) {
+
+  var showText = $control.data('textShow');
+  var hideText = $control.data('textHide');
+
+  $publicContent.toggleClass('js-visible').toggleClass('js-hidden');
+  $secretContent.toggleClass('js-visible').toggleClass('js-hidden');
+  $control.text(text === showText ? hideText : showText);
+
+};
+
+var startTimer = function(text, $control, $publicContent, $secretContent, secondsToTimeout) {
+
+  setTimeout(function() {
+
+    if($publicContent.is(':visible')) {
+      toggleState("Hide", $control, $publicContent, $secretContent);
+    }
+
+  }, parseFloat(secondsToTimeout, 10) * 1000);
+
 };
 
 module.exports = function () {

--- a/assets/test/specs/fixtures/mask-fixture.html
+++ b/assets/test/specs/fixtures/mask-fixture.html
@@ -5,7 +5,7 @@
   </span>
   <a href="#" class="js-visible js-mask-control qa-mask-control" data-text-show="Show" data-text-hide="Hide">Show</a>
 </div>
-<div id="fixture-two" class="js-mask-container">
+<div id="fixture-two" class="js-mask-container" data-mask-timer="0.145">
   <span>
     <span class="js-visible js-mask-secret qa-mask">*******************</span>
     <span class="js-hidden js-mask-revealed qa-secret">aDifferentSecret</span>

--- a/assets/test/specs/mask.spec.js
+++ b/assets/test/specs/mask.spec.js
@@ -46,6 +46,7 @@ var setup = function () {
   fixtureTwoSecretText = $fixtureTwoQaSecret.text();
   fixtureTwoControlTextShow = $fixtureTwoControl.data('textShow');
   fixtureTwoControlTextHide = $fixtureTwoControl.data('textHide');
+
 };
 
 describe('Mask', function () {
@@ -108,5 +109,34 @@ describe('Mask', function () {
       expect($fixtureTwoQaSecret).toHaveClass(JS_HIDDEN_SELECTOR);
       expect($fixtureTwoControl.text()).toBe(fixtureTwoControlTextShow);
     });
+
   });
+
+  describe('on revealing a timer-configured secret', function() {
+
+    beforeEach(function(done) {
+      setup();
+
+      // click to reveal secret
+      $fixtureTwoControl.click();
+
+      // wait longer than configured timer (145 miliseconds) to check that secret is hidden
+      setTimeout(function() {
+        done();
+      }, 150);
+
+    });
+
+    it('150 milliseconds after revealing secret, the secret is masked', function(done) {    
+      expect($fixtureTwoQaMask).toHaveClass(JS_VISIBLE_SELECTOR);
+      done();
+    });
+
+    it('150 milliseconds after revealing secret, link contains correct text', function(done) {
+      expect($fixtureTwoControl.text()).toBe(fixtureTwoControlTextShow);
+      done();
+    });
+
+  });
+
 });


### PR DESCRIPTION
Mask component now has an optional `data-mask-timer="<seconds_to_timeout>"` so that a masked secret that has been revealed can be hidden again once the time is up. Beautiful.

Here's one I made earlier. This times out in 2 seconds.

![ch0rbxpjyj](https://cloud.githubusercontent.com/assets/1764083/13502975/19e1f310-e165-11e5-9965-5f7b952c1369.gif)

Amazeballs.