### PR TITLE
Update subscription count from API response

### DIFF
--- a/assets/javascripts/modules/ajaxCallbacks.js
+++ b/assets/javascripts/modules/ajaxCallbacks.js
@@ -96,6 +96,9 @@ var ajaxCallbacks = {
           $parent.append($offDisabled);
         }
 
+        // update no of subscriptions
+        $('[data-api-subscriptions="'+ response.apiName +'"]').text(response.numberOfSubscriptionText);
+
         helpers.base.success.apply(null, arguments);
       },
       error: function(response, $element, data, helpers, targets, container, type) {


### PR DESCRIPTION
## Problem

Subscription counts are not updated when user subscribe to an API. This bug was introduced as a part of story no [1452](https://jira.tools.tax.service.gov.uk/browse/API-1452). For referecne please check merge request [https://github.com/hmrc/assets-frontend/pull/560]



![gm9v3rhqei](https://cloud.githubusercontent.com/assets/1984591/15152362/e502d78e-16cc-11e6-993e-bc1750055a37.gif)

![ajuwe7ozjq](https://cloud.githubusercontent.com/assets/1984591/15152269/7e7f8fde-16cc-11e6-89f6-3a380cee5bc2.gif)




