### PR TITLE
Component library datatables

### DIFF
--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -67,7 +67,7 @@ $path: "../images/icons/";
 @import "components/side-navigation";
 @import "components/dividers";
 @import "components/reminders";
-@import "modules/datatables";
+@import "components/datatables";
 @import "components/organisation-logo";
 @import "modules/template-footer";
 @import "components/report-error";

--- a/assets/scss/base/form/_text-input.scss
+++ b/assets/scss/base/form/_text-input.scss
@@ -134,3 +134,8 @@ Styleguide Text Input.Currency
   }
 }
 
+::-webkit-input-placeholder {
+  color: $grey-1;
+  font-size: em(15);
+  padding: em(5) 0 0 em(5);
+}

--- a/assets/scss/components/_datatables.scss
+++ b/assets/scss/components/_datatables.scss
@@ -5,6 +5,11 @@ The data tables work is provided via the `datatables` npm package. You can apply
 adding the selectors `.status--unconfirmed` or `.status--confirm-success` as demonstrated in the example below.
 More information for implementation can be found at https://datatables.net
 
+The JavaScript work in [enhancedDatatables.js](https://github.com/hmrc/assets-frontend/blob/master/assets/javascripts/modules/enhancedTables.js) provides HMRC specific default settings and functionality. If you wish to override these you can via `data-` attributes information can be found:
+* https://datatables.net/examples/advanced_init/html5-data-attributes.html
+* https://datatables.net/examples/advanced_init/html5-data-options.html
+
+
 Markup:
 <table class="js-datatable dataTable no-footer"
        data-dom="<'dataTables-filter__block'f>tip"

--- a/assets/scss/modules/_datatables.scss
+++ b/assets/scss/modules/_datatables.scss
@@ -162,6 +162,7 @@ Styleguide dataTable
   }
 }
 
+// POTENTIALLY NOT IN USE
 .controlpanel {
   margin-bottom: em(30);
 

--- a/assets/scss/modules/_datatables.scss
+++ b/assets/scss/modules/_datatables.scss
@@ -38,12 +38,6 @@
   }
 }
 
-::-webkit-input-placeholder {
-  color: $grey-1;
-  font-size: em(15);
-  padding: em(5) 0 0 em(5);
-}
-
 .dataTables_paginate {
   text-align: right;
 

--- a/assets/scss/modules/_datatables.scss
+++ b/assets/scss/modules/_datatables.scss
@@ -1,3 +1,54 @@
+/*
+DataTable
+
+The data tables work is provided via the `datatables` npm package. You can apply custom styles to your table rows by
+adding the selectors `.status--unconfirmed` or `.status--confirm-success` as demonstrated in the example below.
+More information for implementation can be found at https://datatables.net
+
+Markup:
+<table class="js-datatable dataTable no-footer"
+       data-dom="<'dataTables-filter__block'f>tip"
+       data-order='[3,"asc"]'
+       data-fixed-Header="true"
+       data-page-Length="200"
+       data-auto-Width="false"
+       data-column-Defs='[{"targets": [0], "width": "30%"},{"targets": [1],"width": "20%"},{"targets": [2,3],"width": "15%"}]'
+       data-language='{"sSearchPlaceholder":"Search by client name / reference","sSearch":"<span class=\"full-width shim text--left\"><strong>Search Client list</strong></span>"}'>
+  <thead>
+  <tr role="row">
+    <th tabindex="0">Name</th>
+    <th data-orderable="false" data-search="false">Gender</th>
+    <th tabindex="0">Age</th>
+    <th tabindex="0">Nationality</th>
+  </tr>
+  </thead>
+  <tbody>
+    <tr class="tabular-data__cell--centred" role="row">
+      <td>Ben Smith</td>
+      <td>male</td>
+      <td>38</td>
+      <td>British</td>
+    </tr>
+    <tr class="tabular-data__cell--centred status--confirm-success"
+        role="row">
+      <td>Anna Rose</td>
+      <td>female</td>
+      <td>27</td>
+      <td>French</td>
+    </tr>
+    <tr class="tabular-data__cell--centred status--unconfirmed"
+        role="row">
+      <td>George wells</td>
+      <td>male</td>
+      <td>43</td>
+      <td>South African</td>
+    </tr>
+  </tbody>
+</table>
+
+Styleguide dataTable
+*/
+
 .dataTables_wrapper {
   position: relative;
   display: inline-block;


### PR DESCRIPTION
# Component library datatables

- documented data tables
- moved global placeholder webkit styles into form base file
- marked `.controlpanel` as `//POTENTIALLY NOT IN USE` as it cannot be found in repo searches

### Related Issue
issue raise #629

### Gif
![data-tables](https://cloud.githubusercontent.com/assets/2305016/15926172/68db89da-2e32-11e6-9758-06adef5dd207.gif)

### Screenshot
![datatable](https://cloud.githubusercontent.com/assets/2305016/15926167/6118e1a2-2e32-11e6-84b5-9ab6884d74e5.png)

