### PR TITLE
[API-1585] Add waiting/loading component

### DIFF
--- a/assets/javascripts/modules/ajaxCallbacks.js
+++ b/assets/javascripts/modules/ajaxCallbacks.js
@@ -60,6 +60,12 @@ var ajaxCallbacks = {
   helpers: {
     base: {
       beforeSend: function($element, data, helpers, targets, container, type, actions) {
+        // add waiting state component
+        var showWaiting = $element.data('ajax-waiting');
+        if (showWaiting) {
+          $element.prepend($('<span class="waiting"></span>'));
+        }
+
         helpers.utilities.setFormState($element, true);
       },
 
@@ -77,6 +83,12 @@ var ajaxCallbacks = {
       },
 
       always: function(response, $element, data, helpers, targets, container, type, actions) {
+        // clean waiting state
+        var showWaiting = $element.data('ajax-waiting');
+        if (showWaiting) {
+          $element.find('.waiting').remove();
+        }
+
         if (helpers.hasErrorType !== 'service') {
           helpers.resetForms(helpers, type, data, container);
         }

--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -85,6 +85,7 @@ $path: "../images/icons/";
 @import "modules/tabs";
 @import "components/modal-dialog";
 @import "components/app-info";
+@import "components/waiting";
 
 // Page Specific Styles
 @import "pages/messages";

--- a/assets/scss/components/_waiting.scss
+++ b/assets/scss/components/_waiting.scss
@@ -1,11 +1,3 @@
-/*
-Waiting State
-
-Markup:
-<span class="waiting"></span>
-
-Styleguide Waiting State
-*/
 
 .waiting {
   background-image: url('../images/loading.gif');

--- a/assets/scss/components/_waiting.scss
+++ b/assets/scss/components/_waiting.scss
@@ -1,0 +1,19 @@
+/*
+Waiting State
+
+Markup:
+<span class="waiting"></span>
+
+Styleguide Waiting State
+*/
+
+.waiting {
+  background-image: url('../images/loading.gif');
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-position: 50%;
+  height: em(28);
+  width: em(26);
+  vertical-align: middle;
+  display: inline-block;
+}


### PR DESCRIPTION
## Overview

Assets frontend currently don't have any loading/waiting component to show busy state. And as part of story number [API-1452] UI need to show waiting/loading state when user clicks on subscribe button.

## Problem

We cannot use `<img>` tag with `src` because the asset-frontend is loaded as a dependency in other apps and developers need to work out correct `path` in order to use it.

## Solution

Created a new `waiting` component with `'images/loading.gif'` as background image.

## Example Usage

```
<span class="waiting"></span>
```

## Screenshot
![qzhsdjdpv7](https://cloud.githubusercontent.com/assets/1984591/14979420/1163ed6c-111a-11e6-8771-4a24729bfc67.gif)
