### PR TITLE
[PE-1926] validation bug for radio and/or checkbox elements

### DIFF
--- a/assets/javascripts/validation/form.js
+++ b/assets/javascripts/validation/form.js
@@ -120,9 +120,8 @@ var flushHiddenElementErrors = function (invalidInputs) {
   for(var inputName in invalidInputs) {
     var $elem = $('[name="' + inputName + '"]');
 
-    if ($elem.is(':hidden')) {
+    if ($elem.is(':hidden') && ($elem.length > 1 && $elem.is('visible'))) {
       delete invalidInputs[inputName];
-      $elem.val('');
       $elem.closest('.form-field-group').removeClass('form-field-group--error');
     }
   }

--- a/assets/test/specs/fixtures/form-fixture.html
+++ b/assets/test/specs/fixtures/form-fixture.html
@@ -1,4 +1,4 @@
-<form class="js-form" autocomplete="off" novalidate="novalidate">
+<form class="js-form" autocomplete="off" novalidate="novalidate"  data-dynamic-form>
 
   <div class="flash error-summary" id="Search-failure" role="group" aria-labelledby="errorSummaryHeading" tabindex="-1">
     <h2 id="errorSummaryHeading" class="h3-heading">There are errors on the page.</h2>
@@ -46,6 +46,38 @@
              required/>
     </label>
   </fieldset>
-
+  
+  <fieldset class="form-field-group">
+    <label class="block-label" for="other-group-toggle">
+      <input type="checkbox" id="other-group-toggle" data-dynamic-fields="dynamic-group" data-dynamic-fields-hide="false" />
+      Grouped options:
+    </label>
+    <div class="js-hidden data-dynamic-group" id="other-group">
+      <fieldset class="form-field-group">
+        <span id="radio-group-error-message" class="error-notification" role="tooltip">
+            Required selection
+        </span>
+        <label class="block-label" for="radio-group-yes">
+        <input type="radio" 
+               data-rule-required="true" 
+               data-msg-required="You must select an option continue."
+               id="radio-group-yes" 
+               name="group-item"
+               value="yes" aria-required="true" />
+        Yes
+      </label>
+      <label class="block-label" for="radio-group-no">
+        <input type="radio" 
+               data-rule-required="true" 
+               data-msg-required="You must select an option continue."
+               id="radio-group-no" 
+               name="group-item"
+               value="no" aria-required="true" />
+        No
+      </label>
+      </fieldset>
+    </div>
+  </fieldset>
+  
   <button id="submit-button" type="submit">Submit</button>
 </form>

--- a/assets/test/specs/form.spec.js
+++ b/assets/test/specs/form.spec.js
@@ -12,9 +12,14 @@ var $errorSummaryHeading;
 var $textInputExample;
 var $radioYesElement;
 var $radioNoElement;
+var $radioYesGroupElement;
+var $radioNoGroupElement;
+var $groupToggle;
+var toggleDynamic;
 
 var setup = function () {
   form.init();
+  toggleDynamic();
   $formElement = $('.js-form');
   customValidations();
   $errorSummary = $('.error-summary');
@@ -24,6 +29,9 @@ var setup = function () {
   $textInputExample = $('#text-input-example');
   $radioYesElement = $('#radio-yes');
   $radioNoElement = $('#radio-no');
+  $radioYesGroupElement = $('#radio-group-yes');
+  $radioNoGroupElement = $('#radio-group-no');
+  $groupToggle = $('#other-group-toggle');
 };
 
 describe('Form Validation', function () {
@@ -32,6 +40,8 @@ describe('Form Validation', function () {
     jasmine.getFixtures().fixturesPath = 'base/specs/fixtures/';
     loadFixtures('form-fixture.html');
     form = require('../../javascripts/validation/form.js');
+    toggleDynamic = require('../../javascripts/modules/toggleDynamicFormFields.js');
+    document.getElementById(jasmine.getFixtures().containerId).classList.add('js');
     customValidations = require('../../javascripts/validation/customValidations.js');
   });
 
@@ -51,7 +61,7 @@ describe('Form Validation', function () {
           expect(form.getErrorMessages().length).toBe(0)
       });
     });
-
+    
     describe('When I submit the form without filling it out', function () {
 
       beforeEach(function () {
@@ -100,8 +110,7 @@ describe('Form Validation', function () {
         expect(form.getErrorMessages().length).toBe(0);
       });
     });
-
-
+    
     describe('When I enter the wrong pattern on text input and submit', function () {
 
       beforeEach(function () {
@@ -220,5 +229,61 @@ describe('Form Validation', function () {
       });
     });
 
+    describe('When I open the grouped input elements, do not select an item in the group and submit', function () {
+      beforeEach(function () {
+        $groupToggle.click();
+
+        $submitButton.click();
+      });
+
+      it('The radio group inline error should be visible', function () {
+        expect($radioYesGroupElement.closest('.form-field-group.form-field-group--error').is(":visible")).toBe(true);
+      });
+
+
+      it('The form should have the grouped radio required error message', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+        expect($errorMessages.text()).not.toBe($radioYesGroupElement.attr('data-msg-required'));
+      });
+    });
+
+    describe('When I open the grouped input elements, select an item, close the group and submit', function () {
+      
+      beforeEach(function () {
+        $groupToggle.click();
+        $radioYesGroupElement.click();
+        $groupToggle.click();
+        $submitButton.click();
+      });
+
+      it('The form should not have the radio group inline error', function () {
+        expect($radioYesGroupElement.closest('.form-field-group')).not.toHaveClass('form-field-group--error');
+      });
+
+      it('The form should not have the grouped radio required error message', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+
+        for (var e = 0; e < $errorMessages.length; e++) {
+          expect($errorMessages.eq(e).text()).not.toBe($radioNoGroupElement.attr('data-msg-required'));
+        }
+      });
+    });
+
+    describe('When I open the grouped input elements, hit submit and cause an error, then close the grouped input elements', function (){
+      beforeEach(function () {
+        $groupToggle.click();
+        $submitButton.click();
+        $groupToggle.click();
+      });
+
+      it('The radio group inline error should not be visible', function () {
+        expect($('#radio-group-yes').closest('.form-field-group.form-field-group--error').is(":visible")).toBe(false);
+      });
+      
+      it('The form should have the grouped radio required error message', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+        expect($errorMessages.text()).not.toBe($radioYesGroupElement.attr('data-msg-required'));
+      });    
+    });
   });
 });


### PR DESCRIPTION
# [PE-1926] validation bug for radio and/or checkbox elements

## Issue
Bug exposed by grouped form elements when part of group is hidden

## Current behaviour:
When a form validation error is occurs where:
1. the form is bound to generic validation via the `.js-form` selector
2. and some form elements are `:hidden`;
3. the `:hidden` elements value attribute is "cleared" via $(*element*).val('') 

This behaviour is incorrect for both `radio` and/or `checkbox` elements where the value should **not** be cleared.

### Example:
In the shown example, the form:
  * validates that the required number of 'checked' elements in the group is correct
  * has two `radio` elements in the group, which are `:hidden` by a `checkbox` toggle element

 When the form is submitted:
 1. without the required number of elements selected
 2. *and* the `radio` elements are `:hidden`
 3. the bug results in:
    a. the `radio:hidden` element values being set to '' (empty)
    b. *and*, as `flushHiddenElementErrors` uses the `[name="..."]` selector (binding the entire group),
         the visible `checkbox` element values are *also* being set to '' (empty)

## Solution
This change will prevent the value being set to '' (empty) on `radio:hidden` or `checkbox:hidden` elements.

![PE-1926 validation bug for radio and/or checkbox elements](https://cloud.githubusercontent.com/assets/5468091/14892031/06ac1316-0d61-11e6-864a-e28ae090d4aa.gif)