### PR TITLE
[API-1224] Added support for alternating between two targets

### DIFF
--- a/assets/javascripts/modules/toggle.js
+++ b/assets/javascripts/modules/toggle.js
@@ -1,13 +1,13 @@
 require('jquery');
 
 /*
-Helper to enable elements to toggle other elements on the page specified by data attribute
+Helper to enable elements to toggle other elements on the page specified by one or two data attributes.
 Attach event to parent as delegate, open close dependant on triggers id.
 Two usages:
  1. Toggle visibility of one element
  2. Alternate visibility of two elements
 
-Toggle visibility of one element example:
+Example #1 - Toggle visibility of one element:
 
 <fieldset class="form-field-group visible-javascript-on js-aria-show js-toggle"
           data-target="target-element"
@@ -40,7 +40,7 @@ Target markup:
 ......
 </div>
 
-Alternate visibility of two elements example:
+Example #2 - Alternate visibility of two elements:
 
 <fieldset class="form-field-group visible-javascript-on js-aria-show js-toggle"
           data-target="target-element-1"
@@ -55,7 +55,8 @@ Alternate visibility of two elements example:
                class="js-toggle-trigger"
                value="yes"
                name="uk-number"
-               required />
+               required 
+               aria-controls="target-element-1"/>
     </label>
     <label class="block-label block-label--inline">No
         <input type="radio"
@@ -64,7 +65,7 @@ Alternate visibility of two elements example:
                value="no"
                name="uk-number"
                required
-               aria-controls="target-element"/>
+               aria-controls="target-element-2"/>
     </label>
 </fieldset>
 

--- a/assets/javascripts/modules/toggle.js
+++ b/assets/javascripts/modules/toggle.js
@@ -3,38 +3,77 @@ require('jquery');
 /*
 Helper to enable elements to toggle other elements on the page specified by data attribute
 Attach event to parent as delegate, open close dependant on triggers id.
+Two usages:
+ 1. Toggle visibility of one element
+ 2. Alternate visibility of two elements
 
-Toggle markup example:
+Toggle visibility of one element example:
 
 <fieldset class="form-field-group visible-javascript-on js-aria-show js-toggle"
-          id="uk-number"
-          data-target="uk-phone-number-toggle-target"
+          data-target="target-element"
           data-trigger="js-toggle-trigger"
-          data-open="uk-phone-number-toggle-open"
-          data-close="uk-phone-number-toggle-close">
+          data-open="radio-button-to-open"
+          data-close="radio-button-to-close">
 
-    <label class="block-label block-label--inline" for="uk-phone-number-toggle-close">Yes
+    <label class="block-label block-label--inline">Yes
         <input type="radio"
-               id="uk-phone-number-toggle-close"
+               id="radio-button-to-open"
                class="js-toggle-trigger"
                value="yes"
                name="uk-number"
                required />
     </label>
-    <label class="block-label block-label--inline" for="uk-phone-number-toggle-open">No
+    <label class="block-label block-label--inline">No
         <input type="radio"
-               id="uk-phone-number-toggle-open"
+               id="radio-button-to-close"
                class="js-toggle-trigger"
                value="no"
                name="uk-number"
                required
-               aria-controls="uk-phone-number-toggle-target"/>
+               aria-controls="target-element"/>
     </label>
 </fieldset>
 
-Target markup example:
+Target markup:
 
-<div id="uk-phone-number-toggle-target" class="hidden">
+<div id="target-element" class="hidden">
+......
+</div>
+
+Alternate visibility of two elements example:
+
+<fieldset class="form-field-group visible-javascript-on js-aria-show js-toggle"
+          data-target="target-element-1"
+          data-target-closed="target-element-2"
+          data-trigger="js-toggle-trigger"
+          data-open="radio-button-to-open"
+          data-close="radio-button-to-close">
+
+    <label class="block-label block-label--inline">Yes
+        <input type="radio"
+               id="radio-button-to-open"
+               class="js-toggle-trigger"
+               value="yes"
+               name="uk-number"
+               required />
+    </label>
+    <label class="block-label block-label--inline">No
+        <input type="radio"
+               id="radio-button-to-close"
+               class="js-toggle-trigger"
+               value="no"
+               name="uk-number"
+               required
+               aria-controls="target-element"/>
+    </label>
+</fieldset>
+
+Target markup:
+
+<div id="target-element-1">
+......
+</div>
+<div id="target-element-2" class="hidden">
 ......
 </div>
  */
@@ -47,8 +86,9 @@ var $toggleElems;
  * @param $elem
  */
 var toggleEvent = function ($elem) {
-  var $triggerElemSelector = $($elem.data('trigger'));
+  var $triggerElemSelector = $($elem.data('trigger'));  
   var $targetElem = $('#' + $elem.data('target'));
+  var $targetWhenClosed = $('#' + $elem.data('target-closed'));
   var openId = $elem.data('open');
   var closeId = $elem.data('close');
   var target;
@@ -60,8 +100,10 @@ var toggleEvent = function ($elem) {
 
       if (target.id === openId) {
         $targetElem.removeClass('hidden').attr('aria-expanded', 'true').attr('aria-visible', 'true');
+        $targetWhenClosed.addClass('hidden').attr('aria-expanded', 'false').attr('aria-visible', 'false');
       } else if (target.id === closeId) {
         $targetElem.addClass('hidden').attr('aria-expanded', 'false').attr('aria-visible', 'false');
+        $targetWhenClosed.removeClass('hidden').attr('aria-expanded', 'true').attr('aria-visible', 'true');
       }
     }
   });


### PR DESCRIPTION
## Current Design

This module was originally written to handle situations like revealing a `<textarea/>` upon selecting a "Reject" radio button, i.e. giving a reason why. So it traditionally toggles one target's visibility.

## Alternating Visibility Of Two Targets

I have a requirement to alternate the visibility of two elements (see screen shot below). In my case, these are hint texts for two radio buttons. To achieve this using the existing `toggle` module, without introducing the need to modify the HTML of the existing use cases (in IV, API, and a few other services), I've introduced an optional `data-target-closed` attribute so a 2nd element's visibility can be toggled, alternating against the first.

Note: the existing keyboard access still works for the alternating states option.

![i92up25ox3](https://cloud.githubusercontent.com/assets/1764083/14522262/9d9f88da-0225-11e6-979e-506f86b4a62e.gif)