### PR TITLE
Moved .top-aligned-input to .block-label input.top-aligned-input

### DIFF
--- a/assets/scss/base/form/_label.scss
+++ b/assets/scss/base/form/_label.scss
@@ -8,6 +8,7 @@
   }
 }
 
+
 /*
 Label
 
@@ -226,7 +227,13 @@ Styleguide Label.aligned
   @extend %vertically-aligned-input;
 }
 
-
+// to align radio button with top line of content, not centred
+input.top-aligned-input {
+  top: em(31);
+  @include media(tablet) {
+    top: em(29);
+  }
+}
 
 
 /*
@@ -269,18 +276,19 @@ Styleguide Label.block
     @extend %vertically-aligned-input;
   }
 
-  // to align radio button with top line of content, not centred
-  input.top-aligned-input {
-    top: em(31);
-    @include media(tablet) {
-      top: em(29);
-    }
-  }
-
   @include media(tablet) {
     float: left;
     margin-top: 5px;
     margin-bottom: 5px;
+  }
+}
+
+// to align radio button with top line of content, not centred
+// NOTE: element is specified due to competing selector above: .block-label input {...}
+input.top-aligned-input {
+  top: em(31);
+  @include media(tablet) {
+    top: em(29);
   }
 }
 

--- a/assets/scss/base/form/_label.scss
+++ b/assets/scss/base/form/_label.scss
@@ -205,28 +205,6 @@ Styleguide Label.date
 }
 
 
-/*
-Aligned
-
-Labels containing a `radio` input with alignment.
-
-Markup:
-<label class="block-label">
-  London
-  <input class="{{modifier_class}}" name="example" type="radio" />
-</label>
-
-.vertically-aligned-input   - A vertically aligned input
-.top-aligned-input          - A top aligned input
-
-Styleguide Label.aligned
-*/
-
-// Position checkbox within label, to allow text to wrap
-.vertically-aligned-input {
-  @extend %vertically-aligned-input;
-}
-
 
 /*
 Block
@@ -273,6 +251,28 @@ Styleguide Label.block
     margin-top: 5px;
     margin-bottom: 5px;
   }
+}
+
+/*
+Aligned
+
+Labels containing a `radio` input with alignment.
+
+Markup:
+<label class="block-label">
+  London
+  <input class="{{modifier_class}}" name="example" type="radio" />
+</label>
+
+.vertically-aligned-input   - A vertically aligned input
+.top-aligned-input          - A top aligned input
+
+Styleguide Label.aligned
+*/
+
+// Position checkbox within label, to allow text to wrap
+.vertically-aligned-input {
+  @extend %vertically-aligned-input;
 }
 
 // to align radio button with top line of content, not centred

--- a/assets/scss/base/form/_label.scss
+++ b/assets/scss/base/form/_label.scss
@@ -226,13 +226,7 @@ Styleguide Label.aligned
   @extend %vertically-aligned-input;
 }
 
-// to align radio button with top line of content, not centred
-.top-aligned-input {
-  top: em(31);
-  @include media(tablet) {
-    top: em(29);
-  }
-}
+
 
 
 /*
@@ -273,6 +267,14 @@ Styleguide Label.block
 
   input {
     @extend %vertically-aligned-input;
+  }
+
+  // to align radio button with top line of content, not centred
+  input.top-aligned-input {
+    top: em(31);
+    @include media(tablet) {
+      top: em(29);
+    }
   }
 
   @include media(tablet) {

--- a/assets/scss/base/form/_label.scss
+++ b/assets/scss/base/form/_label.scss
@@ -227,14 +227,6 @@ Styleguide Label.aligned
   @extend %vertically-aligned-input;
 }
 
-// to align radio button with top line of content, not centred
-input.top-aligned-input {
-  top: em(31);
-  @include media(tablet) {
-    top: em(29);
-  }
-}
-
 
 /*
 Block

--- a/assets/scss/base/form/_label.scss
+++ b/assets/scss/base/form/_label.scss
@@ -253,37 +253,6 @@ Styleguide Label.block
   }
 }
 
-/*
-Aligned
-
-Labels containing a `radio` input with alignment.
-
-Markup:
-<label class="block-label">
-  London
-  <input class="{{modifier_class}}" name="example" type="radio" />
-</label>
-
-.vertically-aligned-input   - A vertically aligned input
-.top-aligned-input          - A top aligned input
-
-Styleguide Label.aligned
-*/
-
-// Position checkbox within label, to allow text to wrap
-.vertically-aligned-input {
-  @extend %vertically-aligned-input;
-}
-
-// to align radio button with top line of content, not centred
-// NOTE: element is specified due to competing selector above: .block-label input {...}
-input.top-aligned-input {
-  top: em(31);
-  @include media(tablet) {
-    top: em(29);
-  }
-}
-
 .block-label:hover {
   border-color: $black;
 }
@@ -320,6 +289,36 @@ input.top-aligned-input {
   }
 }
 
+/*
+Aligned
+
+Labels containing a `radio` input with alignment.
+
+Markup:
+<label class="block-label">
+  London
+  <input class="{{modifier_class}}" name="example" type="radio" />
+</label>
+
+.vertically-aligned-input   - A vertically aligned input
+.top-aligned-input          - A top aligned input
+
+Styleguide Label.aligned
+*/
+
+// Position checkbox within label, to allow text to wrap
+.vertically-aligned-input {
+  @extend %vertically-aligned-input;
+}
+
+// to align radio button with top line of content, not centred
+// NOTE: element is specified due to competing selector above: .block-label input {...}
+input.top-aligned-input {
+  top: em(31);
+  @include media(tablet) {
+    top: em(29);
+  }
+}
 
 /*
 Form date


### PR DESCRIPTION
Background covered in this issue: fixes #539

Essentially, `.top-aligned-input` was useless, being overridden due to `.block-label input`. To work, it needed to be moved to `.block-label input.top-aligned-input`.