### PR TITLE
Component library - component data

### DIFF
--- a/assets/scss/components/_auto-complete.scss
+++ b/assets/scss/components/_auto-complete.scss
@@ -2,6 +2,7 @@
 Auto Complete
 
 The Auto complete is used to aid a user with a large amount of choices they may have to make.
+The example shown here has country information for the `United Kingdom`, `Afghanistan`, `Sierra Leone and Wallis` and `Futuna`.
 
 Markup:
 <fieldset class="form-field-group">
@@ -28,6 +29,9 @@ Markup:
     </div>
   </label>
 </fieldset>
+
+ExampleData:
+var countries = [{"title": "United Kingdom","value": "44"},{"title": "Afghanistan","value": "93"},{"title": "Sierra Leone","value": "232"},{"title": "Wallis and Futuna","value": "681"}];
 
 Styleguide AutoComplete
 */

--- a/assets/scss/components/_auto-complete.scss
+++ b/assets/scss/components/_auto-complete.scss
@@ -30,7 +30,7 @@ Markup:
   </label>
 </fieldset>
 
-ExampleData:
+Example Data:
 var countries = [{"title": "United Kingdom","value": "44"},{"title": "Afghanistan","value": "93"},{"title": "Sierra Leone","value": "232"},{"title": "Wallis and Futuna","value": "681"}];
 
 Styleguide AutoComplete

--- a/component-lib.json
+++ b/component-lib.json
@@ -14,5 +14,5 @@
   "helpers": [
     "node_modules/hmrc-component-library-template/helpers/"
   ],
-  "custom": ["ExampleData"]
+  "custom": ["Example Data"]
 }

--- a/component-lib.json
+++ b/component-lib.json
@@ -13,5 +13,6 @@
   "homepage": "../../styleguide.md",
   "helpers": [
     "node_modules/hmrc-component-library-template/helpers/"
-  ]
+  ],
+  "custom": ["ExampleData"]
 }


### PR DESCRIPTION
# ComponentData

For the AutoComplete to display in the component library it needs to be accompanied with some mock data. In the examples case an array of countries:

```
<script type="application/json" id="suggestions">
[
   {"title": "United Kingdom","value": "44"},
   {"title": "Afghanistan","value": "93"},
   {"title": "Sierra Leone","value": "232"},
   {"title": "Wallis and Futuna","value": "681"}
]
</script>
```

This data was previously *hardcoded* via a partial in the component-library-template

The comment is sent in via the `ComponentData` attribute (`data` has already been taken) and will be added to the components page.

### Of Note
Once this is merged I will document this functionality in the Wiki