### PR TITLE
GG-656: Print icon and style

### DIFF
--- a/assets/images/icon_printer.svg
+++ b/assets/images/icon_printer.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="54px" height="54px" viewBox="0 0 54 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Printer-icon" fill="#1A1919">
+            <path d="M10,0 L44,0 L44,7 L10,7 L10,0 Z M13,4 L40,4 L40,7 L13,7 L13,4 Z" id="Combined-Shape"></path>
+            <path d="M0,12.0049466 C0,10.8976452 0.892217249,10 2.00209026,10 L51.9979097,10 C53.1036337,10 54,10.8970262 54,12.0049466 L54,31.9950534 C54,33.1023548 53.1077828,34 51.9979097,34 L2.00209026,34 C0.896366344,34 0,33.1029738 0,31.9950534 L0,12.0049466 Z M7,24 L48,24 L48,34 L7,34 L7,24 Z M4,14 L7,14 L7,17 L4,17 L4,14 Z" id="Combined-Shape"></path>
+            <g id="Group" transform="translate(11.000000, 27.000000)">
+                <rect id="Rectangle-4" x="0" y="0" width="3" height="27"></rect>
+                <rect id="Rectangle-4" x="3" y="24" width="21" height="3"></rect>
+            </g>
+            <rect id="Rectangle-4" x="41" y="27" width="4" height="17"></rect>
+            <polyline id="Path-1" points="35 44 35 54 45 44"></polyline>
+            <rect id="Rectangle-8" x="17" y="31" width="21" height="3"></rect>
+            <rect id="Rectangle-8" x="17" y="37" width="13" height="4"></rect>
+        </g>
+    </g>
+</svg>

--- a/assets/scss/base/_icons.scss
+++ b/assets/scss/base/_icons.scss
@@ -109,3 +109,26 @@ Styleguide Icons.Verify
     background-image: url("../images/govuk-verify-2x.png");
   }
 }
+
+
+/*
+Print
+
+Icon used for 'print this page' links.
+
+Markup:
+<span class="print"></span>
+
+Styleguide Icons.Print
+*/
+.print {
+  width: 25px;
+  height: 25px;
+  margin-right: em(10);
+  display: inline-block;
+  vertical-align: bottom;
+  background: {
+    image: url("../images/icon_printer.svg");
+    size: 100%;
+  }
+}

--- a/assets/scss/components/_header.scss
+++ b/assets/scss/components/_header.scss
@@ -81,6 +81,14 @@ Styleguide Header.Transaction
   margin-bottom: 30px;
   text-align: center;
 }
+@media print {
+  .transaction-banner--complete {
+      background-color: $white;
+      color: $black;
+      text-align: left;
+      padding: 0;
+  }
+}
 
 .transaction-banner__heading {
   @include bold-36();


### PR DESCRIPTION

* Add print icon in SVG format
* Add style to display print icon
* Add print only styles to `transaction-banner--complete` class for a more printer-friendly version. The original was white text on a large turquoise background.

Icon:

<img width="163" alt="screenshot 2016-05-10 14 13 58" src="https://cloud.githubusercontent.com/assets/11385498/15147621/79a2fa0e-16b9-11e6-88e6-48e455a9a5ea.png">



screen rendering of  `transaction-banner--complete`:
<img width="620" alt="screenshot 2016-05-10 14 15 21" src="https://cloud.githubusercontent.com/assets/11385498/15147682/bc9abfd6-16b9-11e6-949d-2c851db233df.png">



print rendering of  `transaction-banner--complete`:
<img width="382" alt="screenshot 2016-05-10 14 15 47" src="https://cloud.githubusercontent.com/assets/11385498/15147686/c1302216-16b9-11e6-97ba-d4ac13ca41d8.png">
