### PR TITLE
Downgrade datatables.net version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "browser-sync": "^2.4.0",
     "browserify-istanbul": "^0.1.3",
     "browserify-shim": "^3.8.2",
-    "datatables": "^1.10.5",
+    "datatables": "1.10.9",
     "del": "^1.1.1",
     "fingerprintjs": "^0.5.3",
     "gulp": "^3.8.11",


### PR DESCRIPTION
## Downgrade datatables.net version to 1.10.9 ##

> **Note**: this issue impacts any page using the DataTables.net jQuery plugin. 

#### Feature affected ###
The DataTable.net plugin feature is added to table elements with the `js-datatable` class by the application.js, and uses `./javascripts/modules/enhancedTables.js` to configure default attributes.
#### Issue ####
The [DataTables.net](http://datatables.net) 1.10.11 release introduced a breaking change in `application.min.js` throwing an error which blocks JavaScript execution. The issue is believed to be related to the introduced functionality allowing a [DataTable to be created](http://datatables.net/upgrade/1.10) using:

* `$(...).dataTable()`, or
* `$(...).DataTable()`

> The difference between the two is that the first will return a jQuery object, while the second returns a DataTables API instance.

#### Solution ####
Whilst the previous minor releases of DataTables 1.10 honoured backward compatibility for tables referenced by `$(...).DataTable()` it appears that 1.10.11 does not.

This fix is to change the `package.json` install reference for "datatables" from `^1.10.5` to an explicit reference of `1.10.9` (which maintains backward compatibility). The use of the caret (^) updated DatTables to the most recent major version (the first number), that being the breaking 1.10.11 release.
