### PR TITLE
Update gulp-sass and fix resulting errors

### DIFF
--- a/assets/scss/base/_links.scss
+++ b/assets/scss/base/_links.scss
@@ -65,7 +65,7 @@ a[rel="external"].external-link-16-bold-no-hover {
 }
 
 a[rel="external"].external-link-19 {
-  @extend %external-link-default;
+  @include external-link-default;
   @include external-link-19;
 }
 a[rel="external"].external-link-19-bold-no-hover {

--- a/assets/scss/base/form/_form.scss
+++ b/assets/scss/base/form/_form.scss
@@ -221,7 +221,7 @@ Styleguide Form.date
 
 
 .form-date {
-  @extend %contains-floats;
+  @extend %contain-floats;
   display: inline-block;
 
   @include ie-lte(7) {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "gulp-notify": "^2.2.0",
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.0",
-    "gulp-sass": "^2.1.1",
+    "gulp-sass": "^2.3.0",
     "gulp-sourcemaps": "^1.5.1",
     "gulp-uglify": "^1.1.0",
     "gulp-util": "^3.0.4",


### PR DESCRIPTION
The [`2.3.x` release of `gulp-sass`](https://github.com/dlmanning/gulp-sass/releases/tag/v2.3.0) [bumps the version of `node-sass`]() (which in turn bumps `libsass`) which makes `@extend` stricter.

This in turn meant that our builds were breaking because errors were being thrown that weren't previously...

- Bump gulp-sass to `^2.3.0`
- `@import` instead of `@extend` the `external-link-default` mixin in `_links.scss` as it's not a placeholder
- Fix type on `contain-floats` in `_form.scss`