### PR TITLE
[API-1586] refactored toggle button & added error & disabled state

### DIFF
--- a/assets/javascripts/modules/ajaxCallbacks.js
+++ b/assets/javascripts/modules/ajaxCallbacks.js
@@ -85,7 +85,7 @@ var ajaxCallbacks = {
         // if active user is administrator then provide a link to allow un-subscribe
         if (isAdmin) {
           $offLink = $('<a>Off</a>')
-            .addClass('toggle__btn')
+            .addClass('toggle__button')
             .attr('href', offUrl)
             .data('api-unsubscribe', formContext + '-' + formVersion);
 

--- a/assets/scss/components/_toggle-button.scss
+++ b/assets/scss/components/_toggle-button.scss
@@ -4,8 +4,8 @@ Toggle Button
 Markup:
 <span class="toggle">
   <span class="error-notification inline-block toggle__error">Error state</span>
-  <a href="#" class="toggle_button">link</a>
-  <button class="toggle_button">link</button>
+  <a href="#" class="toggle__button">link</a>
+  <button class="toggle__button">link</button>
   <span class="toggle--on">on</span>
   <span class="toggle--off">off</span>
   <span class="toggle--disabled">disabled</span>
@@ -19,7 +19,7 @@ Styleguide Toggle Button
   white-space: nowrap;
 }
 
-.toggle_button {
+.toggle__button {
   background-color: transparent;
   box-shadow: none;
   text-decoration: underline;
@@ -63,7 +63,7 @@ Styleguide Toggle Button
   color: #6f777b;
 }
 
-.toggle_button,
+.toggle__button,
 .toggle--on,
 .toggle--off,
 .toggle--disabled {

--- a/assets/scss/components/_toggle-button.scss
+++ b/assets/scss/components/_toggle-button.scss
@@ -29,7 +29,8 @@ Styleguide Toggle Button
     top: 0;
     box-shadow: none;
   }
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     outline: none;
     color: $link-hover-colour;
     background-color: transparent;
@@ -37,6 +38,10 @@ Styleguide Toggle Button
   &:disabled,
   [disabled] {
     background-color: transparent;
+    &:hover,
+    &:focus {
+      background-color: transparent;
+    }
   }
 }
 

--- a/assets/scss/components/_toggle-button.scss
+++ b/assets/scss/components/_toggle-button.scss
@@ -4,8 +4,8 @@ Toggle Button
 Markup:
 <span class="toggle">
   <span class="error-notification inline-block toggle__error">Error state</span>
-  <a href="#" class="toggle__btn">link</a>
-  <button class="toggle__btn">link</button>
+  <a href="#" class="toggle_button">link</a>
+  <button class="toggle_button">link</button>
   <span class="toggle--on">on</span>
   <span class="toggle--off">off</span>
   <span class="toggle--disabled">disabled</span>
@@ -19,7 +19,7 @@ Styleguide Toggle Button
   white-space: nowrap;
 }
 
-.toggle__btn {
+.toggle_button {
   background-color: transparent;
   box-shadow: none;
   text-decoration: underline;
@@ -63,7 +63,7 @@ Styleguide Toggle Button
   color: #6f777b;
 }
 
-.toggle__btn,
+.toggle_button,
 .toggle--on,
 .toggle--off,
 .toggle--disabled {

--- a/assets/scss/components/_toggle-button.scss
+++ b/assets/scss/components/_toggle-button.scss
@@ -2,39 +2,45 @@
 Toggle Button
 
 Markup:
-<span class="toggle-buttons">
+<span class="toggle">
   <span class="error-notification inline-block toggle__error">Error state</span>
   <a href="#" class="toggle__button">link</a>
   <button class="toggle__button">link</button>
-  <span class="toggle--on">on</span>
-  <span class="toggle--off">off</span>
-  <span class="toggle--disabled">disabled</span>
+  <span class="toggle__button toggle__button--active">on</span>
+  <span class="toggle__button toggle__button--inactive">off</span>
+  <span class="toggle__button toggle__button--disabled">disabled</span>
 </span>
 
 Styleguide Toggle Button
 */
 
-.toggle-buttons {
+.toggle {
   display: inline-block;
   white-space: nowrap;
 }
 
 .toggle__button {
+  @include core-16;
+  padding: em(5) em(10) em(3) em(10);
   background-color: transparent;
-  box-shadow: none;
   text-decoration: underline;
+  display: inline-block;
+  line-height: 1.4em;
   color: $link-colour;
+  box-shadow: none;
   border: none;
   &:active {
     top: 0;
     box-shadow: none;
   }
+
   &:hover,
   &:focus {
     outline: none;
     color: $link-hover-colour;
     background-color: transparent;
   }
+
   &:disabled,
   [disabled] {
     background-color: transparent;
@@ -43,32 +49,41 @@ Styleguide Toggle Button
       background-color: transparent;
     }
   }
+
 }
 
 .toggle__error {
   padding: em(5) em(40) em(3) em(10);
 }
 
-.toggle--on {
+.toggle__button--active {
   background-color: $button-colour;
   color: $white;
   margin: 0 em(15) 0 0;
+  text-decoration: none;
+  &:hover,
+  &:focus {
+    color: $white;
+    background-color: $button-colour;
+  }
 }
 
-.toggle--off {
+.toggle__button--inactive {
+  color: $text-colour;
   background-color: $light-grey;
+  text-decoration: none;
+  &:hover,
+  &:focus {
+    color: $text-colour;
+    background-color: $light-grey;
+  }
 }
 
-.toggle--disabled {
+.toggle__button--disabled {
   color: #6f777b;
-}
-
-.toggle__button,
-.toggle--on,
-.toggle--off,
-.toggle--disabled {
-  padding: em(5) em(10) em(3) em(10);
-  display: inline-block;
-  line-height: 1.4em;
-  @include core-16;
+  text-decoration: none;
+  &:hover,
+  &:focus {
+    color: #6f777b;
+  }
 }

--- a/assets/scss/components/_toggle-button.scss
+++ b/assets/scss/components/_toggle-button.scss
@@ -16,6 +16,7 @@ Styleguide Toggle Button
 
 .toggle {
   display: inline-block;
+  white-space: nowrap;
 }
 
 .toggle__btn {
@@ -31,6 +32,10 @@ Styleguide Toggle Button
   &:hover, &:focus {
     outline: none;
     color: $link-hover-colour;
+    background-color: transparent;
+  }
+  &:disabled,
+  [disabled] {
     background-color: transparent;
   }
 }

--- a/assets/scss/components/_toggle-button.scss
+++ b/assets/scss/components/_toggle-button.scss
@@ -2,7 +2,7 @@
 Toggle Button
 
 Markup:
-<span class="toggle">
+<span class="toggle-buttons">
   <span class="error-notification inline-block toggle__error">Error state</span>
   <a href="#" class="toggle__button">link</a>
   <button class="toggle__button">link</button>
@@ -14,7 +14,7 @@ Markup:
 Styleguide Toggle Button
 */
 
-.toggle {
+.toggle-buttons {
   display: inline-block;
   white-space: nowrap;
 }

--- a/assets/scss/components/_toggle-button.scss
+++ b/assets/scss/components/_toggle-button.scss
@@ -2,28 +2,59 @@
 Toggle Button
 
 Markup:
-<span class="toggle-btn {{modifier_class}}">Toggle Button</span>
-
-.toggle-btn--on - The toggle button is on
-.toggle-btn--off - The toggle button is off
+<span class="toggle">
+  <span class="toggle__error">Error state</span>
+  <a href="#" class="toggle__btn">link</a>
+  <button class="toggle__btn">link</button>
+  <span class="toggle--on">on</span>
+  <span class="toggle--off">off</span>
+  <span class="toggle--disabled">disabled</span>
+</span>
 
 Styleguide Toggle Button
 */
 
+.toggle__btn {
+  background-color: transparent;
+  box-shadow: none;
+  text-decoration: underline;
+  color: $link-colour;
+  border: none;
+  &:active {
+    top: 0;
+    box-shadow: none;
+  }
+  &:hover, &:focus {
+    outline: none;
+    color: $link-hover-colour;
+    background-color: transparent;
+  }
+}
 
-.toggle-btn {
+.toggle__error {
+  padding: em(5) em(40) em(3) em(10);
+}
+
+.toggle--on {
+  background-color: $button-colour;
+  color: $white;
+  margin: 0 em(15) 0 0;
+}
+
+.toggle--off {
+  background-color: $light-grey;
+}
+
+.toggle--disabled {
+  color: #6f777b;
+}
+
+.toggle__btn,
+.toggle--on,
+.toggle--off,
+.toggle--disabled {
   padding: em(5) em(10) em(3) em(10);
   display: inline-block;
   line-height: 1.4em;
-}
-
-.toggle-btn--on {
-  background-color: $button-colour;
-  color: $white;
-  margin: 0 em(10) 0 0;
-}
-
-.toggle-btn--off {
-  background-color: $light-grey;
-  margin: 0 0 0 em(10);
+  @include core-16;
 }

--- a/assets/scss/components/_toggle-button.scss
+++ b/assets/scss/components/_toggle-button.scss
@@ -3,7 +3,7 @@ Toggle Button
 
 Markup:
 <span class="toggle">
-  <span class="toggle__error">Error state</span>
+  <span class="error-notification inline-block toggle__error">Error state</span>
   <a href="#" class="toggle__btn">link</a>
   <button class="toggle__btn">link</button>
   <span class="toggle--on">on</span>
@@ -13,6 +13,10 @@ Markup:
 
 Styleguide Toggle Button
 */
+
+.toggle {
+  display: inline-block;
+}
 
 .toggle__btn {
   background-color: transparent;


### PR DESCRIPTION
## Overview

As part of API-1452 story we need to handle error state and it visual style should be same as `error-notification` component.

## Problem

Adding `error-notification` wasn't a quick win here as it was not visually align with toggle button.

## Solution

Refactored toggle button to be wrapped inside `toggle` class and added `error` & 'btn' as sub modules to fix style and layout issue.

## Example Usage

```
<span class="toggle">
  <span class="error-notification inline-block toggle__error">Error state</span>
  <a href="#" class="toggle__button">link</a>
  <button class="toggle__button">link</button>
  <span class="toggle__button toggle__button--active">on</span>
  <span class="toggle__button toggle__button--inactive">off</span>
  <span class="toggle__button toggle__button--disabled">disabled</span>
</span>
```
## Screenshot

![78uuwv68it](https://cloud.githubusercontent.com/assets/1984591/14980618/a40520bc-1121-11e6-92a8-4d1b2e1349b3.gif)
![ngfx0dktq0](https://cloud.githubusercontent.com/assets/1984591/14980619/a405cd50-1121-11e6-80fe-2f9bd8257efa.gif)


<img width="827" alt="screen shot 2016-05-11 at 10 53 51 am" src="https://cloud.githubusercontent.com/assets/1984591/15177398/a8bf1f12-1767-11e6-86aa-71d8c65681ba.png">