### PR TITLE
Updated AddRemove component

### DIFF
--- a/assets/javascripts/modules/addRemove.js
+++ b/assets/javascripts/modules/addRemove.js
@@ -135,7 +135,7 @@ var createItem = function ($container) {
 };
 
 var deleteIsEnabled = function ($container) {
-  return $container.attr('data-can-delete') === "true";
+  return $container.attr('data-can-delete') === 'true';
 };
 
 var addDeleteBtn = function ($listItem, $container) {

--- a/assets/javascripts/modules/addRemove.js
+++ b/assets/javascripts/modules/addRemove.js
@@ -2,16 +2,16 @@
 Add Remove
 
 A component to add and remove inputs on a page. You have the option of sending in custom attributes for:
-- `data-can-delete="true"` to add delete buttons
+- `data-can-delete="true"` to add delete buttons (without this attribute, no delete buttons will be rendered)
 - `data-delete-btn-text` to send in custom delete button text, this defaults to **Delete** and will only work when the
- `data-can-delete="true"` is set
-- `data-add-btn-text` to send in custom add button text, this defaults to **Add another redirect URI**
+  `data-can-delete="true"` is set
+- `data-add-btn-text` to send in custom add button text, this defaults to **Add**
 - `data-max` Maximum items allowed in the list
 
 Markup:
 <div data-add-remove
      data-max="5"
-     data-can-delete="true",
+     data-can-delete="true"
      data-delete-btn-text="Delete Me"
      data-add-btn-text="Add Me">
   <ul class="add-remove__list" data-add-remove-list>
@@ -31,7 +31,7 @@ Markup:
 </div>
  */
 
-var DEFAULT_ADD_BTN_TEXT = 'Add another redirect URI',
+var DEFAULT_ADD_BTN_TEXT = 'Add',
     DEFAULT_DELETE_BTN_TEXT = 'Delete',
     addRemoveContainer = '[data-add-remove]',
     addRemoveList = '[data-add-remove-list]',
@@ -50,6 +50,7 @@ var init = function () {
 
       if (deleteIsEnabled($container)) {
         $container.find(addRemoveItem).each(function (index, listItem) {
+          // must always be at least one input on the page for cloning new ones
           if (index > 0) {
             addDeleteBtn($(listItem), $container);
           }
@@ -134,7 +135,7 @@ var createItem = function ($container) {
 };
 
 var deleteIsEnabled = function ($container) {
-  return !!$container.attr('data-can-delete');
+  return $container.attr('data-can-delete') === "true";
 };
 
 var addDeleteBtn = function ($listItem, $container) {

--- a/assets/test/specs/addRemove.spec.js
+++ b/assets/test/specs/addRemove.spec.js
@@ -6,12 +6,14 @@ require('jquery');
 var $container1;
 var $container2;
 var $container3;
+var $container4;
 var addRemove;
 
 var setup = function () {
   $container1 = $('#addRemove1');
   $container2 = $('#addRemove2');
   $container3 = $('#addRemove3');
+  $container4 = $('#addRemove4');
   addRemove();
 };
 
@@ -44,7 +46,7 @@ describe('Given I have a list of inputs to add/remove', function() {
     });
 
     it('Add button should have the default text', function() {
-      expect($container1.find('a[data-add-btn]').text()).toBe('Add another redirect URI');
+      expect($container1.find('a[data-add-btn]').text()).toBe('Add');
     });
 
     it('Delete button should have the custom specified text', function() {
@@ -54,6 +56,19 @@ describe('Given I have a list of inputs to add/remove', function() {
     it('Delete button should have the default text', function() {
       expect($container3.find('a[data-remove-btn]').text()).toBe('Delete');
     });
+
+    it("Delete buttons should not be present on container 2", function() {
+      expect($container2.find('a[data-remove-btn]').length).toBe(0);
+    });
+
+    it("Delete buttons should be present on container 3", function() {
+      expect($container3.find('a[data-remove-btn]').length).toBe(1);
+    });
+
+    it("Delete buttons should not be present on container 4", function() {
+      expect($container4.find('a[data-remove-btn]').length).toBe(0);
+    });
+
   });
 
   describe('When I click the Add button', function() {
@@ -81,6 +96,7 @@ describe('Given I have a list of inputs to add/remove', function() {
       expect($lastInput).toExist();
       expect($lastInputDeleteBtn).toExist();
     });
+
   });
 
   describe('When I add max number of items', function() {
@@ -92,6 +108,7 @@ describe('Given I have a list of inputs to add/remove', function() {
 
       expect($container1.find('[data-add-btn]')).not.toBeVisible();
     });
+
   });
 
   describe('When I remove an item from a full list', function() {
@@ -108,6 +125,7 @@ describe('Given I have a list of inputs to add/remove', function() {
 
       expect($addBtn).toBeVisible();
     });
+
   });
 
   describe('When I click the Add button when delete attribute is not specified', function() {
@@ -124,5 +142,6 @@ describe('Given I have a list of inputs to add/remove', function() {
     it('A delete button should NOT be added', function() {
       expect($container2.find('[data-remove-btn]').length).toBe(0);
     });
+
   });
 });

--- a/assets/test/specs/addRemove.spec.js
+++ b/assets/test/specs/addRemove.spec.js
@@ -57,15 +57,15 @@ describe('Given I have a list of inputs to add/remove', function() {
       expect($container3.find('a[data-remove-btn]').text()).toBe('Delete');
     });
 
-    it("Delete buttons should not be present on container 2", function() {
+    it('Delete buttons should not be present on container 2', function() {
       expect($container2.find('a[data-remove-btn]').length).toBe(0);
     });
 
-    it("Delete buttons should be present on container 3", function() {
+    it('Delete buttons should be present on container 3', function() {
       expect($container3.find('a[data-remove-btn]').length).toBe(1);
     });
 
-    it("Delete buttons should not be present on container 4", function() {
+    it('Delete buttons should not be present on container 4', function() {
       expect($container4.find('a[data-remove-btn]').length).toBe(0);
     });
 

--- a/assets/test/specs/fixtures/addRemove-fixture.html
+++ b/assets/test/specs/fixtures/addRemove-fixture.html
@@ -64,3 +64,23 @@
     </li>
   </ul>
 </div>
+
+<div id="addRemove4"
+     data-add-remove
+     data-max="4"
+     data-can-delete="false">
+  <ul class="add-remove__list" data-add-remove-list>
+    <li class="add-remove__item" data-add-remove-item>
+      <input name="exampleThree[]"
+             type="text"
+             class="form-input input--medium"
+             data-add-remove-input />
+    </li>
+    <li class="add-remove__item" data-add-remove-item>
+      <input name="exampleThree[]"
+             type="text"
+             class="form-input input--medium"
+             data-add-remove-input />
+    </li>
+  </ul>
+</div>


### PR DESCRIPTION
Following updates to AddRemove JS component:

 * Added more explicit comment to `data-can-delete` feature.
 * Set default Add button text to "Add" (shouldn't be service-specific).
 * Updated boolean expression evaluation in `deleteIsEnabled()` method to be more readable.
 * Added jasmine tests to cover 3 different configurations of `data-can-delete`.
 * Added Add/Remove HTML to fixtures for additional test.