### PR TITLE
update devDependencies to dependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,11 @@
     "type": "git",
     "url": "https://github.com/hmrc/assets-frontend.git"
   },
-  "engines" : {
-    "node" : ">=0.12.7",
+  "engines": {
+    "node": ">=0.12.7",
     "npm": ">=2.11.3"
   },
   "scripts": {
-    "install": "napa",
     "start": "npm run dev",
     "dev": "gulp",
     "build": "gulp build",
@@ -21,16 +20,13 @@
     "comp-lib:watch": "nodemon -e html,js,css,png,jpeg -x 'npm run comp-lib:link && npm run comp-lib'",
     "comp-lib:link": "npm link hmrc-component-library-template"
   },
-  "napa": {
-    "stageprompt": "alphagov/stageprompt#2.1.0"
-  },
   "keywords": [
     "HMRC",
     "assets"
   ],
   "author": "HMRC",
   "license": "Apache-2.0",
-  "devDependencies": {
+  "dependencies": {
     "browser-sync": "^2.4.0",
     "browserify-istanbul": "^0.1.3",
     "browserify-shim": "^3.8.2",
@@ -78,11 +74,11 @@
     "lodash": "^3.5.0",
     "minifyify": "^6.0.0",
     "modernizr": "^3.0.0-alpha.4",
-    "napa": "^1.2.0",
     "phantomjs-prebuilt": "^2.1.7",
     "pretty-hrtime": "^1.0.0",
     "require-dir": "^0.2.0",
     "run-sequence": "^1.0.2",
+    "stageprompt": "hmrc/stageprompt",
     "sticky-header": "^0.2.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",


### PR DESCRIPTION
# update devDependencies to dependencies 
For hmrc prototype pulling assets-frontend in, remove napa from dependencies, remove npm run script, white space fix