### PR TITLE
Back To Top Component

### DIFF
--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -85,6 +85,7 @@ $path: "../images/icons/";
 @import "modules/tabs";
 @import "components/modal-dialog";
 @import "components/app-info";
+@import "components/back-to-top";
 
 // Page Specific Styles
 @import "pages/messages";

--- a/assets/scss/components/_back-to-top.scss
+++ b/assets/scss/components/_back-to-top.scss
@@ -1,24 +1,21 @@
 /*
-Back To Top Link
+Back To Top
 
 A link which typically sits at the bottom of the page, or the bottom of a long section.
 Clicking this link scrolls the user back to the top of the page.
 
 Markup:
 <div class="back-to-top">
-  <a href="#" class="back-to-top__link">Back to top</a>
+  <a href="#">Back to top</a>
 </div>
 
-Styleguide Back To Top Link
+Styleguide Back To Top
 */
 
 .back-to-top {
   margin-top: em(40);
   padding-top: em(20);
   border-top: 2px solid $border-colour;
-}
-
-.back-to-top__link {
-  @include bold-16;
-  float: right;
+  text-align: right;
+  @include bold-16;  
 }

--- a/assets/scss/components/_back-to-top.scss
+++ b/assets/scss/components/_back-to-top.scss
@@ -1,0 +1,24 @@
+/*
+Back To Top Link
+
+A link which typically sits at the bottom of the page, or the bottom of a long section.
+Clicking this link scrolls the user back to the top of the page.
+
+Markup:
+<div class="back-to-top">
+  <a href="#" class="back-to-top__link">Back to top</a>
+</div>
+
+Styleguide Back To Top Link
+*/
+
+.back-to-top {
+  margin-top: em(40);
+  padding-top: em(20);
+  border-top: 2px solid $border-colour;
+}
+
+.back-to-top__link {
+  @include bold-16;
+  float: right;
+}

--- a/assets/scss/modules/_navigation.scss
+++ b/assets/scss/modules/_navigation.scss
@@ -136,14 +136,3 @@ a.back-link {
   
 }
 
-
-
-a.back-to-top-link {
-  @include bold-16;
-  margin: 0 0 em(10) 0;
-
-  &:visited {
-    color: $govuk-blue-colour;
-  }
-
-}


### PR DESCRIPTION
## Description

A link which typically sits at the bottom of the page, or the bottom of a long section. Clicking this link scrolls the user back to the top of the page.

## Screenshot
![screencapture-localhost-9032-component-library-section-back-to-top-html-1459775624220](https://cloud.githubusercontent.com/assets/1764083/14248989/797c8fba-fa6f-11e5-9661-ca693d831dc3.png)

## Other Cleanup

I also removed the `back-to-top-link` class from `navigiation.scss` as it's now redundant. This class was only being used by an API service.