### PR TITLE
Component Library: add the comp lib build to the javascript watch task

### DIFF
--- a/gulpfile.js/tasks/watch.js
+++ b/gulpfile.js/tasks/watch.js
@@ -8,7 +8,7 @@ var config   = require('../config'),
 	gulp     = require('gulp');
 
 gulp.task('watch', ['watchify', 'server'], function(callback) {
-  gulp.watch(config.scripts.src, ['jshint']);
+  gulp.watch(config.scripts.src, ['jshint', 'component-library']);
   gulp.watch(config.test.src,  ['test']);
   gulp.watch(config.sass.src,  ['sass', 'component-library']);
 


### PR DESCRIPTION
# Comp lib

I have added the comp lib build to the javascript watch task mainly due to working on JavaScript in the component library without a service.
It may be the case that this is not needed when you are working on a service?

@hmrc/assets thoughts?