### PR TITLE
Fix .form-control select on Webkit

### DIFF
--- a/assets/scss/base/form/_form.scss
+++ b/assets/scss/base/form/_form.scss
@@ -303,6 +303,11 @@ Styleguide Form.control
   @include media(tablet) {
     width: 50%;
   }
+
+}
+// fix the select element on Webkit which is broken in govuk_elements' version of this file
+select.form-control {
+  -webkit-appearance: menulist;
 }
 
 .form-control--block {


### PR DESCRIPTION
_form.scss in govuk_elements sets -webkit-appearance: none on all elements using .form-control, causing the dropdown button to disappear on Chrome/Safari.
This PR fixes the class on the select element.

Before:
<img width="361" alt="screenshot 2016-05-03 10 08 41" src="https://cloud.githubusercontent.com/assets/11385498/14979085/0f9c262c-1118-11e6-870c-4771502f2008.png">


After:
<img width="374" alt="screenshot 2016-05-03 10 08 19" src="https://cloud.githubusercontent.com/assets/11385498/14979091/1c552e7c-1118-11e6-988b-3b5eb9bc00ba.png">
