### PR TITLE
Authentication support for mask component

### DIFF
--- a/assets/javascripts/modules/ajaxCallbacks.js
+++ b/assets/javascripts/modules/ajaxCallbacks.js
@@ -57,6 +57,56 @@ var ajaxCallbacks = {
       }
     }
   },
+  clientSecretResponse: {
+    callbacks: {
+      success: function(response, $element, data, helpers, targets, container, type, actions) {
+        var $containerElem = $element.parent('.js-mask-container').first();
+        var $control = $containerElem.find('.js-mask-control').first();
+        var $validationMessage = $containerElem.find('[data-error-message-placeholder]').first();
+
+        // trigger success event
+        $control.trigger('unmask', response.clientSecret);
+
+        // hide form
+        $element.toggleClass('js-visible').toggleClass('js-hidden');
+        
+        // remove any error state on the input
+        $element.find('.form-field').removeClass('form-field--error');
+        $validationMessage.empty();
+        
+        // reset form state
+        helpers.utilities.setFormState($element, false);
+        helpers.resetForms(helpers, type, data, container);
+        $element[0].reset();
+
+        // call super
+        helpers.base.success.apply(null, arguments);
+      },
+      error: function(response, $element, data, helpers, targets, container, type) {
+        var $containerElem = $element.parent('.js-mask-container').first();
+        var redirectUrl = $element.data('error-redirect-url');
+        var $validationMessage = $containerElem.find('[data-error-message-placeholder]').first();
+
+        // redirect to locked account url
+        if (response.responseJSON.code === 'LOCKED_ACCOUNT') {
+           window.location = redirectUrl;
+        }
+
+        // add error state
+        $element.find('.form-field').addClass('form-field--error');
+
+        // show error message
+        $validationMessage.text(response.responseJSON.message);
+        
+        // reset form state
+        helpers.utilities.setFormState($element, false);
+
+        // call super
+        helpers.base.error.apply(null, arguments);
+
+      }
+    }
+  },
   apiSubscribeResponse: {
     callbacks: {
       success: function(response, $element, data, helpers) {
@@ -66,8 +116,8 @@ var ajaxCallbacks = {
           $off = $parent.find('[data-toggle-subscribe="off"]'),
           formContext = $element.find('[name=context]').val(),
           formVersion = $element.find('[name=version]').val(),
-          isAdmin =  $element.is('[data-role-admin]'),
-          offUrl =  $element.data('off-url'),
+          isAdmin = $element.is('[data-role-admin]'),
+          offUrl = $element.data('off-url'),
           $offLink;
 
         // remove any error already displayed

--- a/assets/javascripts/modules/mask.js
+++ b/assets/javascripts/modules/mask.js
@@ -64,7 +64,7 @@ var maskControlEvent = function ($containerElem) {
     event.preventDefault();
 
     // if toggle target selector is provided
-    if (targetSelector.length > 0) {
+    if (targetSelector && targetSelector.length > 0) {
       var $target = $containerElem.find('.' + targetSelector).first();
 
       // hide is already visible

--- a/assets/javascripts/modules/mask.js
+++ b/assets/javascripts/modules/mask.js
@@ -11,13 +11,22 @@ Example:
     <span class="js-visible js-mask-secret">mask</span>
     <span class="js-hidden js-mask-revealed">secret</span>
   </span>
-  <a href="#" class="js-visible js-mask-control" 
-     data-text-show="Show" 
+  <a href="#" class="js-visible js-mask-control"
+     data-text-show="Show"
      data-text-hide="Hide"
+     data-mask-toggle-target="js-mask-form"
      data-accessible-text="accessible text">
     <span data-toggle-text>Show</span> <span>accessible text</span></a>
+  <form method="GET" class="js-mask-form js-hidden">
+    <div class="form-field soft--right soft--bottom soft--top">
+      <label class="label--full-length bold">Enter your password</label>
+      <p class="error-notification hard--bottom" data-error-message-placeholder></p>
+      <input class="form-input input--medium" name="password" type="password" />
+      <button type="submit" class="button button--padded float--right flush--right">Submit</button>
+    </div>
+  </form>
 </div>
- */
+*/
 
 
 var $maskContainerElems;
@@ -31,19 +40,53 @@ var maskControlEvent = function ($containerElem) {
   var $publicContent = $containerElem.find('.js-mask-revealed').first();
   var $secretContent = $containerElem.find('.js-mask-secret').first();
   var secondsToTimeout = $containerElem.data('mask-timer');
+  var targetSelector = $control.data('mask-toggle-target');
+
+  // listen for success event for secure form
+  $control.on('unmask', function(event, data) {
+    var text = $control.find('[data-toggle-text]').text();
+
+    // add client secret key
+    $publicContent.text(data);
+
+    // toggle to reveal client secret
+    toggleValue($publicContent, $secretContent);
+
+    // start timer if it's configured
+    if(secondsToTimeout) {
+      startTimer(text, $control, $publicContent, $secretContent, secondsToTimeout);
+    }
+  });
 
   $control.on('click', function(event) {
     var text = $control.find('[data-toggle-text]').text();
 
     event.preventDefault();
 
-    toggleState(text, $control, $publicContent, $secretContent);
+    // if toggle target selector is provided
+    if (targetSelector.length > 0) {
+      var $target = $containerElem.find('.' + targetSelector).first();
 
-    // start timer if it's configured
-    if(secondsToTimeout) {
-      startTimer(text, $control, $publicContent, $secretContent, secondsToTimeout);
+      // hide is already visible
+      if($publicContent.hasClass('js-visible')) {
+
+        toggleState("Hide", $control, $publicContent, $secretContent);
+
+      } else {
+        $target.toggleClass('js-visible').toggleClass('js-hidden');
+
+        // update button label
+        toggleLabel(text, $control);
+      }
+
+    } else {
+      toggleState(text, $control, $publicContent, $secretContent);
+
+      // start timer if it's configured
+      if(secondsToTimeout) {
+        startTimer(text, $control, $publicContent, $secretContent, secondsToTimeout);
+      }
     }
-
   });
 
 };
@@ -54,7 +97,7 @@ var addListeners = function () {
   });
 };
 
-var toggleState = function(text, $control, $publicContent, $secretContent) {
+var toggleLabel = function(text, $control) {
 
   var showText = $control.data('textShow');
   var hideText = $control.data('textHide');
@@ -62,10 +105,20 @@ var toggleState = function(text, $control, $publicContent, $secretContent) {
   var accessibleText = $control.data('accessible-text');
   var anchorText = '<span data-toggle-text>' + newText + '</span> <span class="visuallyhidden">' + accessibleText + '</span>';
 
+  $control.html(anchorText);
+};
+
+var toggleValue = function($publicContent, $secretContent) {
+
   $publicContent.toggleClass('js-visible').toggleClass('js-hidden');
   $secretContent.toggleClass('js-visible').toggleClass('js-hidden');
-  $control.html(anchorText);
 
+};
+
+var toggleState = function(text, $control, $publicContent, $secretContent) {
+
+  toggleValue($publicContent, $secretContent);
+  toggleLabel(text, $control);
 };
 
 var startTimer = function(text, $control, $publicContent, $secretContent, secondsToTimeout) {

--- a/assets/test/specs/fixtures/mask-fixture.html
+++ b/assets/test/specs/fixtures/mask-fixture.html
@@ -20,3 +20,23 @@
      data-text-hide="Hide"
      data-accessible-text="accessible text"><span data-toggle-text>Show</span> <span class="visuallyhidden">accessible text</span></a>
 </div>
+<div id="fixture-three" class="js-mask-container" data-mask-timer="0.145">
+  <span>
+    <span class="js-visible js-mask-secret qa-mask">*******************</span>
+    <span class="js-hidden js-mask-revealed qa-secret">aDifferentSecret</span>
+  </span>
+  <a href="#"
+     class="js-visible js-mask-control qa-mask-control"
+     data-text-show="Show"
+     data-text-hide="Hide"
+     data-mask-toggle-target="qa-mask-target"
+     data-accessible-text="accessible text"><span data-toggle-text>Show</span> <span class="visuallyhidden">accessible text</span></a>
+  <form method="GET" class="js-mask-form js-hidden qa-mask-target">
+    <div class="form-field soft--right">
+      <label class="label--full-length bold">Enter your password</label>
+      <p class="error-notification qa-error-message" data-error-message-placeholder></p>
+      <input class="form-input input--medium" name="password" type="password" />
+      <button type="submit" class="button button--padded float--right flush--right">Submit</button>
+    </div>
+  </form>
+</div>

--- a/assets/test/specs/mask.spec.js
+++ b/assets/test/specs/mask.spec.js
@@ -2,6 +2,9 @@ require('jquery');
 
 var JS_VISIBLE_SELECTOR = 'js-visible';
 var JS_HIDDEN_SELECTOR = 'js-hidden';
+var SECRET_KEY = 'secret-key';
+var ERROR_MESSAGE = 'Invalid credential';
+
 var fixtureOneMaskText;
 var fixtureOneSecretText;
 var fixtureOneControlTextShow;
@@ -11,6 +14,12 @@ var fixtureTwoMaskText;
 var fixtureTwoSecretText;
 var fixtureTwoControlTextShow;
 var fixtureTwoControlTextHide;
+
+var $fixtureThreeMaskToggleTarget;
+var fixtureThreeMaskText;
+var fixtureThreeSecretText;
+var fixtureThreeControlTextShow;
+var fixtureThreeControlTextHide;
 
 var $fixtureOne;
 var $fixtureOneQaMask;
@@ -23,6 +32,12 @@ var $fixtureTwoQaSecret;
 var $fixtureTwoControl;
 var mask;
 
+var $fixtureThree;
+var $fixtureThreeQaMask;
+var $fixtureThreeQaSecret;
+var $fixtureThreeControl;
+var $fixtureThreeTarget;
+var $fixtureThreeErrorMessage;
 
 var setup = function () {
   mask();
@@ -37,6 +52,13 @@ var setup = function () {
   $fixtureTwoQaSecret = $fixtureTwo.find('.qa-secret');
   $fixtureTwoControl = $fixtureTwo.find('.qa-mask-control');
 
+  $fixtureThree = $('#fixture-three');
+  $fixtureThreeQaMask = $fixtureThree.find('.qa-mask');
+  $fixtureThreeQaSecret = $fixtureThree.find('.qa-secret');
+  $fixtureThreeControl = $fixtureThree.find('.qa-mask-control');
+  $fixtureThreeTarget = $fixtureThree.find('.qa-mask-target');
+  $fixtureThreeErrorMessage = $fixtureThree.find('.qa-error-message');
+
   fixtureOneMaskText = $fixtureOneQaMask.text();
   fixtureOneSecretText = $fixtureOneQaSecret.text();
   fixtureOneControlTextShow = $fixtureOneControl.data('textShow') + ' ' +
@@ -50,6 +72,15 @@ var setup = function () {
                               $fixtureTwoControl.data('accessibleText');
   fixtureTwoControlTextHide = $fixtureTwoControl.data('textHide') + ' ' +
                               $fixtureTwoControl.data('accessibleText');
+
+
+  $fixtureThreeMaskToggleTarget = $fixtureThreeControl.data('mask-toggle-target');
+  fixtureThreeMaskText = $fixtureThreeQaMask.text();
+  fixtureThreeSecretText = $fixtureThreeQaSecret.text();
+  fixtureThreeControlTextShow = $fixtureThreeControl.data('textShow') + ' ' +
+                                $fixtureThreeControl.data('accessibleText');
+  fixtureThreeControlTextHide = $fixtureThreeControl.data('textHide') + ' ' +
+                                $fixtureThreeControl.data('accessibleText');
 
 };
 
@@ -72,6 +103,11 @@ describe('Mask', function () {
       expect(fixtureTwoMaskText).toBe(fixtureTwoMaskText);
       expect(fixtureTwoSecretText).toBe(fixtureTwoSecretText);
       expect($fixtureTwoControl.text()).toBe(fixtureTwoControlTextShow);
+
+      expect(fixtureThreeMaskText).toBe(fixtureThreeMaskText);
+      expect(fixtureThreeSecretText).toBe(fixtureThreeSecretText);
+      expect($fixtureThreeControl.text()).toBe(fixtureThreeControlTextShow);
+      expect($fixtureThreeMaskToggleTarget).toBe('qa-mask-target');
     });
 
     it('components visibility is correctly set up', function () {
@@ -80,6 +116,8 @@ describe('Mask', function () {
 
       expect($fixtureTwoQaMask).toHaveClass(JS_VISIBLE_SELECTOR);
       expect($fixtureTwoQaSecret).toHaveClass(JS_HIDDEN_SELECTOR);
+
+      expect($fixtureThreeTarget).toHaveClass(JS_HIDDEN_SELECTOR);
     });
   });
 
@@ -114,6 +152,17 @@ describe('Mask', function () {
       expect($fixtureTwoControl.text()).toBe(fixtureTwoControlTextShow);
     });
 
+    it('should show target (if defined) when control', function () {
+      $fixtureThreeControl.click();
+      expect($fixtureThreeQaMask).toHaveClass(JS_VISIBLE_SELECTOR);
+      expect($fixtureThreeQaSecret).toHaveClass(JS_HIDDEN_SELECTOR);
+      expect($fixtureThreeTarget).toHaveClass(JS_VISIBLE_SELECTOR);
+    });
+
+    it('should set secret key on "unmask" event', function () {
+      $fixtureThreeControl.trigger('unmask', SECRET_KEY);
+      expect($fixtureThreeQaSecret.text()).toBe(SECRET_KEY);
+    });
   });
 
   describe('on revealing a timer-configured secret', function() {


### PR DESCRIPTION
## Overview

The `Mask` component should display a string of `•••••••••••••••••••` and reveal the underlying string when the user clicks a trigger.

## Problem

The current implementation does not support password authentication in order to reveal secret. 

The other issue is that backend service expect password as header instead of form body or querystring.

## Solution

Added a toggle target as an intermediary step. If `data-mask-toggle-target` attribute is set on mask control, its then toggle target selector on click. After that It's then down to the target component to `trigger` event on `mask` component to reveal secret. 

The form use `ajaxFormSubmit` to submit request. Extend it support custom headers from input field. It now looks for input with `data-ajax-header` attribute to map to header.

On success callback, it triggers `setKey` event with secret key on mask component.  
On error callback it display relevant error message returned from backend.  


## Example Usage

```
<div class="js-mask-container" data-mask-timer="20">
  <span>
    <span class="js-visible js-mask-secret">mask</span>
    <span class="js-hidden js-mask-revealed">secret</span>
  </span>

  <a href="#" class="js-visible js-mask-control" 
     data-text-show="Show" 
     data-text-hide="Hide"
     data-mask-toggle-target="js-mask-form"
     data-accessible-text="accessible text">
    <span data-toggle-text>Show</span> <span>accessible text</span></a>

  <form method="GET" class="js-mask-form js-hidden">
    <div class="form-field soft--right">
      <label class="label--full-length bold">Enter your password</label>
      <p class="error-notification hard--bottom" data-error-message-placeholder></p>
      <input class="form-input input--medium" data-ajax-header="true" name="password" type="password" />
      <button type="submit" class="button button--padded float--right flush--right">Submit</button>
    </div>
  </form>
</div>
```

## Screenshot
![fjzu4wfxco](https://cloud.githubusercontent.com/assets/1984591/15152908/007b030e-16cf-11e6-8865-95fd748a231f.gif)