### PR TITLE
YTA-1864 - Remove extra padding bottom from the light and dark themed highlight messages

### DIFF
--- a/assets/scss/components/_notifications.scss
+++ b/assets/scss/components/_notifications.scss
@@ -280,7 +280,6 @@ Styleguide Notification.Highlight
 .highlight-message--light {
   background-color: $white;
   color: $black;
-  padding-bottom: em(30);
 }
 
 
@@ -306,5 +305,4 @@ Styleguide Notification.Highlight dark
   
   background-color: $govuk-blue-colour;
   color: $white;
-  padding-bottom: em(30);
 }


### PR DESCRIPTION
Removed the extra padding bottom added to the 'highlight-message--light' and 'highlight-message--dark' classes. This should ensure that the highlight messages have equal padding top and bottom

Before: 

![before](https://cloud.githubusercontent.com/assets/2510683/14913659/9b760d62-0dfc-11e6-83bc-c54d6cf25969.png)


After:

![after](https://cloud.githubusercontent.com/assets/2510683/14913661/a4fde1c0-0dfc-11e6-9e65-a7acdfe98eac.png)
