### PR TITLE
AutoComplete - component library

### DIFF
--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -77,7 +77,7 @@ $path: "../images/icons/";
 @import "modules/breadcrumb";
 @import "modules/accordion";
 @import "modules/youtube-player";
-@import "modules/auto-complete";
+@import "components/auto-complete";
 @import "modules/toggle";
 @import "modules/_external-markup";
 @import "modules/char-counter";

--- a/assets/scss/components/_auto-complete.scss
+++ b/assets/scss/components/_auto-complete.scss
@@ -1,3 +1,38 @@
+/*
+Auto Complete
+
+The Auto complete is used to aid a user with a large amount of choices they may have to make.
+
+Markup:
+<fieldset class="form-field-group">
+  <label>
+  Tell us the country where the number is registered
+    <div class="suggestions-input-container">
+      <input type="text"
+             name="country-code-auto-complete"
+             id="country-code-auto-complete"
+             class="suggestions-input
+                    form-control
+                    form-control--block
+                    js-choose-country-auto-complete"
+             autocomplete="off"
+             spellcheck="false"
+             aria-autocomplete="list"
+             aria-haspopup="true"
+             aria-owns="suggestions-list"
+             aria-activedescendant />
+      <i class="suggestions-clear hidden js-suggestions-clear"></i>
+      <span role="status" aria-live="polite"
+            class="visuallyhidden js-suggestions-status-message"></span>
+      <div id="suggestions-list" class="suggestions js-suggestions"></div>
+    </div>
+  </label>
+</fieldset>
+
+Styleguide AutoComplete
+*/
+
+
 .suggestions {
   position: absolute;
   z-index: 1000;
@@ -7,6 +42,10 @@
 
 .suggestions-input-container {
   position: relative;
+}
+
+.suggestions-input {
+  width: 92%;
 }
 
 .suggestions-list {


### PR DESCRIPTION
# AutoComplete

- Move autocomplete to `components` folder (this is the new name for modules), 
- add `.suggestions-input` selector to bring in work that was being applied from panels to autocomplete styles
- Add component-library comments

### Example
![autcomplete-comp-lib](https://cloud.githubusercontent.com/assets/2305016/13821518/e9731076-eb99-11e5-8d70-f043653a7045.gif)

