### PR TITLE
[API-1452] Ability to subscribe to an API (JS version)

### DIFF
--- a/assets/javascripts/modules/ajaxCallbacks.js
+++ b/assets/javascripts/modules/ajaxCallbacks.js
@@ -57,6 +57,51 @@ var ajaxCallbacks = {
       }
     }
   },
+  apiSubscribeResponse: {
+    callbacks: {
+      success: function(response, $element, data, helpers) {
+        var $onDisabled = $('<span class="toggle--on">On</span>'),
+          $offDisabled = $('<span class="toggle--disabled">Off</span>'),
+          $parent = $element.parent(),
+          $off = $element.next(),
+          formContext = $element.find('[name=context]').val(),
+          formVersion = $element.find('[name=version]').val(),
+          isAdmin =  $element.is('[data-role-admin]'),
+          offUrl =  $element.data('off-url'),
+          $offLink;
+
+        // add "On" element
+        $parent.prepend($onDisabled);
+
+        // remove subscribe form
+        $element.remove();
+
+        // clear the off container
+        $off.remove();
+
+        // if active user is administrator then provide a link to allow un-subscribe
+        if (isAdmin) {
+          $offLink = $('<a>Off</a>')
+            .addClass('toggle__btn')
+            .attr('href', offUrl)
+            .data('api-unsubscribe', formContext + '-' + formVersion);
+
+          // add 'off' link
+          $parent.append($offLink);
+        } else {
+          // add disabled 'off' text for developers
+          $parent.append($offDisabled);
+        }
+
+        helpers.base.success.apply(null, arguments);
+      },
+      error: function(response, $element, data, helpers, targets, container, type) {
+        // show error message
+        $element.find('.toggle__error').addClass('inline-block');
+        helpers.base.error.apply(null, arguments);
+      }
+    }
+  },
   helpers: {
     base: {
       beforeSend: function($element, data, helpers, targets, container, type, actions) {

--- a/assets/javascripts/modules/ajaxCallbacks.js
+++ b/assets/javascripts/modules/ajaxCallbacks.js
@@ -63,7 +63,7 @@ var ajaxCallbacks = {
         var $onDisabled = $('<span class="toggle--on">On</span>'),
           $offDisabled = $('<span class="toggle--disabled">Off</span>'),
           $parent = $element.parent(),
-          $off = $element.next(),
+          $off = $parent.find('[data-toggle-subscribe="off"]'),
           formContext = $element.find('[name=context]').val(),
           formVersion = $element.find('[name=version]').val(),
           isAdmin =  $element.is('[data-role-admin]'),

--- a/assets/javascripts/modules/ajaxCallbacks.js
+++ b/assets/javascripts/modules/ajaxCallbacks.js
@@ -70,6 +70,9 @@ var ajaxCallbacks = {
           offUrl =  $element.data('off-url'),
           $offLink;
 
+        // remove any error already displayed
+        $element.find('.toggle__error').removeClass('inline-block');
+
         // add "On" element
         $parent.prepend($onDisabled);
 

--- a/assets/javascripts/modules/ajaxFormSubmit.js
+++ b/assets/javascripts/modules/ajaxFormSubmit.js
@@ -93,14 +93,14 @@ var ajaxFormSubmit = {
     handlers.fn = _this.getCallback(handlers.config, serializedData);
 
     if (!!handlers) {
-      _this.doSubmit(path, serializedData, handlers.fn);
+      _this.doSubmit(path, serializedData, handlers.fn, $form);
     }
   },
 
-  doSubmit: function(path, data, callback) {
+  doSubmit: function(path, data, callback, $form) {
     $.ajax({
       url: path,
-      type: 'POST',
+      type: $form.attr('method') || 'POST',
       data: data,
       beforeSend: function() {
         if (!!callback) {
@@ -140,6 +140,8 @@ var ajaxFormSubmit = {
         helpers = config.helpers,
         $element = config.$element,
         targets = config.targets;
+
+    config.parameters = [];
 
     if (!!config.name) {
       if (!!config.args) {


### PR DESCRIPTION
## Overview

Progressive enhance to API subscription module to use ajax to subscribe for an API and displaying various state like loading & error. The part of this story relies on backend changes in third-party-developer-frontend as well on some asset-frontend components e.g toggle button, error notification & ajax waiting state  

## Problem

The challenge here was to use existing `ajaxFormSubmit` & `ajaxCallbacks` components and adapt it to our need. Existing functionality use `link` with parameters and runs some business logic on backend  to switch to correct state of the buttons when user click on the link.

## Solution

Converted `link` to `form` and used `hidden` fields for parameters. Additional information is passed as `data` attribute on the form to run business logic checks on client side and update DOM accordingly.

## Example Usage

```
<form method="GET"  
  class="inline-block"
  action="context&version&tab=subscriptions"                                                         
  data-role-admin=""
  data-off-url="context&version&tab=subscriptions"
  data-ajax-submit="true"
  data-callback-name="apiSubscribeResponse.callbacks"
  data-callback-args="">
       <span class="error-notification toggle__error float--left">Server error, please try again</span>
       <input type="hidden" name="context" value=""/>
       <input type="hidden" name="version" value=""/>
       <input type="hidden" name="tab" value="subscriptions"/>
       <button type="submit"  data-api-subscribe=""  class="toggle__btn">On</button>
</form>
```

## Screenshot
![78uuwv68it](https://cloud.githubusercontent.com/assets/1984591/14980618/a40520bc-1121-11e6-92a8-4d1b2e1349b3.gif)
![ngfx0dktq0](https://cloud.githubusercontent.com/assets/1984591/14980619/a405cd50-1121-11e6-80fe-2f9bd8257efa.gif)