### PR TITLE
Fe 190 add no vendor prefix stylelint

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -6,6 +6,7 @@
     "value-keyword-case": "lower",
     "unit-case": "lower",
     "value-no-vendor-prefix": true,
-    "string-quotes": "double"
+    "string-quotes": "double",
+    "property-no-vendor-prefix": true
   }
 }

--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -1,8 +1,6 @@
 @mixin vertically-centered() {
   display: block;
   top: 50%;
-  -ms-transform: translateY(-50%);
-  -webkit-transform: translateY(-50%);
   transform: translateY(-50%);
 }
 

--- a/assets/scss/base/_icons.scss
+++ b/assets/scss/base/_icons.scss
@@ -50,10 +50,6 @@ Styleguide Icons.Arrow
 
 // used in JavaScript
 .arrow--expand {
-  -webkit-transform: rotate(90deg);
-  -moz-transform: rotate(90deg);
-  -ms-transform: rotate(90deg);
-  -o-transform: rotate(90deg);
   transform: rotate(90deg);
   transition-duration: 0.2s;
 }

--- a/assets/scss/base/_normalize.scss
+++ b/assets/scss/base/_normalize.scss
@@ -1,3 +1,4 @@
+/*stylelint-disable*/
 /*! normalize.css v2.0.1 | MIT License | git.io/normalize */
 
 /* ==========================================================================

--- a/assets/scss/base/_table.scss
+++ b/assets/scss/base/_table.scss
@@ -273,7 +273,5 @@ Styleguide Table.Marker
   text-indent: -99999px;
   width: 10px;
   height: 10px;
-  -webkit-border-radius: 50%;
-  -moz-border-radius: 50%;
   border-radius: 50%;
 }

--- a/assets/scss/base/form/_form.scss
+++ b/assets/scss/base/form/_form.scss
@@ -287,8 +287,8 @@ Styleguide Form.control
   background-color: $white;
   border: 1px solid $border-colour;
 
-  // Disable webkit appearance and remove rounded corners
-  -webkit-appearance: none;
+  // Disable appearance and remove rounded corners
+  appearance: none;
   border-radius: 0;
 
   @include media(tablet) {
@@ -299,7 +299,7 @@ Styleguide Form.control
 
 // fix the select element on Webkit which is broken in govuk_elements' version of this file
 select.form-control {
-  -webkit-appearance: menulist;
+  appearance: menulist;
 }
 
 .form-control--block {

--- a/assets/scss/base/form/_text-input.scss
+++ b/assets/scss/base/form/_text-input.scss
@@ -103,12 +103,12 @@ Markup:
 Styleguide Text Input.number
 */
 .input--no-spinner {
-  -moz-appearance: textfield;
+  appearance: textfield;
 }
 
 .input--no-spinner::-webkit-inner-spin-button,
 .input--no-spinner::-webkit-outer-spin-button {
-  -webkit-appearance: none;
+  appearance: none;
 }
 
 /*

--- a/assets/scss/pages/_payments.scss
+++ b/assets/scss/pages/_payments.scss
@@ -3,7 +3,7 @@
 
   input[type=number]::-webkit-inner-spin-button,
   input[type=number]::-webkit-outer-spin-button {
-    -webkit-appearance: none;
+    appearance: none;
     margin: 0;
   }
 

--- a/gulpfile.js/tasks/sass.js
+++ b/gulpfile.js/tasks/sass.js
@@ -21,7 +21,7 @@ gulp.task('sass', ['stylelint'], function() {
          this.emit('end');
        }))
        .pipe(sass(config[env].settings))
-       .pipe(autoprefixer())
+       .pipe(autoprefixer({browsers: ['last 2 versions', 'IE >= 8']}))
        .pipe(rename({suffix: '.min'}))
        .pipe(gulpif(isDev, sourceMaps.write(config[env].sourceMapsDir)))
        .pipe(gulp.dest(config[env].dest));


### PR DESCRIPTION
# Stylelint property-no-vendor-prefix

- add `"property-no-vendor-prefix": true` rule
- remove any vendor prefixes 
- disable stylelint in [_normalize.scss](https://github.com/hmrc/assets-frontend/blob/FE-190-add-no-vendor-prefix-stylelint/assets/scss/base/_normalize.scss)
- explicitly set vendor prefixing in autoprefixer to `['last 2 versions', 'IE >= 8']`

### Before
```
.arrow--expand {
  transform: rotate(90deg);
  transition-duration: 0.2s;
}
```

### After
```
.arrow--expand {
  -webkit-transform: rotate(90deg);
      -ms-transform: rotate(90deg);
          transform: rotate(90deg);
  -webkit-transition-duration: 0.2s;
          transition-duration: 0.2s;
}
```
