### PR TITLE
Specify versions of requirement and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,23 +29,25 @@ $ sm --start ASSETS_FRONTEND
 
 ### Requirements
 
-* [node.js](https://nodejs.org/en/)
-* [npm](https://www.npmjs.com/)
-* [nodemon](https://github.com/remy/nodemon) (for [working on the Component Library](working-on-the-component-library))
+* [Node.js](https://nodejs.org/en/) `>= 0.12.7`
+* [npm](https://www.npmjs.com/) `>= 2.11.3`
 
-#### [node.js](https://nodejs.org/en/) & [npm](https://www.npmjs.com/)
+#### [Node.js](https://nodejs.org/en/) & [npm](https://www.npmjs.com/)
 
-Please install node.js and npm. 
-You may find it easier to use the Node Version Manager [nvm](https://github.com/creationix/nvm)
+To install multiple versions of Node.js, you may find it easier to use a node version manager:
 
-#### nodemon
+* [nvm](https://github.com/creationix/nvm)
+* [n](https://github.com/tj/n)
+
+#### [nodemon](http://nodemon.io/) (optional)
+
+`nodemon` is used to develop [the Component Library](working-on-the-component-library).
 
 It is recommended to install nodemon globally.
 
 ```
 $ npm install -g nodemon
 ```
-
 
 ### Running Locally (Development mode)
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "type": "git",
     "url": "https://github.com/hmrc/assets-frontend.git"
   },
+  "engines" : {
+    "node" : ">=0.12.7",
+    "npm": ">=2.11.3"
+  },
   "scripts": {
     "install": "napa",
     "start": "npm run dev",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "minifyify": "^6.0.0",
     "modernizr": "^3.0.0-alpha.4",
     "napa": "^1.2.0",
+    "phantomjs-prebuilt": "^2.1.7",
     "pretty-hrtime": "^1.0.0",
     "require-dir": "^0.2.0",
     "run-sequence": "^1.0.2",


### PR DESCRIPTION
Using older versions of node and/or npm leads to conflicts with dependancies.

This specifies the versions we should be using in order to avoid those conflicts and the README's been updated.

There was also a missing dependancy for phantomJS when using a version of node greater than 5. That's been added.