### PR TITLE
PE-1968: Styles to add pound currency symbol to number input fields

### DIFF
--- a/assets/scss/base/form/_text-input.scss
+++ b/assets/scss/base/form/_text-input.scss
@@ -8,12 +8,13 @@ Markup:
 
 .input--xxsmall      - An extra extra! small input
 .input--xsmall       - An extra small input
-.input--small        - An small input
-.input--normal       - An normal input
-.input--fullwidth    - An full width input
+.input--small        - A small input
+.input--normal       - A normal input
+.input--fullwidth    - A full width input
 .input--no-spinner   - An input without a spinner
 .input--cleared      - To make an input `{display: block}`
 .input--link         - To make an input appear like a link
+.input--left-padding - An input with left padding giving space for symbols
 
 Styleguide Text Input
 */
@@ -62,6 +63,10 @@ input {
   display: block;
 }
 
+.input--left-padding {
+  padding-left: em(19);
+}
+
 // POTENTIALLY-NOT-IN-USE
 .input--link {
   background: none;
@@ -102,5 +107,28 @@ Styleguide Text Input.number
 .input--no-spinner::-webkit-inner-spin-button,
 .input--no-spinner::-webkit-outer-spin-button {
   -webkit-appearance: none;
+}
+
+/*
+Currency
+
+Currency inputs add the **£** symbol visually within the input field
+
+Markup:
+<span class="input-currency">
+  <input name="example_monetary_input" type="number" class="input--small input--no-spinner input--left-padding" value="0.99" />
+</span>
+
+Styleguide Text Input.Currency
+*/
+.input-currency {
+  position: relative;
+
+  &::before {
+    content: '\00a3';
+    left: em(6.4);
+    position: absolute;
+    top: em(1.6);
+  }
 }
 


### PR DESCRIPTION
<img width="887" alt="screen shot 2016-05-10 at 17 10 42" src="https://cloud.githubusercontent.com/assets/6884347/15153709/330132a0-16d2-11e6-8857-460b86269cf1.png">
Component library screenshot.
Identity Verification frontend requirement to add a **£** symbol visually within a number input field.
I understand this will be useful for other services too.