### PR TITLE
Remove "px" from em mixin

### DIFF
--- a/assets/scss/base/layouts/_layouts.scss
+++ b/assets/scss/base/layouts/_layouts.scss
@@ -26,7 +26,7 @@ body {
 
   p {
     @include core-19();
-    margin: em(12px) 0;
+    margin: em(12) 0;
   }
 
   .full-width & {


### PR DESCRIPTION
This fixes the fact that `<p></p>`s within `.content__body` were having their margin ignored.