### PR TITLE
Align radio button selected state with GDS standards and fix the radio button focusout

### DIFF
--- a/assets/javascripts/modules/registerBlockInputFields.js
+++ b/assets/javascripts/modules/registerBlockInputFields.js
@@ -21,5 +21,5 @@ module.exports = function() {
     .on('focusout', function() {
       var current = $(this).closest('label')[0];
       $(current).removeClass('add-focus');
-               });
+    });
 };

--- a/assets/javascripts/modules/registerBlockInputFields.js
+++ b/assets/javascripts/modules/registerBlockInputFields.js
@@ -9,7 +9,7 @@ module.exports = function() {
 
       var current = $(this).closest('label')[0];
       $(current).addClass('add-focus');
-      $selectableInputs.not(current).removeClass('add-focus selected');
+      $selectableInputs.not(current).removeClass('add-focus');
     })
     .on('change', function() {
       if ($(this).attr('type') === 'radio') {
@@ -17,5 +17,9 @@ module.exports = function() {
       }
 
       $(this).closest('label').toggleClass('selected', $(this).prop('checked'));
-    });
+    })
+    .on('focusout', function() {
+      var current = $(this).closest('label')[0];
+      $(current).removeClass('add-focus');
+               });
 };


### PR DESCRIPTION
Fixes on issues:

1 - Currently, whenever a radio button is selected the radio buttons in other button groups lose their white background too. 
![screenshot from 2016-03-08 11 50 58](https://cloud.githubusercontent.com/assets/9132533/13636967/a4f3820c-e5fc-11e5-9de1-760024923158.png)

[As GDS standards state](http://govuk-elements.herokuapp.com/form-elements/example-radios-checkboxes/), selected radio buttons should have white background.

2 - Currently, radio buttons don't lose focus whenever we focus on any other kind of component(i.e. textbox).