### PR TITLE
FE-165: Mark _help-contents.scss as possibly not in use

### DIFF
--- a/assets/scss/modules/_help-contents.scss
+++ b/assets/scss/modules/_help-contents.scss
@@ -1,3 +1,5 @@
+//POTENTIALLY NOT IN USE
+
 nav.help-contents {
   position: relative;
   width: 100%;


### PR DESCRIPTION
The Jira story was to document `_help-contents.scss` for the Component Library and migrate into components, but the styles are no longer used anywhere.
The styles used to be used in `help-frontend` but has been removed from there, and also removed from 2 prototypes which used it, `hmrc-businesstax` and `hmrc-payments`.

assets-frontend issue created to address establishing whether the classes are still used:
https://github.com/hmrc/assets-frontend/issues/612
 