### PR TITLE
add rule to enforce newlines after semi colons

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,6 +4,7 @@
     "declaration-colon-space-after": "always",
     "declaration-colon-space-before": "never",
     "declaration-block-trailing-semicolon": "always",
+    "declaration-block-semicolon-newline-after": "always-multi-line",
     "value-keyword-case": "lower",
     "unit-case": "lower",
     "value-no-vendor-prefix": true,


### PR DESCRIPTION
Stylelint rule `"declaration-block-semicolon-newline-after": "always-multi-line"` to enforce multiline declaration blocks

```
.example {
   margin-top: 2em;
}
```
Not:
`.example {margin-top: 2em;}`