### PR TITLE
move stylelint to dependencies due to hmrc prototype kit pulling in a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "vinyl-transform": "^1.0.0",
-    "watchify": "^2.6.0"
+    "watchify": "^2.6.0",
+    "gulp-stylelint": "^2.0.2"
   },
   "browserify": {
     "transform": [
@@ -127,8 +128,5 @@
     "mdtpdf": {
       "depends": "json3"
     }
-  },
-  "devDependencies": {
-    "gulp-stylelint": "^2.0.2"
   }
 }


### PR DESCRIPTION
…f as dependency