### PR TITLE
Hotfix button link style

### DIFF
--- a/assets/scss/base/_buttons.scss
+++ b/assets/scss/base/_buttons.scss
@@ -128,14 +128,21 @@ button, .button {
   }
 }
 
+/*
+Link Style
+
+Make a button appear like a link
+
+Markup:
+<button class="button--link-style">Button text</button>
+
+Styleguide Buttons.Link Style
+*/
+
 .button--link-style {
-  margin: 0;
-  padding: 0;
-  border: none;
+  @extend .link-style;
   background: none;
   box-shadow: none;
-  cursor: pointer;
-  text-decoration: underline;
 
   &:hover,
   &:focus,

--- a/assets/scss/base/_buttons.scss
+++ b/assets/scss/base/_buttons.scss
@@ -13,8 +13,7 @@ Markup:
 .button--alert         - An alert button
 .button--small         - A smaller button
 .button--table         - A button within a table
-.button--link   - To make a button appear like a link
-.button--link-style    - To make a button appear like a link with white text
+.button--link          - To make a button appear like a link
 
 Styleguide Buttons
 */

--- a/assets/scss/base/_links.scss
+++ b/assets/scss/base/_links.scss
@@ -22,6 +22,8 @@ Link
 
 To make an element appear as a link.
 
+**NOTE:** This relies on `a` from govuk_frontend_static/basic
+
 Markup:
 <span class="link-style">Example Link</span>
 
@@ -29,6 +31,7 @@ Styleguide Links.Link
 */
 
 .link-style {
+  @extend a;
   margin: 0;
   padding: 0;
   border: none;


### PR DESCRIPTION
This fixes a button that's styled to look like a link being white.

# Before
![image](https://cloud.githubusercontent.com/assets/1752124/15605793/fe1bce70-23ff-11e6-89c8-1d191755ffc0.png)

# After
![image](https://cloud.githubusercontent.com/assets/1752124/15606005/54f0d1ea-2401-11e6-8f54-f2019b957c59.png)
