### PR TITLE
[API-1355] Library to dynamically update GA event tags

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -44,7 +44,8 @@ var sso = require('./modules/sso.js'),
     tabs = require('./modules/tabs.js'),
     charCounter = require('./modules/charCounter.js'),
     addRemove = require('./modules/addRemove.js'),
-    modalDialog = require('./modules/modalDialog.js');
+    modalDialog = require('./modules/modalDialog.js'),
+    dynamicGaTags = require('./modules/dynamicGaTags.js');
 
 //initialise mdtpf
 fingerprint();
@@ -169,5 +170,6 @@ $(function() {
   charCounter();
   addRemove();
   modalDialog();
+  dynamicGaTags();
 
 });

--- a/assets/javascripts/modules/dynamicGaTags.js
+++ b/assets/javascripts/modules/dynamicGaTags.js
@@ -1,0 +1,66 @@
+/**
+ 
+  Dynamic Google Analytics (GA) Tags
+ 
+  Allows the label (third parameter) of a GA event to be dynamically set based on a radio button selection.
+  
+  Example:
+    <form data-journey-dynamic-radios>
+			
+			<fieldset>
+          <legend class="visuallyhidden">Choose approve or reject application</legend>
+          <label class="block-label--stacked selected">
+              <input type="radio" id="approve-app" name="action" value="APPROVE" data-journey-val="Approved">Approve
+          </label>
+          <label class="block-label--stacked">
+              <input type="radio" id="reject-app" name="action" value="REJECT" data-journey-val="Rejected" checked>Reject
+          </label>
+      </fieldset>
+
+      <input id="submit" type="submit" class="button" value="Submit" data-journey-click="gate-keeper:Click:Approved" data-journey-target>
+
+    </form>
+ 
+	Note: it is up to server-side template to populate the correct initial GA event string
+
+ */
+
+
+module.exports = function() {
+
+	$('[data-journey-dynamic-radios]').each(function() {
+
+		var $container = $(this),
+        $radioBtns = $container.find('input[type=radio]'),
+        $target    = $('#' + $container.attr('data-journey-target'));
+
+    $radioBtns.on("click", function(e) {
+      onRadioBtnClick(e, $container);
+    });
+
+	});
+
+};
+
+
+/**
+ * Click handler for radio buttons
+ */
+var onRadioBtnClick = function(e, $container) {
+
+	var $radioBtn    = $(e.currentTarget),
+      $target      = $container.find('[data-journey-target]'),
+      journeyAttr  = $target.attr('data-journey-click'),
+      journeyParts = journeyAttr.split(":");
+
+	if(journeyParts.length === 3) {
+		
+		// replace label part of GA event string with radio button's specified value
+		journeyParts[2] = $radioBtn.attr('data-journey-val');
+
+		// update GA event string on data attribute
+		$target.attr('data-journey-click', journeyParts.join(":"));
+
+	}
+
+};

--- a/assets/test/specs/dynamicGaTags.spec.js
+++ b/assets/test/specs/dynamicGaTags.spec.js
@@ -1,0 +1,52 @@
+require('jquery');
+
+describe("Given I have two sets of radio buttons and corresponding submit buttons with dynamic GA tags", function() {
+
+  var dynamicGaTags,
+      $container1,
+      $container2;
+
+  beforeEach(function() {
+
+    jasmine.getFixtures().fixturesPath = "base/specs/fixtures/";
+    loadFixtures('dynamic-ga-tags-fixture.html');
+
+    dynamicGaTags = require('../../javascripts/modules/dynamicGaTags.js');
+
+    $container1 = $('#container1');
+    $container2 = $('#container2');
+
+    dynamicGaTags();
+  });
+
+  describe("When I select Reject in the first set of radio buttons", function() {
+
+    beforeEach(function() {
+      
+      $('#rejectBtn').prop('checked', true).trigger('click');
+    });
+
+    it("Then the 1st submit button's GA event label should match the clicked radio's data attribute", function() {
+      
+      var rejectText  = $('#rejectBtn').attr('data-journey-val');
+      var gaAttr      = $container1.find('input[type=submit]').attr('data-journey-click');
+      var updatedText = gaAttr.substr(gaAttr.lastIndexOf(':') + 1);
+
+      expect(updatedText).toBe(rejectText);
+
+    });
+
+    it("Then the 2nd submit button's GA event label should not have changed", function() {
+
+      var $checked    = $container2.find('input:checked');
+      var checkedText = $checked.attr('data-journey-val');
+      var gaAttr      = $container2.find('input[type=submit]').attr('data-journey-click');
+      var gaLabel     = gaAttr.substr(gaAttr.lastIndexOf(':') + 1);
+
+      expect(gaLabel).toBe(checkedText);
+
+    });
+
+  });
+
+});

--- a/assets/test/specs/fixtures/dynamic-ga-tags-fixture.html
+++ b/assets/test/specs/fixtures/dynamic-ga-tags-fixture.html
@@ -1,0 +1,29 @@
+<form id="container1" action="/some/amazing/endpoint" data-journey-dynamic-radios>
+
+	<fieldset>
+    <label>
+      <input type="radio" id="approveBtn" name="radioBtn" value="APPROVE" data-journey-val="Approved" checked/>
+      Approve
+    </label>
+		<label>
+      <input type="radio" id="rejectBtn" name="radioBtn" value="REJECT" data-journey-val="Rejected"/>
+      Reject
+    </label>
+	</fieldset>
+
+	<input type="submit" value="Submit" data-journey-click="gate-keeper:Click:Approved" data-journey-target/>
+
+</form>
+
+<form id="container2" action="/another/amazing/endpoint" data-journey-dynamic-radios>
+
+	<fieldset>
+	  <legend>Please select a most delicious fruit</legend>
+		<input type="radio" id="appleBtn" name="radioBtn" value="APPLE" data-journey-val="apple" checked/>
+		<input type="radio" id="orangeBtn" name="radioBtn" value="ORANGE" data-journey-val="orange"/>
+		<input type="radio" id="pineappleBtn" name="radioBtn" value="PINEAPPLE" data-journey-val="pineapple"/>
+	</fieldset>
+
+	<input type="submit" value="Let Me Eat" data-journey-click="gate-keeper:Click:apple" data-journey-target/>
+
+</form>


### PR DESCRIPTION
## Overview

Currently, our `stageprompt.js` script binds click events to all `data-journey-click` tags in the page, sending Google Analytics (GA) track events.

## Problem

In some instances, the GA event applies to the submit button of a form. The value of the `data-journey-click` attribute is `<category>:<event>:<label>`. I needed to alternate the value of `label` depending on a radio button selection.

## Solution

I created a new JS module, `dynamicGaTags`, to update a `data-journey-click` attribute based on the radio button selection.

## Example Usage

```
<form id="container1" action="/some/amazing/endpoint" data-journey-dynamic-radios>

	<fieldset>
    <label>
      <input type="radio" id="approveBtn" name="radioBtn" value="APPROVE" data-journey-val="Approved" checked/>
      Approve
    </label>
		<label>
      <input type="radio" id="rejectBtn" name="radioBtn" value="REJECT" data-journey-val="Rejected"/>
      Reject
    </label>
	</fieldset>

	<input type="submit" value="Submit" data-journey-click="gate-keeper:Click:Approved" data-journey-target/>

</form>
```

### Attributes

`data-journey-dynamic-radios` - outer element, containing the form (radio buttons and submit button)
`data-journey-val="<value>"` - set on each radio button to give the value to be set on the target
`data-journey-target` - target element which contains the `data-journey-click` attribute

## Screenshot

![ffbxuebze2](https://cloud.githubusercontent.com/assets/1764083/14712590/a86f2396-07d5-11e6-9d1e-db5434e68e24.gif)
