### PR TITLE
[aoss-257] flag icon fix for statement data table

### DIFF
--- a/assets/scss/modules/_epaye-statements.scss
+++ b/assets/scss/modules/_epaye-statements.scss
@@ -130,10 +130,12 @@
     background-image: url("../images/statements-flag3.png");
     background-repeat: no-repeat;
     background-position: 3px 4px;
-    padding-left: 3px;
+    padding-left: 12px;
     
     &:before {
-      content: "\f104";
+      content: "\00a0";
+      height: 14px;
+      width: 11px;
     }
   }
 

--- a/assets/scss/modules/_epaye-statements.scss
+++ b/assets/scss/modules/_epaye-statements.scss
@@ -130,12 +130,12 @@
     background-image: url("../images/statements-flag3.png");
     background-repeat: no-repeat;
     background-position: 3px 4px;
-    padding-left: 12px;
+    padding-left: em(12);
     
     &:before {
       content: "\00a0";
-      height: 14px;
-      width: 11px;
+      height: em(14);
+      width: em(11);
     }
   }
 


### PR DESCRIPTION
### [aoss-257] flag icon fix for statement data table

* fix badly rendered icon flag `background-image`
  * `:before` pseudo was using `fa-angle-left` ("\f104") from Font Awesome
  * changed to space ("\00a0") and increased `padding-left` to pixel width of icon + 1

#### BEFORE and AFTER
![aoss-257-icon-flag-fix-for-datatable-statement](https://cloud.githubusercontent.com/assets/5468091/14031389/8a80024c-f204-11e5-90b8-754450f61218.png)

