### PR TITLE
GG-895: Indent wrapped text on form hint list items.

### DIFF
--- a/assets/scss/base/form/_hint.scss
+++ b/assets/scss/base/form/_hint.scss
@@ -87,6 +87,7 @@ Markup:
 </ul>
 
 .form-hint-list-item--valid - A valid form hint (used in conjunction with `formHintHelper.js`)
+.form-hint-list-item--indented - Longer text following a hint indicator wraps below the text, not the indicator.
 
 Styleguide Form Hint.list
 */
@@ -125,4 +126,9 @@ Styleguide Form Hint.list
       background-image: url("../images/valid-icon.png");
     }
   }
+}
+
+.form-hint-list-item--indented {
+  margin-left: em(30);
+  text-indent: em(-30);
 }

--- a/assets/scss/base/form/_hint.scss
+++ b/assets/scss/base/form/_hint.scss
@@ -73,11 +73,15 @@ List
 
 A Form hint list. The form hint list can also be used in conjunction with `formHintHelper.js` for instance if you
 had a password text input and wanted to check the hints have been correctly matched.
+Optionally wrap the `.form-hint-list-item__indicator` element in a `.form-hint-list-item__primary` element to give a
+2 column layout to avoid text wrapping under the indicator.
 
 Markup:
 <ul class="form-hint-list">
   <li class="form-hint-list-item">
-    <span class="form-hint-list-item__indicator"></span>
+    <span class="form-hint-list-item__primary">
+      <span class="form-hint-list-item__indicator"></span>
+    </span>
     An example form hint, providing extra information to a user
   </li>
   <li class="form-hint-list-item {{modifier_class}}">
@@ -87,7 +91,6 @@ Markup:
 </ul>
 
 .form-hint-list-item--valid - A valid form hint (used in conjunction with `formHintHelper.js`)
-.form-hint-list-item--indented - Longer text following a hint indicator wraps below the text, not the indicator.
 
 Styleguide Form Hint.list
 */
@@ -99,6 +102,7 @@ Styleguide Form Hint.list
 
 .form-hint-list-item {
   margin: 0 0 em(6) 0;
+  display: table;
 }
 
 .form-hint-list-item__indicator {
@@ -128,7 +132,7 @@ Styleguide Form Hint.list
   }
 }
 
-.form-hint-list-item--indented {
-  margin-left: em(30);
-  text-indent: em(-30);
+.form-hint-list-item__primary {
+  display: table-cell;
 }
+


### PR DESCRIPTION
Long text after form hint list items wraps below the bullet point / green tick, rather than below the first line of text. This changes the behaviour from the former to the latter.

<img width="451" alt="screenshot 2016-05-12 15 07 40" src="https://cloud.githubusercontent.com/assets/11385498/15217609/3dbe94c0-1854-11e6-82f8-fe6ede455ba6.png">


<img width="443" alt="screenshot 2016-05-12 15 06 42" src="https://cloud.githubusercontent.com/assets/11385498/15217619/43bcdbca-1854-11e6-8b53-82c5a25f5336.png">
