### PR TITLE
PE-2200 : Instead of responsive images, we provide an oversized image…

### DIFF
--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -33,6 +33,7 @@ $path: "../images/icons/";
 @import "base/layouts/gutters";
 @import "base/grid";
 @import "base/buttons";
+@import "base/images";
 @import "base/lists";
 @import "base/table";
 @import "base/helpers";

--- a/assets/scss/base/_images.scss
+++ b/assets/scss/base/_images.scss
@@ -13,4 +13,4 @@ Markup:
 
 Styleguide Images
 */
-img {max-width:100%}
+img {max-width: 100%}

--- a/assets/scss/base/_images.scss
+++ b/assets/scss/base/_images.scss
@@ -1,0 +1,16 @@
+/*
+Images
+
+Because displays now come at different pixel densities, we require higher res imagery to display clearly for all browsers.  This means:
+Use images at least 1200px wide if they are to sit in a full column;
+Use tools like optiPNG or imageOptim to minify the file size of the image if using PNG.
+Use lossy compression sparingly for images containing many colours, and double check quality with a designer.
+
+Markup:
+<div>
+  <img src="/assets/images/bank-account-last-4-digits.png"/>
+</div>
+
+Styleguide Images
+*/
+img {max-width:100%}


### PR DESCRIPTION
… that retains clarity on retina screens and at zoomed in levels.  For this end, we need to constrain images at a maximum of 100% of their containers width.