### PR TITLE
Add remove refactor

### DIFF
--- a/assets/javascripts/modules/addRemove.js
+++ b/assets/javascripts/modules/addRemove.js
@@ -1,233 +1,166 @@
-/**
- * Add/Remove Module
- *
- * Usage:
- *
- *  <div class="add-remove"
- *        data-add-remove
- *        data-add-remove-max="5"
- *        data-attr-name="redirectUris[$]">
- *
- *    <script type="text/template" data-item-template>
- *      <li class="add-remove__item" data-add-remove-item>
- *        <input type="text" value="" data-add-remove-unique/>
- *      </li>
- *    </script>
- *    <script type="text/template" data-remove-btn-template>
- *      <a href="#" class="add-remove__remove-btn" data-remove-btn>Delete</a>
- *    </script>
- *    <script type="text/template" data-add-btn-template>
- *      <a href="#" data-add-btn>Add another redirect URI</a>
- *    </script>
- *
- *    <ul data-add-remove-list>
- *      <li data-add-remove-item>
- *        <input type="text" value="Value 1" name="redirectUris[0]" data-add-remove-unique/>
- *      </li>
- *      <li data-add-remove-item>
- *        <input type="text" value="Value 2" name="redirectUris[1]" data-add-remove-unique/>
- *      </li>
- *      <li data-add-remove-item>
- *        <input type="text" value="Value 3" name="redirectUris[2]" data-add-remove-unique/>
- *      </li>
- *    </ul>
- *
- *  </div>
- *
+/*
+Add Remove
+
+A component to add and remove inputs on a page. You have the option of sending in custom attributes for:
+- `data-can-delete="true"` to add delete buttons
+- `data-delete-btn-text` to send in custom delete button text, this defaults to **Delete** and will only work when the
+ `data-can-delete="true"` is set
+- `data-add-btn-text` to send in custom add button text, this defaults to **Add another redirect URI**
+- `data-max` Maximum items allowed in the list
+
+Markup:
+<div data-add-remove
+     data-max="5"
+     data-can-delete="true",
+     data-delete-btn-text="Delete Me"
+     data-add-btn-text="Add Me">
+  <ul class="add-remove__list" data-add-remove-list>
+    <li class="add-remove__item" data-add-remove-item>
+      <input name="example[]"
+             type="text"
+             class="form-input input--medium"
+             data-add-remove-input />
+    </li>
+    <li class="add-remove__item" data-add-remove-item>
+      <input name="example[]"
+             type="text"
+             class="form-input input--medium"
+             data-add-remove-input />
+    </li>
+  </ul>
+</div>
  */
 
+var DEFAULT_ADD_BTN_TEXT = 'Add another redirect URI',
+    DEFAULT_DELETE_BTN_TEXT = 'Delete',
+    addRemoveContainer = '[data-add-remove]',
+    addRemoveList = '[data-add-remove-list]',
+    addRemoveItem = '[data-add-remove-item]',
+    addRemoveInput = '[data-add-remove-input]',
+    addButton = '[data-add-btn]',
+    maxItems = 'data-max';
 
-var addRemoveContainer = '[data-add-remove]',
-    addRemoveList      = '[data-add-remove-list]',
-    addRemoveItem      = '[data-add-remove-item]',
-    addButton          = '[data-add-btn]',
-    removeButton       = '[data-remove-btn]',
-    maxItems           = 'data-add-remove-max';
-
-var itemTemplate       = '[data-item-template]',
-    addBtnTemplate     = '[data-add-btn-template]',
-    removeBtnTemplate  = '[data-remove-btn-template]';
-
-
-/**
- * Init add/remove, where necessary
- *
- * @param
- */
-module.exports = function() {
-
+var init = function () {
   var $addRemoveContainers = $(addRemoveContainer);
 
-  // only continue if counter html exists
-  if($addRemoveContainers.length === 0) return;
+  if ($addRemoveContainers.length) {
 
-  // for each add/remove container on the page
-  $addRemoveContainers.each(function() {
-    var $container = $(this);
+    $addRemoveContainers.each(function (i, container) {
+      var $container = $(container);
 
-    $container.find('[data-removable]').each(function() {
-      var $item = $(this);
+      if (deleteIsEnabled($container)) {
+        $container.find(addRemoveItem).each(function (index, listItem) {
+          if (index > 0) {
+            addDeleteBtn($(listItem), $container);
+          }
+        });
+      }
 
-      // add html for remove button
-      insertRemoveButton($container, $item);
-
-      // bind remove click event
-      bindRemoveEvent($container, $item);
-
+      // only insert Add button if list has space
+      if (!maxLengthReached($container)) {
+        insertAddButton($container);
+      }
     });
-
-    // only insert Add button if list has space
-    if(!isListFull($container)) {
-
-      // add html for add button
-      insertAddButton($container);
-
-    }
-
-    // bind add click
-    bindAddEvent($container);
-
-  });
-
-};
-
-/**
- * Insert a Remove button in the item
- *
- * @param $container
- * @param $item
- */
-var insertRemoveButton = function($container, $item) {
-
-  var html = $container.find(removeBtnTemplate).html();
-
-  $item.append(html);
-
-};
-
-/**
- * Bind click event on Remove button for an item
- *
- * @param $container
- * @param $item
- */
-var bindRemoveEvent = function($container, $item) {
-
-  $item.on('click', removeButton, function(e) {
-    e.preventDefault();
-
-    // remove list item
-    $item.remove();
-
-    // if there's no Add button
-    if($container.find(addButton).length === 0) {
-
-      // insert Add button as there must be at least one available slot
-      insertAddButton($container);
-
-    }
-
-  });
-
+  }
 };
 
 /**
  * Insert a Add button after the list of items
- *
  * @param $container
  */
-var insertAddButton = function($container) {
+var insertAddButton = function ($container) {
+  var addBtnText = $container.attr('data-add-btn-text') || DEFAULT_ADD_BTN_TEXT;
+  var $addInputBtn = $('<a href="#" data-add-btn>' + addBtnText + '</a>')
+    .click(function (event) {
+      event.preventDefault();
+      addListItem($container);
+    });
 
-  var html = $container.find(addBtnTemplate).html();
-
-  $container.append(html);
-
+  $container.append($addInputBtn);
 };
 
 /**
- * Bind a click event to the Add button
- *
+ * Show the add input button
  * @param $container
  */
-var bindAddEvent = function($container) {
-
-  $container.on('click', addButton, function(e) {
-
-    e.preventDefault();
-
-    addItem($container);
-
-  });
-
+var showAddButton = function ($container) {
+  if (!maxLengthReached($container)) {
+    $container.find(addButton).show();
+  }
 };
 
-
 /**
- * Add a new item to the list
- *
+ * Hide the add input button
  * @param $container
  */
-var addItem = function($container) {
-
-  var $list    = $container.find(addRemoveList),
-      $newItem = createItem($container);
-
-  // only insert Remove button if item should be removable
-  if($newItem.is('[data-removable]')) {
-
-    // add the Remove button
-    insertRemoveButton($container, $newItem);
-
-    // bind click event on Remove button
-    bindRemoveEvent($container, $newItem);
-
+var hideAddButton = function ($container) {
+  if (maxLengthReached($container)) {
+    $container.find(addButton).hide();
   }
-
-  // append new item to list
-  $list.append($newItem);
-
-  // if max length reached
-  if(isListFull($container)) {
-    $container.find(addButton).remove();
-  }
-
 };
 
-
-
 /**
- * Create new item based off template
+ * Add a new list item to list
+ * @param $container
  */
-var createItem = function($container) {
+var addListItem = function ($container) {
+  var $list = $container.find(addRemoveList),
+      $lisItem = createItem($container);
 
-  var listCount = $container.find('[data-add-remove-item]').length,      // get count of items
-      nameAttr  = $container.attr('data-attr-name'),                     // get pattern for unique name attribute
-      $newItem,
-      $unique;
-
-  // get clone of template item wrapped in LI
-  $newItem = $($container.find(itemTemplate).html());
-
-  // get unique item (e.g. input, textarea) within item
-  $unique = $newItem.find('[data-add-remove-unique]');
-
-  // prepare unique attributes for unique element (e.g. input, textarea), if specified
-  if(nameAttr) {
-    nameAttr = nameAttr.replace(/\$/, listCount);
-    $unique.attr({name: nameAttr});
-  }
-
-  return $newItem;
-
+  $list.append($lisItem);
+  hideAddButton($container);
 };
 
 
 /**
- * Returns whether or not list is full based on maxItems attribute
- *
+ * Create new list item containing input. If the attribute data-can-delete="true" has been added to the container
+ * then the list item will have the delete functionality added.
+ * @param $container
+ * @returns {*}
+ */
+var createItem = function ($container) {
+  var $listItemClone,
+      $input;
+
+  $listItemClone = $container.find(addRemoveItem).first().clone();
+  $input = $listItemClone.find(addRemoveInput);
+  $input.val('');
+
+  if (deleteIsEnabled($container)) {
+    addDeleteBtn($listItemClone, $container);
+  }
+
+  return $listItemClone;
+};
+
+var deleteIsEnabled = function ($container) {
+  return !!$container.attr('data-can-delete');
+};
+
+var addDeleteBtn = function ($listItem, $container) {
+  var deleteBtnText = $container.attr('data-delete-btn-text') || DEFAULT_DELETE_BTN_TEXT,
+      $deleteBtn;
+
+  $deleteBtn = $('<a href="#" class="add-remove__remove-btn" data-remove-btn>' + deleteBtnText + '</a>')
+    .click(function (event) {
+      event.preventDefault();
+      $listItem.remove();
+      showAddButton($container);
+    });
+
+  $listItem.append($deleteBtn);
+};
+
+/**
+ * Returns whether or not list is full based on data-max attribute
  * @param $container
  * @returns {boolean}
  */
-var isListFull = function($container) {
-  return $container.find(addRemoveItem).length === parseInt($container.attr(maxItems), 10);
+var maxLengthReached = function ($container) {
+  var listLength = $container.find(addRemoveItem).length;
+  var maxListsAllowed = parseInt($container.attr(maxItems), 10);
+
+  return listLength === maxListsAllowed;
 };
+
+module.exports = init;

--- a/assets/test/specs/addRemove.spec.js
+++ b/assets/test/specs/addRemove.spec.js
@@ -3,114 +3,126 @@
  */
 
 require('jquery');
+var $container1;
+var $container2;
+var $container3;
+var addRemove;
 
-describe("Given I have a list of inputs to add/remove", function() {
+var setup = function () {
+  $container1 = $('#addRemove1');
+  $container2 = $('#addRemove2');
+  $container3 = $('#addRemove3');
+  addRemove();
+};
 
-  jasmine.getFixtures().fixturesPath = "base/specs/fixtures/";
-  var addRemove = require('../../javascripts/modules/addRemove.js');
-  var $container1,
-      $container2;
+describe('Given I have a list of inputs to add/remove', function() {
 
-  describe("When I load the page", function() {
+  beforeEach(function() {
+    jasmine.getFixtures().fixturesPath = 'base/specs/fixtures/';
+    loadFixtures('addRemove-fixture.html');
+    addRemove = require('../../javascripts/modules/addRemove.js');
+  });
 
-    beforeEach(function() {
-      loadFixtures('addRemove-fixture.html');
-      addRemove();
-      $container1 = $('#addRemove1');
-      $container2 = $('#addRemove2');
+  describe('When I load the page', function() {
+    beforeEach(setup);
+
+    it('When delete attribute specified delete buttons should be added to all items except the first', function() {
+      expect($container1.find('li a[data-remove-btn]').length).toBe(2);
     });
-
-    it("Then Delete buttons are added to each item in first container", function() {
-      expect($container1.find('li a[data-remove-btn]').length).toBe(3);
-    });
-
-    it("Then Delete buttons are added to each item in second container", function() {
+    
+    it('No Delete Buttons should be added', function() {
       expect($container2.find('li a[data-remove-btn]').length).toBe(0);
     });
 
-    it("Then Add buttons are inserted in both containers", function() {
+    it('Add buttons should be inserted', function() {
       expect($container1.find('a[data-add-btn]').length).toBe(1);
       expect($container2.find('a[data-add-btn]').length).toBe(1);
     });
 
-    it("Then Add button has the specified text in both containers", function() {
-      expect($container1.find('a[data-add-btn]').text()).toBe('Add another redirect URI');
+    it('Add button should have the custom specified text', function() {
       expect($container2.find('a[data-add-btn]').text()).toBe('Add Item');
     });
 
+    it('Add button should have the default text', function() {
+      expect($container1.find('a[data-add-btn]').text()).toBe('Add another redirect URI');
+    });
+
+    it('Delete button should have the custom specified text', function() {
+      expect($container1.find('a[data-remove-btn]').first().text()).toBe('Press');
+    });
+
+    it('Delete button should have the default text', function() {
+      expect($container3.find('a[data-remove-btn]').text()).toBe('Delete');
+    });
   });
 
-  describe("When I click the Add button within the first container", function() {
+  describe('When I click the Add button', function() {
 
-    beforeEach(function() {
-      loadFixtures('addRemove-fixture.html');
-      addRemove();
-      $container1 = $('#addRemove1');
+    beforeEach(function () {
+      setup();
       $container1.find('a[data-add-btn]').trigger('click');
     });
 
-    it("Then an additional input is added to the list", function() {
-      expect($container1.find('li:nth-child(4)')).toBeVisible();
+    it('An additional input should be added to the list', function() {
+      expect($container1.find('[data-add-remove-item]').length).toBe(4);
     });
 
-    it("Then the additional input has the correct name and id attributes", function() {
-      expect($container1.find('li:nth-child(4) [data-add-remove-unique]').attr('name')).toBe('redirectUris[3]');
+    it('Additional input should have the expected name attribute', function() {
+      var $lastInput = $container1.find('[data-add-remove-input]').last();
+
+      expect($lastInput).toExist();
+      expect($lastInput.attr('name')).toBe('exampleOne[]');
     });
 
-    it("Then a corresponding Delete button is added beside the input", function() {
-      expect($container1.find('li:nth-child(4) a[data-remove-btn]')).toBeVisible();
-    });
+    it('Delete button should be added with the input', function() {
+      var $lastInput = $container1.find('[data-add-remove-item]').last();
+      var $lastInputDeleteBtn = $lastInput.find('[data-remove-btn]')
 
+      expect($lastInput).toExist();
+      expect($lastInputDeleteBtn).toExist();
+    });
   });
 
-  describe("When I add two items in the first container", function() {
+  describe('When I add max number of items', function() {
 
-    beforeEach(function() {
-      loadFixtures('addRemove-fixture.html');
-      addRemove();
-      $container1 = $('#addRemove1');
+    beforeEach(setup);
+
+    it('Then the Add button should be hidden', function() {
       $container1.find('a[data-add-btn]').trigger('click').trigger('click');
-    });
 
-    it("Then the Add button no longer exists", function() {
-      expect($container1.find('[data-add-btn]').length).toBe(0);
+      expect($container1.find('[data-add-btn]')).not.toBeVisible();
     });
-
   });
 
-  describe("When I remove an item from a full list", function() {
+  describe('When I remove an item from a full list', function() {
+    beforeEach(setup);
 
-    beforeEach(function() {
-      loadFixtures('addRemove-fixture.html');
-      addRemove();
-      $container1 = $('#addRemove1');
-      $container1.find('a[data-add-btn]').trigger('click').trigger('click');
+    it('The Add button should exist', function() {
+      var $addBtn = $container1.find('[data-add-btn]');
+
+      $addBtn.trigger('click').trigger('click');
+
+      expect($addBtn).not.toBeVisible();
+
       $container1.find('li:last-child a[data-remove-btn]').trigger('click');
-    });
 
-    it("Then the Add button exists", function() {
-      expect($container1.find('[data-add-btn]')).toBeVisible();
+      expect($addBtn).toBeVisible();
     });
-
   });
 
-  describe("When I click the Add button within the second container", function() {
+  describe('When I click the Add button when delete attribute is not specified', function() {
 
-    beforeEach(function() {
-      loadFixtures('addRemove-fixture.html');
-      addRemove();
-      $container2 = $('#addRemove2');
-      $container2.find('a[data-add-btn]').trigger('click');
+    beforeEach(function () {
+        setup();
+        $container2.find('a[data-add-btn]').trigger('click');
     });
 
-    it("An additional item is added to the list", function() {
-      expect($container2.find('li:nth-child(2)')).toBeVisible();
+    it('An additional item should be added to the list', function() {
+      expect($container2.find('[data-add-remove-item]').length).toBe(3);
     });
 
-    it("No delete button is added", function() {
-      expect($container2.find('li:last-child a[data-remove-btn]').length).toBe(0);
+    it('A delete button should NOT be added', function() {
+      expect($container2.find('[data-remove-btn]').length).toBe(0);
     });
-
   });
-
 });

--- a/assets/test/specs/fixtures/addRemove-fixture.html
+++ b/assets/test/specs/fixtures/addRemove-fixture.html
@@ -1,56 +1,66 @@
 <div id="addRemove1"
-     class="add-remove"
      data-add-remove
-     data-add-remove-max="5"
-     data-attr-name="redirectUris[$]">
-
-  <script type="text/template" data-item-template>
-    <li class="add-remove--item" data-add-remove-item data-removable>
-      <input type="text" value="" data-add-remove-unique/>
+     data-max="5"
+     data-can-delete="true"
+     data-delete-btn-text="Press">
+  <ul class="add-remove__list" data-add-remove-list>
+    <li class="add-remove__item" data-add-remove-item>
+      <input name="exampleOne[]"
+             type="text"
+             class="form-input input--medium"
+             data-add-remove-input/>
     </li>
-  </script>
-  <script type="text/template" data-remove-btn-template>
-    <a href="#" class="add-remove__remove-btn" data-remove-btn>Delete</a>
-  </script>
-  <script type="text/template" data-add-btn-template>
-    <a href="#" data-add-btn>Add another redirect URI</a>
-  </script>
-
-  <ul data-add-remove-list>
-    <li data-add-remove-item data-removable>
-      <input type="text" value="Value 1" name="redirectUris[0]" data-add-remove-unique/>
+    <li class="add-remove__item" data-add-remove-item>
+      <input name="exampleOne[]"
+             type="text"
+             class="form-input input--medium"
+             data-add-remove-input/>
     </li>
-    <li data-add-remove-item data-removable>
-      <input type="text" value="Value 2" name="redirectUris[1]" data-add-remove-unique/>
-    </li>
-    <li data-add-remove-item data-removable>
-      <input type="text" value="Value 3" name="redirectUris[2]" data-add-remove-unique/>
+    <li class="add-remove__item" data-add-remove-item>
+      <input name="exampleOne[]"
+             type="text"
+             class="form-input input--medium"
+             data-add-remove-input/>
     </li>
   </ul>
 </div>
 
-
 <div id="addRemove2"
-     class="add-remove"
      data-add-remove
-     data-add-remove-max="10">
-
-  <script type="text/template" data-item-template>
-    <li data-add-remove-item>
-      <p>Item 1</p>
+     data-max="10"
+     data-add-btn-text="Add Item">
+  <ul class="add-remove__list" data-add-remove-list>
+    <li class="add-remove__item" data-add-remove-item>
+      <input name="exampleTwo[]"
+             type="text"
+             class="form-input input--medium"
+             data-add-remove-input />
     </li>
-  </script>
-  <script type="text/template" data-remove-btn-template>
-    <a href="#" class="add-remove__remove-btn" data-remove-btn>Delete</a>
-  </script>
-  <script type="text/template" data-add-btn-template>
-    <a href="#" data-add-btn>Add Item</a>
-  </script>
-
-  <ul data-add-remove-list>
-    <li data-add-remove-item>
-      <p>Item 1</p>
+    <li class="add-remove__item" data-add-remove-item>
+      <input name="exampleTwo[]"
+             type="text"
+             class="form-input input--medium"
+             data-add-remove-input />
     </li>
   </ul>
+</div>
 
+<div id="addRemove3"
+     data-add-remove
+     data-max="4"
+     data-can-delete="true">
+  <ul class="add-remove__list" data-add-remove-list>
+    <li class="add-remove__item" data-add-remove-item>
+      <input name="exampleThree[]"
+             type="text"
+             class="form-input input--medium"
+             data-add-remove-input />
+    </li>
+    <li class="add-remove__item" data-add-remove-item>
+      <input name="exampleThree[]"
+             type="text"
+             class="form-input input--medium"
+             data-add-remove-input />
+    </li>
+  </ul>
 </div>


### PR DESCRIPTION
# Add/Remove

A refactor on the add remove module

- bring template script functionality into JavaScript, 
- add ability to send in custom delete and add button text, 
- added ability to turn on/off delete functionality, 
- updated usage comments, 
- fix bug to do with order of inputs and deletion

### Data Attribute Details
- `data-can-delete="true"` to add delete buttons
- `data-delete-btn-text` to send in custom delete button text, this defaults to **Delete** and will only work when the
 `data-can-delete="true"` is set
- `data-add-btn-text` to send in custom add button text, this defaults to **Add another redirect URI**
- `data-max` Maximum items allowed in the list


### Markup Example
```
<div data-add-remove
     data-max="5"
     data-can-delete="true",
     data-delete-btn-text="Delete Me"
     data-add-btn-text="Add Me">
  <ul class="add-remove__list" data-add-remove-list>
    <li class="add-remove__item" data-add-remove-item>
      <input name="example[]"
             type="text"
             class="form-input input--medium"
             data-add-remove-input />
    </li>
    <li class="add-remove__item" data-add-remove-item>
      <input name="example[]"
             type="text"
             class="form-input input--medium"
             data-add-remove-input />
    </li>
  </ul>
</div>
```
### Tests
<img width="367" alt="screen shot 2016-04-01 at 13 27 17" src="https://cloud.githubusercontent.com/assets/2305016/14206788/7e1f424c-f80d-11e5-9d68-a365f04c6b8c.png">



### Example
![addremove](https://cloud.githubusercontent.com/assets/2305016/14206489/58e39192-f80b-11e5-8199-36de85f8671d.gif)


