### PR TITLE
Added button--flush modifier

### DIFF
--- a/assets/scss/base/_buttons.scss
+++ b/assets/scss/base/_buttons.scss
@@ -8,12 +8,14 @@ If you are using an `<a>` element please also apply the `role="button"` attribut
 Markup:
 <button class="button {{modifier_class}}">Button text</button>
 
-.button--get-started   - For a button to start a user journey
-.button--secondary     - A secondary button
-.button--alert         - An alert button
-.button--small         - A smaller button
-.button--table         - A button within a table
-.button.button--link   - To make a button appear like a link
+.button--get-started           - For a button to start a user journey
+.button--secondary             - A secondary button
+.button--alert                 - An alert button
+.button--small                 - A smaller button
+.button--table                 - A button within a table
+.button.button--link           - To make a button appear like a link
+.button--link.button--flush    - Button that looks like link with margin and padding removed
+
 
 Styleguide Buttons
 */
@@ -66,7 +68,12 @@ button, .button {
 // adds margin on left and right of button for situations
 // where button is sitting inline with other elements
 .button--spaced {
-  margin: 0 em(10) 0 em(10);
+  margin: em(10) 0 0 0;
+
+  @include media(tablet) {
+    margin: 0 em(10) 0 em(10);  
+  }
+
 }
 
 // adds left and right padding for buttons whose text is extremely short
@@ -74,6 +81,7 @@ button, .button {
   padding-left: em(30);
   padding-right: em(30);
 }
+
 
 /**
  * For links that need to be positioned beside buttons
@@ -108,6 +116,12 @@ button, .button {
   @include media(mobile) {
     margin-top: 10px;
   }
+}
+
+.button--link.button--flush {
+  margin: 0;
+  padding: 0;
+  line-height: 20px;
 }
 
 /* Transforms button into a link */


### PR DESCRIPTION
## Background

Originally, `.button--link` was created for buttons that need to look like links. Smells of bigger problems, I know. However, the margins and paddings were maintained, making the link text line up nicely with any buttons sitting next to it.

But...we want to be able to use link-styled buttons elsewhere, for example:

![screen shot 2016-04-04 at 4 28 01 pm](https://cloud.githubusercontent.com/assets/1764083/14253144/3cd0bdb2-fa82-11e5-85a8-a7ec39c74d0d.png)

In that situation, we don't want to maintain margins and paddings like buttons have. A `line-height:20px` was also added here. I did this because otherwise the "Remove" link in my example didn't line up with other text in the table row.

## Component Library Entry

<img width="840" alt="screen shot 2016-04-04 at 4 24 54 pm" src="https://cloud.githubusercontent.com/assets/1764083/14253229/8bfe6fb0-fa82-11e5-9487-d239fd07d66b.png">

## Problems

I'm not quite happy with how I've implemented this and would like your input. I've created a `button--flush` class that is dependent on `button--link` (as it doesn't make sense without it). Any thoughts on how this could be done better guys? Should I separate `.button--flush` out?