### PR TITLE
[API-1370] Added caching of cloneable item HTML

### DIFF
--- a/assets/javascripts/modules/addRemove.js
+++ b/assets/javascripts/modules/addRemove.js
@@ -53,8 +53,6 @@ var init = function () {
       var $container = $(container),
           $cloneableItem = $container.find('[' + $container.attr('data-template-item') + ']');
 
-      //$container.data('index', i);
-
       if($cloneableItem.length > 0) {
       
         // cache this AddRemove instance's item template for when Add is clicked
@@ -136,11 +134,13 @@ var addListItem = function ($container) {
  * @returns {*}
  */
 var createItem = function ($container) {
-  var $listItemClone,
+  var cachedTemplateIndex,
+      $listItemClone,
       $input;
 
-  // cloneable item is cached for this instance of AddRemove
-  $listItemClone = $addRemoveContainers.index($container);
+  cachedTemplateIndex = $addRemoveContainers.index($container);
+
+  $listItemClone = $(cachedTemplate[cachedTemplateIndex]);
 
   $input = $listItemClone.find(addRemoveInput);
 

--- a/assets/javascripts/modules/addRemove.js
+++ b/assets/javascripts/modules/addRemove.js
@@ -7,9 +7,11 @@ A component to add and remove inputs on a page. You have the option of sending i
   `data-can-delete="true"` is set
 - `data-add-btn-text` to send in custom add button text, this defaults to **Add**
 - `data-max` Maximum items allowed in the list
+- each instance's outer div MUST have an ID so that the cloneable item html can be cached for that instance
 
 Markup:
-<div data-add-remove
+<div id="uniqueId"
+     data-add-remove
      data-max="5"
      data-can-delete="true"
      data-delete-btn-text="Delete Me"
@@ -40,7 +42,8 @@ var DEFAULT_ADD_BTN_TEXT = 'Add',
     addRemoveInput = '[data-add-remove-input]',
     template = '[data-template]',
     addButton = '[data-add-btn]',
-    maxItems = 'data-max';
+    maxItems = 'data-max',
+    cachedTemplate = [];
 
 var init = function () {
   var $addRemoveContainers = $(addRemoveContainer);
@@ -48,7 +51,15 @@ var init = function () {
   if ($addRemoveContainers.length) {
 
     $addRemoveContainers.each(function (i, container) {
-      var $container = $(container);
+      var $container = $(container),
+          $cloneableItem = $container.find('[' + $container.attr('data-template-item') + ']');
+
+      if($cloneableItem.length > 0) {
+
+        // cache this AddRemove instance's item template for when Add is clicked
+        cachedTemplate[$container.attr('id')] = $cloneableItem[0].outerHTML;
+
+      }
 
       if (deleteIsEnabled($container)) {
         $container.find(addRemoveItem).each(function (index, listItem) {
@@ -64,7 +75,9 @@ var init = function () {
         insertAddButton($container);
       }
     });
+
   }
+
 };
 
 /**
@@ -123,12 +136,11 @@ var addListItem = function ($container) {
  */
 var createItem = function ($container) {
   var $listItemClone,
-      $input,
-      dataTemplateItem;
-  
-  dataTemplateItem = $container.attr('data-template-item');
-  $listItemClone = $container.find('[' + dataTemplateItem + ']').clone();
-  $listItemClone.removeAttr('data-template');
+      $input;
+
+  // cloneable item is cached for this instance of AddRemove
+  $listItemClone = $(cachedTemplate[$container.attr('id')]);
+
   $input = $listItemClone.find(addRemoveInput);
 
   $input.val('');

--- a/assets/javascripts/modules/addRemove.js
+++ b/assets/javascripts/modules/addRemove.js
@@ -7,11 +7,9 @@ A component to add and remove inputs on a page. You have the option of sending i
   `data-can-delete="true"` is set
 - `data-add-btn-text` to send in custom add button text, this defaults to **Add**
 - `data-max` Maximum items allowed in the list
-- each instance's outer div MUST have an ID so that the cloneable item html can be cached for that instance
 
 Markup:
-<div id="uniqueId"
-     data-add-remove
+<div data-add-remove
      data-max="5"
      data-can-delete="true"
      data-delete-btn-text="Delete Me"
@@ -54,11 +52,13 @@ var init = function () {
       var $container = $(container),
           $cloneableItem = $container.find('[' + $container.attr('data-template-item') + ']');
 
+      $container.data('index', i);
+
       if($cloneableItem.length > 0) {
-
+      
         // cache this AddRemove instance's item template for when Add is clicked
-        cachedTemplate[$container.attr('id')] = $cloneableItem[0].outerHTML;
-
+        cachedTemplate[i] = $cloneableItem[0].outerHTML;
+      
       }
 
       if (deleteIsEnabled($container)) {
@@ -139,7 +139,7 @@ var createItem = function ($container) {
       $input;
 
   // cloneable item is cached for this instance of AddRemove
-  $listItemClone = $(cachedTemplate[$container.attr('id')]);
+  $listItemClone = $(cachedTemplate[$container.data('index')]);
 
   $input = $listItemClone.find(addRemoveInput);
 

--- a/assets/javascripts/modules/addRemove.js
+++ b/assets/javascripts/modules/addRemove.js
@@ -32,7 +32,8 @@ Markup:
 </div>
  */
 
-var DEFAULT_ADD_BTN_TEXT = 'Add',
+var $addRemoveContainers, 
+    DEFAULT_ADD_BTN_TEXT = 'Add',
     DEFAULT_DELETE_BTN_TEXT = 'Delete',
     addRemoveContainer = '[data-add-remove]',
     addRemoveList = '[data-add-remove-list]',
@@ -44,7 +45,7 @@ var DEFAULT_ADD_BTN_TEXT = 'Add',
     cachedTemplate = [];
 
 var init = function () {
-  var $addRemoveContainers = $(addRemoveContainer);
+  $addRemoveContainers = $(addRemoveContainer);
 
   if ($addRemoveContainers.length) {
 
@@ -52,12 +53,12 @@ var init = function () {
       var $container = $(container),
           $cloneableItem = $container.find('[' + $container.attr('data-template-item') + ']');
 
-      $container.data('index', i);
+      //$container.data('index', i);
 
       if($cloneableItem.length > 0) {
       
         // cache this AddRemove instance's item template for when Add is clicked
-        cachedTemplate[i] = $cloneableItem[0].outerHTML;
+        cachedTemplate.push($cloneableItem[0].outerHTML);
       
       }
 
@@ -139,7 +140,7 @@ var createItem = function ($container) {
       $input;
 
   // cloneable item is cached for this instance of AddRemove
-  $listItemClone = $(cachedTemplate[$container.data('index')]);
+  $listItemClone = $addRemoveContainers.index($container);
 
   $input = $listItemClone.find(addRemoveInput);
 

--- a/assets/scss/components/_add-remove.scss
+++ b/assets/scss/components/_add-remove.scss
@@ -6,9 +6,11 @@ A component to add and remove inputs on a page. You have the option of sending i
 - `data-delete-btn-text` to send in custom delete button text, this defaults to **Delete** and will only work when the
  `data-can-delete="true"` is set
 - `data-add-btn-text` to send in custom add button text, this defaults to **Add another redirect URI**
+- each instance's outer div MUST have an ID so that the cloneable item html can be cached for that instance
 
 Markup:
-<div data-add-remove
+<div id="uniqueId"
+     data-add-remove
      data-max="5"
      data-can-delete="true"
      data-add-btn-text="Add me"

--- a/assets/scss/components/_add-remove.scss
+++ b/assets/scss/components/_add-remove.scss
@@ -6,11 +6,9 @@ A component to add and remove inputs on a page. You have the option of sending i
 - `data-delete-btn-text` to send in custom delete button text, this defaults to **Delete** and will only work when the
  `data-can-delete="true"` is set
 - `data-add-btn-text` to send in custom add button text, this defaults to **Add another redirect URI**
-- each instance's outer div MUST have an ID so that the cloneable item html can be cached for that instance
 
 Markup:
-<div id="uniqueId"
-     data-add-remove
+<div data-add-remove
      data-max="5"
      data-can-delete="true"
      data-add-btn-text="Add me"

--- a/assets/test/specs/addRemove.spec.js
+++ b/assets/test/specs/addRemove.spec.js
@@ -144,4 +144,19 @@ describe('Given I have a list of inputs to add/remove', function() {
     });
 
   });
+
+  describe('When I add to list of container #4', function() {
+
+    beforeEach(function () {
+        setup();
+        $container4.find('a[data-add-btn]').trigger('click');
+    });
+
+    it('The addtional item is of the correct template', function() {      
+      expect($container4.find('[data-add-remove-item]:nth-child(3) p')).toExist();
+    });
+
+  });
+
+
 });

--- a/assets/test/specs/fixtures/addRemove-fixture.html
+++ b/assets/test/specs/fixtures/addRemove-fixture.html
@@ -75,16 +75,10 @@
      data-template-item="data-template">
   <ul class="add-remove__list" data-add-remove-list>
     <li class="add-remove__item" data-add-remove-item data-template>
-      <input name="exampleThree[]"
-             type="text"
-             class="form-input input--medium"
-             data-add-remove-input />
+      <p>Item</p>
     </li>
     <li class="add-remove__item" data-add-remove-item>
-      <input name="exampleThree[]"
-             type="text"
-             class="form-input input--medium"
-             data-add-remove-input />
+      <p>Item</p>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
## Problem

Currently, to add a new item, the AddRemove module clones a particular item in the list. It does this on click of the Add button. However, the cloned item might be in an error state, which results in copying over an error message and error class to the new element, as shown below:

![screen shot 2016-04-12 at 11 42 49](https://cloud.githubusercontent.com/assets/1764083/14489780/04c3439a-0167-11e6-9ee2-ebe0f0c74e10.png)

## Solution

For each instantiation of AddRemove module on the page, a cached template is created (against the index of that instance). To ensure the cached template is always clean (not in an error state), an empty item always needs to be available at the bottom of the list. Otherwise, there might only be one item in the list which is in an error state and cannot be cloned. This limitation is currently due to the fact that my usage of AddRemove only provides server-side validation on inputs. Further work will be needed to implement client-side validation.

