### PR TITLE
Component-library - Marked as potentially not in use

### DIFF
--- a/assets/scss/pages/_risk-triage.scss
+++ b/assets/scss/pages/_risk-triage.scss
@@ -1,15 +1,19 @@
+//POTENTIALLY-NOT-IN-USE
 .marriage-allowance__heading {
   margin:15px 0 30px 0;
 }
 
+//POTENTIALLY-NOT-IN-USE
 .p60__details {
   margin:10px 0 0 0;
 }
 
+//POTENTIALLY-NOT-IN-USE
 .your-pay__text {
   margin:0 0 10px 0;
 }
 
+//POTENTIALLY-NOT-IN-USE
 .p60-form__image {
   width:400px;
 


### PR DESCRIPTION
# POTENTIALLY NOT IN USE

I can't find these styles anywhere - marked as `//POTENTIALLY-NOT-IN-USE`

Issue raised:
https://github.com/hmrc/assets-frontend/issues/435