### PR TITLE
Fixes notification icon alignment in Firefox

### DIFF
--- a/assets/scss/modules/_notifications.scss
+++ b/assets/scss/modules/_notifications.scss
@@ -163,8 +163,7 @@
 }
 
 .highlight-message--icon-top {
-  background-position: em(20) em(20);
-  background-size: em(27) em(27);
+  background-position: 20px 20px;
 }
 
 .highlight-message--dark {

--- a/assets/scss/modules/_notifications.scss
+++ b/assets/scss/modules/_notifications.scss
@@ -163,7 +163,8 @@
 }
 
 .highlight-message--icon-top {
-  background-position-y: em(20);
+  background-position: em(20) em(20);
+  background-size: em(27) em(27);
 }
 
 .highlight-message--dark {


### PR DESCRIPTION
### Fixes notification icon alignment on `.highlight-message--icon-top` in Firefox.
* `background-position-y` not supported in Firefox - update to supported `background-position`
* `device-pixel-ratio` not supported in Firefox - add `background-size` as used in `device-pixel-ratio` media-query on `.highlight-message`

#### Before (left) and After (right) - `.highlight-message--icon-top` positioning fix for Firefox
<img width="1627" alt="aoss_926-icon notification positioning fix for firefox" src="https://cloud.githubusercontent.com/assets/5468091/14031807/90d464ba-f206-11e5-809e-6afb7c9be5f3.png">
