### PR TITLE
Iht 1887 fix and tests

### DIFF
--- a/assets/javascripts/modules/registerBlockInputFields.js
+++ b/assets/javascripts/modules/registerBlockInputFields.js
@@ -5,21 +5,33 @@ module.exports = function() {
 
   $selectableInputs
     .find('input[type=radio], input[type=checkbox]')
-    .on('focus click', function() {
+    .map(function (index, input) {
 
-      var current = $(this).closest('label')[0];
-      $(current).addClass('add-focus');
-      $selectableInputs.not(current).removeClass('add-focus');
+      var $input = $(input);
+
+      if ($input.is(':checked')) {
+        $input.closest('label').addClass('selected');
+      }
+      return input;
     })
-    .on('change', function() {
-      if ($(this).attr('type') === 'radio') {
-        $(this).closest('label').siblings().removeClass('selected');
+    .on('focus click', function(event) {
+
+      var $label = $(event.target).closest('label');
+
+      $label.addClass('add-focus');
+      $selectableInputs.not($label).removeClass('add-focus');
+    })
+    .on('change', function(event) {
+
+      var $input = $(event.target);
+
+      if ($input.attr('type') === 'radio') {
+        $input.closest('label').siblings().removeClass('selected');
       }
 
-      $(this).closest('label').toggleClass('selected', $(this).prop('checked'));
+      $input.closest('label').toggleClass('selected', $input.prop('checked'));
     })
-    .on('focusout', function() {
-      var current = $(this).closest('label')[0];
-      $(current).removeClass('add-focus');
+    .on('focusout', function(event) {
+      $(event.target).closest('label').removeClass('add-focus');
     });
 };

--- a/assets/javascripts/modules/registerBlockInputFields.js
+++ b/assets/javascripts/modules/registerBlockInputFields.js
@@ -26,7 +26,9 @@ module.exports = function() {
       var $input = $(event.target);
 
       if ($input.attr('type') === 'radio') {
-        $input.closest('label').siblings().removeClass('selected');
+        $("input[name='" + $input.prop('name') + "']").map(function (index, inputWithSameName) {
+            $(inputWithSameName).closest('label').removeClass('selected');
+        });
       }
 
       $input.closest('label').toggleClass('selected', $input.prop('checked'));

--- a/assets/test/specs/fixtures/register-block-input-fields-fixture.html
+++ b/assets/test/specs/fixtures/register-block-input-fields-fixture.html
@@ -1,0 +1,52 @@
+<div id="radio-inputs">
+
+  <label for="first-name">
+    First Name
+    <input type="text" id="first-name" name="firstname"/>
+  </label>
+
+  <label for="yes-radio" class="block-label">
+    Yes
+    <input type="radio" id="yes-radio" name="choice" checked="checked"/>
+  </label>
+
+  <label for="no-radio" class="block-label">
+    No
+    <input type="radio" id="no-radio" name="choice"/>
+  </label>
+
+  <label for="maybe-radio" class="block-label">
+    Maybe
+    <input type="radio" id="maybe-radio" name="choice"/>
+  </label>
+
+  <label for="of-course-radio" class="block-label">
+    Of Course
+    <input type="radio" id="of-course-radio" name="choice"/>
+  </label>
+
+</div>
+
+<div id="checkbox-inputs">
+
+  <label for="yes-checkbox" class="block-label">
+    Yes
+    <input type="checkbox" id="yes-checkbox" name="choice"/>
+  </label>
+
+  <label for="no-checkbox" class="block-label">
+    No
+    <input type="checkbox" id="no-checkbox" name="choice"/>
+  </label>
+
+  <label for="maybe-checkbox" class="block-label">
+    Maybe
+    <input type="checkbox" id="maybe-checkbox" name="choice"/>
+  </label>
+
+  <label for="of-course-checkbox" class="block-label">
+    Of Course
+    <input type="checkbox" id="of-course-checkbox" name="choice" checked="checked"/>
+  </label>
+
+</div>

--- a/assets/test/specs/registerBlockInputFields.spec.js
+++ b/assets/test/specs/registerBlockInputFields.spec.js
@@ -1,0 +1,141 @@
+require('jquery');
+
+var registerBlockInputFields;
+
+var $radioInputs;
+var $yesRadio;
+var $yesRadioLabel;
+var $ofCourseRadio;
+var $ofCourseRadioLabel;
+var $noRadio;
+var $noRadioLabel;
+
+var $checkboxInputs;
+var $ofCourseCheckbox;
+var $ofCourseCheckboxLabel;
+var $maybeCheckbox;
+var $maybeCheckboxLabel;
+
+var setup = function () {
+  registerBlockInputFields();
+
+  $radioInputs = $('#radio-inputs');
+  $yesRadio = $radioInputs.find('#yes-radio');
+  $yesRadioLabel = $radioInputs.find("label[for='yes-radio']");
+  $ofCourseRadio = $radioInputs.find('#of-course-radio');
+  $ofCourseRadioLabel = $radioInputs.find("label[for='of-course-radio']");
+  $noRadio = $radioInputs.find('#no-radio');
+  $noRadioLabel = $radioInputs.find("label[for='no-radio']");
+
+  $checkboxInputs = $('#checkbox-inputs');
+  $ofCourseCheckbox = $checkboxInputs.find('#of-course-checkbox');
+  $ofCourseCheckboxLabel = $checkboxInputs.find("label[for='of-course-checkbox']");
+  $maybeCheckbox = $checkboxInputs.find('#maybe-checkbox');
+  $maybeCheckboxLabel = $checkboxInputs.find("label[for='maybe-checkbox']");
+
+
+};
+
+describe('Register Block Input Fields', function () {
+
+  beforeEach(function () {
+    jasmine.getFixtures().fixturesPath = 'base/specs/fixtures/';
+    loadFixtures('register-block-input-fields-fixture.html');
+    registerBlockInputFields = require('../../javascripts/modules/registerBlockInputFields.js');
+  });
+
+  describe('on page load', function () {
+    beforeEach(setup);
+
+    it('radio and checkbox elements should be setup correctly', function () {
+
+      expect($yesRadio).toHaveAttr('checked', 'checked');
+      expect($yesRadioLabel).toHaveClass('selected');
+
+      expect($ofCourseCheckbox).toHaveAttr('checked', 'checked');
+      expect($ofCourseCheckboxLabel).toHaveClass('selected');
+
+      expect($ofCourseRadio).not.toHaveAttr('checked');
+      expect($ofCourseRadioLabel).not.toHaveClass('selected');
+
+      expect($maybeCheckbox).not.toHaveAttr('checked');
+      expect($maybeCheckboxLabel).not.toHaveClass('selected');
+    });
+  });
+
+  describe('on interaction', function () {
+    beforeEach(setup);
+
+    it('input should have correct class when focused', function () {
+
+      $noRadio.click();
+
+      expect($noRadio).toBeChecked();
+      expect($noRadioLabel).toHaveClass('selected');
+      expect($noRadioLabel).toHaveClass('add-focus');
+
+      expect($ofCourseRadio).not.toBeChecked;
+      expect($ofCourseRadioLabel).not.toHaveClass('selected');
+      expect($ofCourseRadioLabel).not.toHaveClass('add-focus');
+
+      expect($maybeCheckbox).not.toBeChecked;
+      expect($maybeCheckboxLabel).not.toHaveClass('selected');
+      expect($maybeCheckboxLabel).not.toHaveClass('add-focus');
+    });
+
+    it('input should have correct class when blured', function () {
+
+      $noRadio.click();
+
+      expect($noRadio).toBeChecked();
+      expect($noRadioLabel).toHaveClass('selected');
+      expect($noRadioLabel).toHaveClass('add-focus');
+
+      expect($ofCourseRadio).not.toBeChecked();
+      expect($ofCourseRadioLabel).not.toHaveClass('selected');
+      expect($ofCourseRadioLabel).not.toHaveClass('add-focus');
+
+      expect($maybeCheckbox).not.toBeChecked();
+      expect($maybeCheckboxLabel).not.toHaveClass('selected');
+      expect($maybeCheckboxLabel).not.toHaveClass('add-focus');
+
+      $noRadio.blur();
+
+      expect($noRadio).toBeChecked();
+      expect($noRadioLabel).toHaveClass('selected');
+      expect($noRadioLabel).not.toHaveClass('add-focus');
+    });
+
+    it('input should have correct class when changed', function () {
+
+      $noRadio.click();
+
+      expect($noRadio).toBeChecked();
+      expect($noRadioLabel).toHaveClass('selected');
+      expect($noRadioLabel).toHaveClass('add-focus');
+
+      expect($ofCourseRadio).not.toBeChecked();
+      expect($ofCourseRadioLabel).not.toHaveClass('selected');
+      expect($ofCourseRadioLabel).not.toHaveClass('add-focus');
+
+      expect($maybeCheckbox).not.toBeChecked();
+      expect($maybeCheckboxLabel).not.toHaveClass('selected');
+      expect($maybeCheckboxLabel).not.toHaveClass('add-focus');
+
+      $ofCourseRadio.click();
+
+      expect($ofCourseRadio).toBeChecked();
+      expect($ofCourseRadioLabel).toHaveClass('selected');
+      expect($ofCourseRadioLabel).toHaveClass('add-focus');
+
+      expect($noRadio).not.toBeChecked();
+      expect($noRadioLabel).not.toHaveClass('selected');
+      expect($noRadioLabel).not.toHaveClass('add-focus');
+
+      expect($maybeCheckbox).not.toBeChecked();
+      expect($maybeCheckboxLabel).not.toHaveClass('selected');
+      expect($maybeCheckboxLabel).not.toHaveClass('add-focus');
+    });
+  });
+
+});


### PR DESCRIPTION
# Fix and Tests for Radio/Checkbox input focus/selection

This work involved:
- Fix the `registerBlockInputFields.js` file so that pre-selected checkbox/radio buttons have the class `selected` applied on load
- Tidy up the `registerBlockInputFields.js` 
- Remove brittle `JavaScript` that was relying on markup structure
- Add tests around this functionality

### Example (in sandbox)
![test-inputs](https://cloud.githubusercontent.com/assets/2305016/13671269/cfdc5c58-e6c6-11e5-8cfa-97ad7a2887ab.gif)


### Tests
<img width="435" alt="screen shot 2016-03-10 at 13 40 00" src="https://cloud.githubusercontent.com/assets/2305016/13671083/a688e200-e6c5-11e5-82f3-3c55cc9487a7.png">
