### PR TITLE
Add styles for inline freetext date field

### DIFF
--- a/assets/scss/base/form/_form.scss
+++ b/assets/scss/base/form/_form.scss
@@ -227,6 +227,16 @@ Styleguide Form.date
   @include ie-lte(7) {
     zoom: 1;
   }
+
+  input[type="text"] {
+    margin-left: 0;
+  }
+
+  .form-group {
+    @include media(mobile) {
+      width: 100%;
+    }
+  }
 }
 
 .form-date .form-group-year {


### PR DESCRIPTION
We created a new date input component on play-ui and these are the associated styles.

There are no considerations for its use.

![screenshot from 2016-04-12 16 43 26](https://cloud.githubusercontent.com/assets/8497852/14466265/eec25d22-00cd-11e6-9021-5515022892d0.png)
