### PR TITLE
Auto complete data source refactor

### DIFF
--- a/assets/javascripts/modules/autoComplete.js
+++ b/assets/javascripts/modules/autoComplete.js
@@ -319,31 +319,22 @@ var suggestionsEvent = function () {
  * @param $elem
  * @param $targetElem
  */
-var setup = function ($elem, $targetElem, suggestionFormat) {
+var setup = function ($elem, suggestionsData, $targetElem, suggestionFormat) {
   $autoCompleteInputElem = $elem;
   $targetInput = $targetElem;
   suggestionDisplayFormat = suggestionFormat;
-  $suggestionsData = $('#suggestions');
+  suggestions = suggestionsData;
   $clearInputButton = $('.js-suggestions-clear');
   $suggestionsContainer = $('.js-suggestions').first();
   $suggestionsStatusMessage = $('.js-suggestions-status-message').first();
-  getSuggestions();
-};
-
-/**
- * parse suggestions JSON data
- */
-var getSuggestions = function () {
-  try {
-    suggestions = JSON.parse($suggestionsData.html());
-  } catch (error) {
-    //TODO - add reporting?
-  }
 };
 
 /**
  * create the autoComplete
  * @param $autoCompleteInputElem
+ *
+ * @param suggestionsData
+ * The suggestion data used in the autoComplete. Typically this will be a global variable.
  *
  * @param $targetInputElem - [optional]
  * Input element to apply the suggestion.value too when a suggestion is selected. If this is not supplied then the autoComplete input will contain the
@@ -351,10 +342,11 @@ var getSuggestions = function () {
  *
  * @param suggestionFormat - [optional]
  * Format for the suggestion to be displayed in the suggestion list, this will default to suggestion.title if a format is not supplied
+ *
  */
-var build = function ($autoCompleteInputElem, $targetInputElem, suggestionFormat) {
+var build = function ($autoCompleteInputElem, suggestionsData, $targetInputElem, suggestionFormat) {
   if ($autoCompleteInputElem.length) {
-    setup($autoCompleteInputElem, $targetInputElem, suggestionFormat);
+    setup($autoCompleteInputElem, suggestionsData, $targetInputElem, suggestionFormat);
     addEventListeners();
   }
 };

--- a/assets/javascripts/modules/autoComplete.js
+++ b/assets/javascripts/modules/autoComplete.js
@@ -4,7 +4,7 @@ require('jquery');
 
 Suggestions AutoComplete module
 - Create an autoComplete with the following markup
-- Create a JSON suggestions object with the following markup
+- Create a global suggestions object, the structure is demonstrated below
 - Optionally provide a target input to update with suggestions value
 
 
@@ -28,10 +28,10 @@ Suggestions auto complete html markup:
  </div>
 
 
-Suggestions JSON data format:
+Suggestions Data format:
 
- <script type="application/json" id="suggestions">
-  [{"title":"United Kingdom","value":"44"}]
+ <script type="application/json">
+  var countries = [{"title":"United Kingdom","value":"44"}]
  </script>
 
 */

--- a/assets/javascripts/modules/autoComplete.js
+++ b/assets/javascripts/modules/autoComplete.js
@@ -2,13 +2,13 @@ require('jquery');
 
 /*
 
-Suggestions AutoComplete module
+AutoComplete module
 - Create an autoComplete with the following markup
-- Create a global suggestions object, the structure is demonstrated below
+- Create a JSON object as a global variable, the structure is demonstrated below
 - Optionally provide a target input to update with suggestions value
 
 
-Suggestions auto complete html markup:
+Auto complete html markup:
 
  <div class="suggestions-input-container">
     <input type="text"
@@ -28,16 +28,15 @@ Suggestions auto complete html markup:
  </div>
 
 
-Suggestions Data format:
+Data format:
 
- <script type="application/json">
+<script type="text/javascript">
   var countries = [{"title":"United Kingdom","value":"44"}]
- </script>
+</script>
 
 */
 
 var suggestions;
-var $suggestionsData;
 var $suggestionsContainer;
 var $autoCompleteInputElem;
 var $targetInput;
@@ -315,22 +314,8 @@ var suggestionsEvent = function () {
 };
 
 /**
- * setup variables and get suggestion data
- * @param $elem
- * @param $targetElem
- */
-var setup = function ($elem, suggestionsData, $targetElem, suggestionFormat) {
-  $autoCompleteInputElem = $elem;
-  $targetInput = $targetElem;
-  suggestionDisplayFormat = suggestionFormat;
-  suggestions = suggestionsData;
-  $clearInputButton = $('.js-suggestions-clear');
-  $suggestionsContainer = $('.js-suggestions').first();
-  $suggestionsStatusMessage = $('.js-suggestions-status-message').first();
-};
-
-/**
- * create the autoComplete
+ * setup variables and create the autoComplete
+ *
  * @param $autoCompleteInputElem
  *
  * @param suggestionsData
@@ -344,11 +329,18 @@ var setup = function ($elem, suggestionsData, $targetElem, suggestionFormat) {
  * Format for the suggestion to be displayed in the suggestion list, this will default to suggestion.title if a format is not supplied
  *
  */
-var build = function ($autoCompleteInputElem, suggestionsData, $targetInputElem, suggestionFormat) {
-  if ($autoCompleteInputElem.length) {
-    setup($autoCompleteInputElem, suggestionsData, $targetInputElem, suggestionFormat);
+var setup = function ($elem, suggestionsData, $targetInputElem, suggestionFormat) {
+  if ($elem.length) {
+    $autoCompleteInputElem = $elem;
+    $targetInput = $targetInputElem;
+    suggestionDisplayFormat = suggestionFormat;
+    suggestions = suggestionsData;
+    $clearInputButton = $('.js-suggestions-clear');
+    $suggestionsContainer = $('.js-suggestions').first();
+    $suggestionsStatusMessage = $('.js-suggestions-status-message').first();
+
     addEventListeners();
   }
 };
 
-module.exports = build;
+module.exports = setup;

--- a/assets/javascripts/modules/autoCompleteFactory.js
+++ b/assets/javascripts/modules/autoCompleteFactory.js
@@ -8,7 +8,7 @@ var createAutoCompleteCountries = function () {
     return title + ' (+' + value + ')';
   };
 
-  autoComplete($chooseCountryAutoCompleteElem.first(), $countryCodeInput, suggestionDisplayTemplate);
+  autoComplete($chooseCountryAutoCompleteElem.first(), countries, $countryCodeInput, suggestionDisplayTemplate);
 };
 
 module.exports = function () {


### PR DESCRIPTION
# Auto complete data source refactor

A body of work to enable the sending in of suggestions for the autoComplete via a `global` variable rather than interrogating a script tag via the id `suggestions`. 
This work is associated with https://github.com/hmrc/assets-frontend/pull/521

- update signiture of autoComplete to take an object of suggestions rather than using an `id` on a script tag
- update comments