### PR TITLE
[API-965] Application info module

### DIFF
--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -85,6 +85,7 @@ $path: "../images/icons/";
 @import "components/toggle-button";
 @import "modules/tabs";
 @import "components/modal-dialog";
+@import "components/app-info";
 
 // Page Specific Styles
 @import "pages/messages";

--- a/assets/scss/components/_app-info.scss
+++ b/assets/scss/components/_app-info.scss
@@ -78,8 +78,7 @@ Styleguide App Info.Approved
 /*
 Status
 
-Status is used to display the status of `.app-info`.
-Currently, an application can either be `verified` or `not verified`.
+Describes the status of an application, which is either verified (green text) or not verified (orange text).
 
 Markup:
 <span class="status {{modifier_class}}">Example status text</span>

--- a/assets/scss/components/_app-info.scss
+++ b/assets/scss/components/_app-info.scss
@@ -1,0 +1,100 @@
+
+/*
+Pending
+
+An item which describes an application. Typically this would be one item in a list of pending applications.
+The info below the heading typically provides subtext of less importance, e.g. date of submission.
+The call-to-action link is typically to process the application, e.g. Review.
+
+Markup:
+<ul>
+  <li class="app-info">
+      <div class="app-info__primary">
+          <h3 class="app-info__heading">Application heading</h3>
+          <p class="app-info__info">Application info text</p>
+      </div>
+      <div class="app-info__secondary">
+          <a href="">CTA link</a>
+      </div>
+  </li>
+</ul>
+
+Styleguide App Info.Pending
+*/
+
+/*
+Approved
+
+An item which describes an application with status.
+
+Markup:
+<ul>
+  <li class="app-info">
+      <div class="app-info__primary">
+          <h3 class="app-info__heading">Application heading</h3>
+          <p class="app-info__info">Application info text</p>
+      </div>
+      <div class="app-info__secondary">
+          <span class="status status--verified">verified</span>
+      </div>
+  </li>
+</ul>
+
+Styleguide App Info.Approved
+*/
+
+
+.app-info {
+  display: table;
+  width: 100%;
+  border-bottom: 1px solid $border-colour;
+}
+
+.app-info__primary,
+.app-info__secondary {
+  display: table-cell;
+  vertical-align: top;
+  @include core-19;
+}
+
+.app-info__secondary {
+  text-align: right;
+}
+
+.app-info__heading {
+  @include core-19;
+  margin: 0;
+}
+
+.app-info__info {
+  @extend .faded-text;
+  @include core-16;
+  margin-top: em(5) !important;  // neeed to override .content__body p
+}
+
+
+/*
+Status
+
+Status is used to display the status of `.app-info`.
+
+Markup:
+<span class="status {{modifier_class}}">Example status text</span>
+
+.status--verified        - Verified status
+.status--not-verified    - Not verified status
+
+Styleguide App Info.Status
+*/
+
+.status {
+  @include core-19;  
+}
+
+.status--verified {
+  color: #009900;
+}
+
+.status--not-verified {
+  color: #F47738;
+}

--- a/assets/scss/components/_app-info.scss
+++ b/assets/scss/components/_app-info.scss
@@ -1,10 +1,20 @@
 
 /*
+App Info
+
+An item which describes an application. Typically this would be one item in a list of applications.
+The heading is the application name. 
+The info below the heading typically provides subtext of less importance, e.g. date of submission.
+The call-to-action link is typically to process a pending application, e.g. Review.
+
+Styleguide App Info
+*/
+
+/*
+
 Pending
 
-An item which describes an application. Typically this would be one item in a list of pending applications.
-The info below the heading typically provides subtext of less importance, e.g. date of submission.
-The call-to-action link is typically to process the application, e.g. Review.
+An application which is pending approval and contains a call-to-action link to process the application.
 
 Markup:
 <ul>
@@ -25,7 +35,7 @@ Styleguide App Info.Pending
 /*
 Approved
 
-An item which describes an application with status.
+An application which has been approved and has a status indicating whether or not it has been verified via email.
 
 Markup:
 <ul>

--- a/assets/scss/components/_app-info.scss
+++ b/assets/scss/components/_app-info.scss
@@ -31,7 +31,9 @@ Markup:
 <ul>
   <li class="app-info">
       <div class="app-info__primary">
-          <h3 class="app-info__heading">Application heading</h3>
+          <h3 class="app-info__heading">
+            <a href="">Application heading</a>
+          </h3>
           <p class="app-info__info">Application info text</p>
       </div>
       <div class="app-info__secondary">
@@ -62,14 +64,14 @@ Styleguide App Info.Approved
 }
 
 .app-info__heading {
-  @include core-19;
+  @include core-19; // required to override default bold heading
   margin: 0;
 }
 
 .app-info__info {
   @extend .faded-text;
   @include core-16;
-  margin-top: em(5) !important;  // neeed to override .content__body p
+  margin-top: em(5) !important;  // needed to override .content__body p
 }
 
 
@@ -77,6 +79,7 @@ Styleguide App Info.Approved
 Status
 
 Status is used to display the status of `.app-info`.
+Currently, an application can either be `verified` or `not verified`.
 
 Markup:
 <span class="status {{modifier_class}}">Example status text</span>


### PR DESCRIPTION
# App Info

A module that describes an application. Typically used as an item among a list of applications. For example, a lists of Pending and Approved applications.

# Status

A module that describes an application's status.

![screencapture-localhost-9032-component-library-section-app-info-html-1459352378689](https://cloud.githubusercontent.com/assets/1764083/14148120/2d9878b6-f696-11e5-9f62-6ed8cce42868.png)

# Example Usage

![screen shot 2016-03-29 at 4 16 07 pm](https://cloud.githubusercontent.com/assets/1764083/14113141/93a81fee-f5c9-11e5-9cb5-77c41bbcc532.png)
