### PR TITLE
Changed example hero heading and subheading text to be generic

### DIFF
--- a/assets/scss/modules/_hero.scss
+++ b/assets/scss/modules/_hero.scss
@@ -10,9 +10,9 @@ Provides classes for a heading and a subheading.
 Markup:
 <header class="hero">  
     <section class="hero__content">        
-        <h1 class="hero__heading-large">HMRC API Developer Hub</h1>
+        <h1 class="hero__heading-large">Hero Heading</h1>
         <h2 class="hero__heading-small">
-          Tax-related APIs for building smarter software
+          Hero subheading
         </h2>
     </section>
 </header>


### PR DESCRIPTION
Remove service-specific heading example text, and replaced with this:

<img width="791" alt="screen shot 2016-04-01 at 4 05 45 pm" src="https://cloud.githubusercontent.com/assets/1764083/14211010/a033fba0-f823-11e5-884e-2b4b09142ad9.png">
