### PR TITLE
[API-965] Textarea modifier

### DIFF
--- a/assets/scss/base/form/_textarea.scss
+++ b/assets/scss/base/form/_textarea.scss
@@ -28,10 +28,10 @@ textarea {
   }
 }
 
-.textarea--fullwidth {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
+.textarea--medium {
+  width: 75%;
+}
 
+.textarea--fullwidth {
   width:100%;
 }

--- a/assets/scss/base/form/_textarea.scss
+++ b/assets/scss/base/form/_textarea.scss
@@ -7,6 +7,7 @@ Markup:
 <textarea class="{{modifier_class}}" name="example_textarea_input" id="example" cols="30" rows="10"></textarea>
 
 .textarea--fullwidth - A full width textarea
+.textarea--3-4       - A three quarters width textarea
 
 Styleguide Textarea Input
 */

--- a/assets/scss/base/form/_textarea.scss
+++ b/assets/scss/base/form/_textarea.scss
@@ -28,7 +28,7 @@ textarea {
   }
 }
 
-.textarea--medium {
+.textarea--3-4 {
   width: 75%;
 }
 


### PR DESCRIPTION
Added a `textarea--3-4` modifier to provide 75% width to textarea elements. The default width is often to small, and the 100% is too wide in certain cases.

![screen shot 2016-03-24 at 2 24 20 pm](https://cloud.githubusercontent.com/assets/1764083/14020343/9e0de53a-f1ce-11e5-92b2-f79700fef3c7.png)
