### PR TITLE
Component library footer

### DIFF
--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -40,7 +40,6 @@ $path: "../images/icons/";
 @import "base/links";
 @import "base/icons";
 @import "base/details";
-@import "base/footer";
 
 // Form
 @import "base/form/errors";

--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -40,6 +40,7 @@ $path: "../images/icons/";
 @import "base/links";
 @import "base/icons";
 @import "base/details";
+@import "base/footer";
 
 // Form
 @import "base/form/errors";
@@ -55,7 +56,7 @@ $path: "../images/icons/";
 @import "components/header";
 @import "components/attorney-banner";
 @import "components/notice-banner";
-@import "modules/footer";
+@import "components/footer";
 @import "components/phase-alpha";
 @import "components/phase-beta";
 @import "modules/service-info";
@@ -69,7 +70,6 @@ $path: "../images/icons/";
 @import "components/reminders";
 @import "modules/datatables";
 @import "components/organisation-logo";
-@import "modules/template-footer";
 @import "components/report-error";
 @import "modules/help-contents";
 @import "components/template-sidebar";

--- a/assets/scss/components/_footer.scss
+++ b/assets/scss/components/_footer.scss
@@ -1,3 +1,25 @@
+#footer .open-government-licence h2 {
+  margin-top: 0 !important;
+}
+
+.footer-meta {
+  ul li {
+    @include core-16;
+  }
+}
+
+@include media(mobile) {
+  #footer .footer-meta .footer-meta-inner .open-government-licence h2 {
+    height: auto;
+  }
+}
+
+@include ie(7) {
+  #footer .footer-meta .footer-meta-inner {
+    margin-top: 90px;
+  }
+}
+
 // POTENTIALLY NOT IN USE
 .footer {
   background-color: $grey-8;

--- a/assets/scss/components/_footer.scss
+++ b/assets/scss/components/_footer.scss
@@ -4,8 +4,8 @@ Footer
 Deprecated: These footer styles are no longer in use and are
 awaiting removal
 
-.footer - Footer styles
-.footer-meta - Meta info wrapper
+.footer            - Footer styles
+.footer-meta       - Meta info wrapper
 .footer-meta-inner - Meta info container
 */
 .footer {
@@ -32,13 +32,13 @@ Explore
 Deprecated: These explore styles are no longer in use and are
 awaiting removal
 
-.explore - Explore GOV.UK footer nav links
-.explore--inside-government - Positions the inside gov link
-.explore--inline - Inline link modifier
-.explore--inline__links - Another inline modifier
-.explore--inline__copyright - Inlines the copyright info
+.explore                          - Explore GOV.UK footer nav links
+.explore--inside-government       - Positions the inside gov link
+.explore--inline                  - Inline link modifier
+.explore--inline__links           - Another inline modifier
+.explore--inline__copyright       - Inlines the copyright info
 .explore--inline__copyright__logo - Inlines the copyright logo
-.explore__heading - Heading for explore links
+.explore__heading                 - Heading for explore links
 */
 .explore {
   float: left;

--- a/assets/scss/components/_footer.scss
+++ b/assets/scss/components/_footer.scss
@@ -1,16 +1,22 @@
-#footer .open-government-licence h2 {
-  margin-top: 0 !important;
+/*
+Footer
+
+Deprecated: These footer styles are no longer in use and are
+awaiting removal
+
+.footer - Footer styles
+.footer-meta - Meta info wrapper
+.footer-meta-inner - Meta info container
+*/
+.footer {
+  background-color: $grey-8;
+  border-top: 10px solid $mainstream-brand;
+  padding-top: 0;
 }
 
 .footer-meta {
   ul li {
     @include core-16;
-  }
-}
-
-@include media(mobile) {
-  #footer .footer-meta .footer-meta-inner .open-government-licence h2 {
-    height: auto;
   }
 }
 
@@ -20,14 +26,20 @@
   }
 }
 
-// POTENTIALLY NOT IN USE
-.footer {
-  background-color: $grey-8;
-  border-top: 10px solid $mainstream-brand;
-  padding-top: 0;
-}
+/*
+Explore
 
-// POTENTIALLY NOT IN USE
+Deprecated: These explore styles are no longer in use and are
+awaiting removal
+
+.explore - Explore GOV.UK footer nav links
+.explore--inside-government - Positions the inside gov link
+.explore--inline - Inline link modifier
+.explore--inline__links - Another inline modifier
+.explore--inline__copyright - Inlines the copyright info
+.explore--inline__copyright__logo - Inlines the copyright logo
+.explore__heading - Heading for explore links
+*/
 .explore {
   float: left;
   margin-right: 7%;
@@ -57,7 +69,6 @@
   }
 }
 
-// POTENTIALLY NOT IN USE
 .explore--inside-government {
   @extend .explore;
   width: 31%;
@@ -71,7 +82,6 @@
   }
 }
 
-// POTENTIALLY NOT IN USE
 .explore--inline {
   @extend .explore;
   border-top: 0;
@@ -95,14 +105,12 @@
   }
 }
 
-// POTENTIALLY NOT IN USE
 .explore--inline__links {
   color: $grey-3;
   padding-top: 106px;
   width: 75%;
 }
 
-// POTENTIALLY NOT IN USE
 .explore--inline__copyright {
   padding-top: 30px;
   width: 25%;
@@ -111,7 +119,6 @@
   text-align: center;
 }
 
-// POTENTIALLY NOT IN USE
 .explore--inline__copyright__logo {
   background: url("/assets/images/govuk-crest-2x.png") no-repeat 50% 0;
   background-size: 125px 102px;
@@ -120,14 +127,30 @@
   padding-top: 11.5rem;
 }
 
-// POTENTIALLY NOT IN USE
 .explore__heading {
   @include bold-24;
 }
 
-// POTENTIALLY NOT IN USE
+/*
+Open Government Licence Logo
+
+Deprecated: These OGL logo styles are no longer in use and are
+awaiting removal
+
+.open-government-licence-logo - the OGL logo in the footer
+*/
 .open-government-licence-logo {
   padding-right: 10px;
   width: 43px;
   height: 17px;
+}
+
+#footer .open-government-licence h2 {
+  margin-top: 0 !important;
+}
+
+@include media(mobile) {
+  #footer .footer-meta .footer-meta-inner .open-government-licence h2 {
+    height: auto;
+  }
 }

--- a/assets/scss/components/_footer.scss
+++ b/assets/scss/components/_footer.scss
@@ -1,12 +1,11 @@
-/*------------------------------------*\
-    footer
-\*------------------------------------*/
+// POTENTIALLY NOT IN USE
 .footer {
   background-color: $grey-8;
   border-top: 10px solid $mainstream-brand;
   padding-top: 0;
 }
 
+// POTENTIALLY NOT IN USE
 .explore {
   float: left;
   margin-right: 7%;
@@ -34,9 +33,9 @@
       clear: none;
     }
   }
-
 }
 
+// POTENTIALLY NOT IN USE
 .explore--inside-government {
   @extend .explore;
   width: 31%;
@@ -50,6 +49,7 @@
   }
 }
 
+// POTENTIALLY NOT IN USE
 .explore--inline {
   @extend .explore;
   border-top: 0;
@@ -73,21 +73,23 @@
   }
 }
 
+// POTENTIALLY NOT IN USE
 .explore--inline__links {
   color: $grey-3;
   padding-top: 106px;
   width: 75%;
 }
 
+// POTENTIALLY NOT IN USE
 .explore--inline__copyright {
   padding-top: 30px;
   width: 25%;
   min-height: 150px;
   min-height: 15rem;
   text-align: center;
-
 }
 
+// POTENTIALLY NOT IN USE
 .explore--inline__copyright__logo {
   background: url("/assets/images/govuk-crest-2x.png") no-repeat 50% 0;
   background-size: 125px 102px;
@@ -96,29 +98,14 @@
   padding-top: 11.5rem;
 }
 
+// POTENTIALLY NOT IN USE
 .explore__heading {
   @include bold-24;
 }
 
-#footer .open-government-licence h2 {
-  margin-top: 0 !important;
-}
-
-@include media(mobile) {
-  #footer .footer-meta .footer-meta-inner .open-government-licence h2 {
-    height: auto;
-  }
-}
-
+// POTENTIALLY NOT IN USE
 .open-government-licence-logo {
   padding-right: 10px;
   width: 43px;
   height: 17px;
-}
-
-@include ie(7) {
-  #footer .footer-meta .footer-meta-inner {
-    margin-top: 90px;
-  }
-
 }

--- a/assets/scss/modules/_template-footer.scss
+++ b/assets/scss/modules/_template-footer.scss
@@ -1,5 +1,0 @@
-.footer-meta {
-  ul li {
-    @include core-16;
-  }
-}


### PR DESCRIPTION
# Component library footer documentation

- moved what looks like small tweaks to the `footer` into a `base/footer` file
- marked the majority of work in `components/footer` as `//POTENTIALLY NOT IN USE` as they cannot be found in repo searches
- moved work from `modules/template-footer` into `base/footer` as this was an override

### Of Note
There is no actual component library documentation here this is just a cleanup and deprecation marking PR

### Related Issue
issue raise #626 