### PR TITLE
Add/Remove Component Bug Fix

### DIFF
--- a/assets/javascripts/modules/addRemove.js
+++ b/assets/javascripts/modules/addRemove.js
@@ -123,7 +123,7 @@ var createItem = function ($container) {
   var $listItemClone,
       $input;
 
-  $listItemClone = $container.find(addRemoveItem).first().clone();
+  $listItemClone = $container.find(addRemoveItem).last().clone();
   $input = $listItemClone.find(addRemoveInput);
   $input.val('');
 

--- a/assets/javascripts/modules/addRemove.js
+++ b/assets/javascripts/modules/addRemove.js
@@ -13,9 +13,10 @@ Markup:
      data-max="5"
      data-can-delete="true"
      data-delete-btn-text="Delete Me"
-     data-add-btn-text="Add Me">
+     data-add-btn-text="Add Me"
+     data-template-item="data-template">
   <ul class="add-remove__list" data-add-remove-list>
-    <li class="add-remove__item" data-add-remove-item>
+    <li class="add-remove__item" data-add-remove-item data-template>
       <input name="example[]"
              type="text"
              class="form-input input--medium"
@@ -37,6 +38,7 @@ var DEFAULT_ADD_BTN_TEXT = 'Add',
     addRemoveList = '[data-add-remove-list]',
     addRemoveItem = '[data-add-remove-item]',
     addRemoveInput = '[data-add-remove-input]',
+    template = '[data-template]',
     addButton = '[data-add-btn]',
     maxItems = 'data-max';
 
@@ -121,10 +123,14 @@ var addListItem = function ($container) {
  */
 var createItem = function ($container) {
   var $listItemClone,
-      $input;
-
-  $listItemClone = $container.find(addRemoveItem).last().clone();
+      $input,
+      dataTemplateItem;
+  
+  dataTemplateItem = $container.attr('data-template-item');
+  $listItemClone = $container.find('[' + dataTemplateItem + ']').clone();
+  $listItemClone.removeAttr('data-template');
   $input = $listItemClone.find(addRemoveInput);
+
   $input.val('');
 
   if (deleteIsEnabled($container)) {

--- a/assets/scss/components/_add-remove.scss
+++ b/assets/scss/components/_add-remove.scss
@@ -21,12 +21,6 @@ Markup:
              class="form-input input--medium"
              data-add-remove-input />
     </li>
-    <li class="add-remove__item" data-add-remove-item>
-      <input name="example[]"
-             type="text"
-             class="form-input input--medium"
-             data-add-remove-input/>
-    </li>
   </ul>
 </div>
 

--- a/assets/scss/components/_add-remove.scss
+++ b/assets/scss/components/_add-remove.scss
@@ -12,9 +12,10 @@ Markup:
      data-max="5"
      data-can-delete="true"
      data-add-btn-text="Add me"
-     data-delete-btn-text="Delete me">
+     data-delete-btn-text="Delete me"
+     data-template-item="data-template">
   <ul class="add-remove__list" data-add-remove-list>
-    <li class="add-remove__item" data-add-remove-item>
+    <li class="add-remove__item" data-add-remove-item data-template>
       <input name="example[]"
              type="text"
              class="form-input input--medium"
@@ -24,7 +25,7 @@ Markup:
       <input name="example[]"
              type="text"
              class="form-input input--medium"
-             data-add-remove-input />
+             data-add-remove-input/>
     </li>
   </ul>
 </div>

--- a/assets/test/specs/fixtures/addRemove-fixture.html
+++ b/assets/test/specs/fixtures/addRemove-fixture.html
@@ -2,9 +2,10 @@
      data-add-remove
      data-max="5"
      data-can-delete="true"
-     data-delete-btn-text="Press">
+     data-delete-btn-text="Press"
+     data-template-item="data-template">
   <ul class="add-remove__list" data-add-remove-list>
-    <li class="add-remove__item" data-add-remove-item>
+    <li class="add-remove__item" data-add-remove-item data-template>
       <input name="exampleOne[]"
              type="text"
              class="form-input input--medium"
@@ -28,9 +29,10 @@
 <div id="addRemove2"
      data-add-remove
      data-max="10"
-     data-add-btn-text="Add Item">
+     data-add-btn-text="Add Item"
+     data-template-item="data-template">
   <ul class="add-remove__list" data-add-remove-list>
-    <li class="add-remove__item" data-add-remove-item>
+    <li class="add-remove__item" data-add-remove-item data-template>
       <input name="exampleTwo[]"
              type="text"
              class="form-input input--medium"
@@ -48,9 +50,10 @@
 <div id="addRemove3"
      data-add-remove
      data-max="4"
-     data-can-delete="true">
+     data-can-delete="true"
+     data-template-item="data-template">
   <ul class="add-remove__list" data-add-remove-list>
-    <li class="add-remove__item" data-add-remove-item>
+    <li class="add-remove__item" data-add-remove-item data-template>
       <input name="exampleThree[]"
              type="text"
              class="form-input input--medium"
@@ -68,9 +71,10 @@
 <div id="addRemove4"
      data-add-remove
      data-max="4"
-     data-can-delete="false">
+     data-can-delete="false"
+     data-template-item="data-template">
   <ul class="add-remove__list" data-add-remove-list>
-    <li class="add-remove__item" data-add-remove-item>
+    <li class="add-remove__item" data-add-remove-item data-template>
       <input name="exampleThree[]"
              type="text"
              class="form-input input--medium"


### PR DESCRIPTION
## Overview 

Currently, adding a new item clones the first item in the list. However, the first item is not always a text input. Sometimes it's a read only field. Therefore, for cloning to work in all cases, the last item should be cloned, which is always a text input.

## Screenshot
<img width="615" alt="screen shot 2016-04-08 at 12 37 41 pm" src="https://cloud.githubusercontent.com/assets/1764083/14382603/e7085eb4-fd86-11e5-87ce-ccc9b2617704.png">

