### PR TITLE
Component Library - remove for attribute on labels 

### DIFF
--- a/assets/scss/base/form/_errors.scss
+++ b/assets/scss/base/form/_errors.scss
@@ -78,20 +78,18 @@ Markup:
   <legend>Please enter your full name</legend>
   <div class="form-field form-field--error {{modifier_class}}">
     <span class="error-notification">Please enter your first name</span>
-    <label for="firstname">
+    <label>
         Full Name
         <input type="text"
-               class="input--medium error-field"
-               id="firstname" />
+               class="input--medium error-field"/>
     </label>
   </div>
   <div class="form-field form-field--error {{modifier_class}}">
     <span class="error-notification">Please enter your surname</span>
-    <label for="surname">
+    <label>
         Full Name
         <input type="text"
-               class="input--medium error-field"
-               id="surname" />
+               class="input--medium error-field"/>
     </label>
   </div>
 </fieldset>
@@ -142,21 +140,19 @@ Markup:
 <fieldset class="form-field-group form-field-group--error">
   <legend>Please enter your full name</legend>
   <div class="form-field">
-    <label for="firstname">
+    <label>
         First Name
         <span class="error-notification">Please enter your first name</span>
         <input type="text"
-               class="form-control"
-               id="firstname" />
+               class="form-control"/>
     </label>
   </div>
   <div class="form-field">
-    <label for="surname">
+    <label>
         Surname
         <span class="error-notification">Please enter your surname</span>
         <input type="text"
-               class="form-control"
-               id="surname" />
+               class="form-control"/>
     </label>
   </div>
 </fieldset>

--- a/assets/scss/base/form/_form.scss
+++ b/assets/scss/base/form/_form.scss
@@ -6,15 +6,15 @@ A Form field is used to group several controls or elements within a web form.
 Markup:
 <fieldset class="{{modifier_class}}">
   <div class="form-field">
-    <label for="first-name">
+    <label>
       First Name
-      <input type="text" id="first-name" value=""/>
+      <input type="text" value=""/>
     </label>
   </div>
  <div class="form-field">
-    <label for="second-name">
+    <label>
       Second Name
-      <input type="text" id="second-name" value=""/>
+      <input type="text" value=""/>
     </label>
   </div>
   <div class="form-field">
@@ -63,15 +63,15 @@ A Form field is used to group several controls or elements within a web form.
 Markup:
 <fieldset class="form-field-group">
   <div class="form-field {{modifier_class}}">
-    <label for="first-name">
+    <label>
       First Name
-      <input type="text" id="first-name" value=""/>
+      <input type="text" value=""/>
     </label>
   </div>
   <div class="form-field {{modifier_class}}">
-    <label for="second-name">
+    <label>
       Second Name
-      <input type="text" id="second-name" value=""/>
+      <input type="text" value=""/>
     </label>
   </div>
   <div class="form-field {{modifier_class}}">
@@ -105,14 +105,14 @@ For a inline elements you have a few choices.
 Markup:
 <fieldset class="form-field-group">
   <div class="{{modifier_class}}">
-    <label for="blue" class="block-label">
-      <input type="radio" id="blue"/>
+    <label class="block-label">
+      <input type="radio"/>
       Blue
     </label>
   </div>
   <div class="{{modifier_class}}">
-    <label for="green" class="block-label">
-      <input type="radio" id="green"/>
+    <label class="block-label">
+      <input type="radio"/>
       Green
     </label>
   </div>
@@ -208,8 +208,9 @@ For displaying a date you can use the following markup.
 Markup:
 <div class="form-date">
   <div class="form-group form-group-year">
-    <label for="year" class="block-label">
-      <input class="input--xsmall" type="number" pattern="[0-9]*" min="0" max="12" id="year" name="year"/>
+    <label class="block-label">
+      <input class="input--xsmall" type="number" pattern="[0-9]*"
+             min="0" max="12" name="year"/>
       Year
     </label>
   </div>
@@ -248,8 +249,8 @@ For dynamically displayed markup.
 
 Markup:
 <fieldset class="dynamically-displayed">
-  <label for="textarea">
-    <textarea id="textarea" name="details" cols="40" rows="6"></textarea>
+  <label>
+    <textarea name="details" cols="40" rows="6"></textarea>
   </label>
 </fieldset>
 
@@ -275,9 +276,9 @@ Control
 For displaying form controls.
 
 Markup:
-<label for="control">
+<label>
   Surname
-  <input type="text" id="control"
+  <input type="text"
          name="surname" class="form-control {{modifier_class}}"/>
 </label>
 

--- a/assets/scss/base/form/_label.scss
+++ b/assets/scss/base/form/_label.scss
@@ -14,9 +14,9 @@ Label
 Labels are used to describe an input or group of inputs.
 
 Markup:
-<label class="{{modifier_class}}" for="label_example">
+<label class="{{modifier_class}}">
   First Name
-  <input id="label_example" class="input--cleared" name="example" type="text" value="example value" />
+  <input class="input--cleared" name="example" type="text" value="example value" />
 </label>
 
 .indent                   - An indented label
@@ -87,9 +87,9 @@ Radio input
 Labels containing a `radio` input.
 
 Markup:
-<label class="block-label {{modifier_class}}" for="label_radio_example">
+<label class="block-label {{modifier_class}}">
   Purple
-  <input id="label_radio_example" name="example" type="radio" />
+  <input name="example" type="radio" />
 </label>
 
 .label--inlineRadio                   - An inline radio label
@@ -135,9 +135,9 @@ Radio expanded
 Labels containing a `radio` input and a `span` wrapping the labels text.
 
 Markup:
-<label class="block-label label--inlineRadio--expanded" for="label_radio_expanded_example">
+<label class="block-label label--inlineRadio--expanded">
   <span class="label__text">Yellow</span>
-  <input id="label_radio_expanded_example" name="example" type="radio" />
+  <input name="example" type="radio" />
 </label>
 
 Styleguide Label.radio expanded
@@ -167,8 +167,8 @@ Select input
 Labels containing a `select` input.
 
 Markup:
-<label class="label--inlineDropDown" for="label_select_example">
-  <select id="label_select_example" class="select" name="example">
+<label class="label--inlineDropDown">
+  <select class="select" name="example">
     <option value="one">Option One</option>
     <option value="two">Option Two</option>
     <option value="three">Option Three</option>
@@ -190,7 +190,7 @@ Date
 Labels containing a `date`.
 
 Markup:
-<label for="example_label_date" class=" label--dateField-group">
+<label for="example_label_date" class="label--dateField-group">
   <span>Month</span>
 </label>
 <input type="text" name="month" id="example_label_date">
@@ -210,9 +210,9 @@ Aligned
 Labels containing a `radio` input with alignment.
 
 Markup:
-<label class="block-label" for="label_aligned_example">
+<label class="block-label">
   London
-  <input class="{{modifier_class}}" id="label_aligned_example" name="example" type="radio" />
+  <input class="{{modifier_class}}" name="example" type="radio" />
 </label>
 
 .vertically-aligned-input   - A vertically aligned input
@@ -241,12 +241,12 @@ Block
 Labels containing a `radio` input and a `span` wrapping the labels text.
 
 Markup:
-<label class="block-label {{modifier_class}}" for="label_block_example">
-  <input id="label_block_example" name="example" type="radio" />
+<label class="block-label {{modifier_class}}">
+  <input name="example" type="radio" />
   Blue
 </label>
-<label class="block-label {{modifier_class}}" for="label_block_example_other">
-  <input id="label_block_example_other" name="example" type="radio" />
+<label class="block-label {{modifier_class}}">
+  <input name="example" type="radio" />
   Green
 </label>
 
@@ -326,12 +326,12 @@ A container element using the `.form-date` css selector will change how a child 
 
 Markup:
 <div class="form-date">
-  <label for="label_form_date_example">
-    <input class="input--xxsmall input--no-spinner" id="label_form_date_example" name="example" type="number" />
+  <label>
+    <input class="input--xxsmall input--no-spinner" name="example" type="number" />
     Yellow
   </label>
-  <label for="label_form_date_example_other">
-    <input class="input--xxsmall input--no-spinner" id="label_form_date_example_other" name="example" type="number" />
+  <label>
+    <input class="input--xxsmall input--no-spinner" name="example" type="number" />
     Orange
   </label>
 </div>

--- a/assets/scss/base/form/_radio-input.scss
+++ b/assets/scss/base/form/_radio-input.scss
@@ -4,13 +4,13 @@ Radio Input
 Radio Inputs are used to enable users to make a choice in a form.
 
 Markup:
-<label for="example-radio" class="block-label {{modifier_class}}">
+<label class="block-label {{modifier_class}}">
   Yes
-  <input name="example_text_input" type="radio" value="example value" id="example-radio"/>
+  <input name="example_text_input" type="radio" value="example value"/>
 </label>
-<label for="example-radio" class="block-label {{modifier_class}}">
+<label class="block-label {{modifier_class}}">
   No
-  <input name="example_text_input" type="radio" value="example value" id="example-radio"/>
+  <input name="example_text_input" type="radio" value="example value"/>
 </label>
 
 Styleguide Radio Input


### PR DESCRIPTION
Remove `for` attributes and `ids` for labels and inputs due to them causing problems with repeated code when using modifiers