### PR TITLE
add component library Background custom tag

### DIFF
--- a/component-lib.json
+++ b/component-lib.json
@@ -14,5 +14,5 @@
   "helpers": [
     "node_modules/hmrc-component-library-template/helpers/"
   ],
-  "custom": ["Example Data"]
+  "custom": ["Example Data", "Background"]
 }


### PR DESCRIPTION
# Background flag component library

Added the flag `Background:` to allow developers to make the element that contains component examples have a dark background.

### Example Screenshot
<img width="607" alt="screen shot 2016-06-14 at 16 26 58" src="https://cloud.githubusercontent.com/assets/2305016/16048683/e598b4b6-324c-11e6-805b-86fdbf015755.png">

