### PR TITLE
GG-896: Add class to display elements full-width on small screens

### DIFF
--- a/assets/scss/base/layouts/_layouts.scss
+++ b/assets/scss/base/layouts/_layouts.scss
@@ -93,6 +93,12 @@ body {
   width: $full-width;
 }
 
+.full-width--small {
+  @include media(mobile) {
+    width: $full-width;
+  }
+}
+
 .row {
   margin-bottom: 20px;
 }


### PR DESCRIPTION
I added this to `_layouts.scss` instead of `_buttons.scss`, as there was a similar `.full-screen` class there, and this way it is reusable, rather than only applying to buttons.
It is not mobile-first, as it is only specifying the small-screen behaviour for any given element, which may have its own widths at other screen sizes.

This use case is for action buttons, to make them more easily hit on a touch screen.
<img width="336" alt="screenshot 2016-05-18 12 52 18" src="https://cloud.githubusercontent.com/assets/11385498/15357594/aee6fba4-1cf7-11e6-9935-068dac69f216.png">
