### PR TITLE
PE-2200 : Setting img max-width to 100% of container element.

### DIFF
--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -33,6 +33,7 @@ $path: "../images/icons/";
 @import "base/layouts/gutters";
 @import "base/grid";
 @import "base/buttons";
+@import "base/images";
 @import "base/lists";
 @import "base/table";
 @import "base/helpers";

--- a/assets/scss/base/_images.scss
+++ b/assets/scss/base/_images.scss
@@ -1,0 +1,3 @@
+img {
+  max-width: 100%;
+}


### PR DESCRIPTION
… that retains clarity on retina screens and at zoomed in levels.  For this end, we need to constrain images at a maximum of 100% of their containers width.

What was:
![image-full](https://cloud.githubusercontent.com/assets/383343/15608018/cda9292c-240e-11e6-92aa-851551cfaa29.gif)

becomes:
![image-fit](https://cloud.githubusercontent.com/assets/383343/15608035/fdfb9f2e-240e-11e6-82d6-9b540b1fdf3a.gif)

