### PR TITLE
FE-169: Document _report-error.scss and move into components

### DIFF
--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -69,7 +69,7 @@ $path: "../images/icons/";
 @import "modules/datatables";
 @import "components/organisation-logo";
 @import "modules/template-footer";
-@import "modules/report-error";
+@import "components/report-error";
 @import "modules/help-contents";
 @import "components/template-sidebar";
 @import "components/notifications";

--- a/assets/scss/components/_report-error.scss
+++ b/assets/scss/components/_report-error.scss
@@ -1,8 +1,25 @@
+/*
+Report Error
+
+Display 'Get help with this page' form, and loading spinner while form is loaded by ajax.
+
+Markup:
+<div class="report-error">
+    <a class="report-error__toggle">Get help with this page</a>
+    <div class="report-error__content">
+        <div class="report-error__loading"></div>
+    </div>
+</div>
+
+Styleguide Report Error
+*/
+
 .report-error {
   display: inline-block;
   clear: both;
   width: 100%;
   margin: 2em 0 1.5em 0;
+
   .report-error__toggle {
     @include core-16;
     color: #454a4c;

--- a/assets/scss/components/_report-error.scss
+++ b/assets/scss/components/_report-error.scss
@@ -1,7 +1,10 @@
 /*
-Report Error
+Load Partial
 
-Display 'Get help with this page' form, and loading spinner while form is loaded by ajax.
+Styles to contain a page partial loaded into the current page by AJAX, and a loading spinner to be displayed while the content is being loaded.
+This is used on the 'Get help with this page' content on the templates of many front-ends.
+The spinner is shown while loading, then removed and replaced with the loaded content.
+The component requires Javascript module: [/javascripts/modules/reportAProblem.js](https://github.com/hmrc/assets-frontend/blob/master/assets/javascripts/modules/reportAProblem.js).
 
 Markup:
 <div class="report-error">
@@ -11,7 +14,7 @@ Markup:
     </div>
 </div>
 
-Styleguide Report Error
+Styleguide Load Partial
 */
 
 .report-error {


### PR DESCRIPTION
Component Library documentation for report-error, used for 'Get help with this page' form.

![screenshot 2016-06-02 10 55 19](https://cloud.githubusercontent.com/assets/11385498/15741219/a45a2e26-28b0-11e6-8c4c-242899bd4c99.png)

This will not demonstrate the functionality of the component until we have worked out how to use our JS in the library, and possibly mock external dependencies such as the ajax file load which this module typically uses. Issue for resolving this:
https://github.com/hmrc/component-library-template/issues/19
