### PR TITLE
TCS-812c updating media queries in calendar icon

### DIFF
--- a/assets/scss/base/_buttons.scss
+++ b/assets/scss/base/_buttons.scss
@@ -181,7 +181,7 @@ Styleguide Buttons.Full width style
   box-sizing: border-box;
 }
 
-@media (max-width: 640px) {
+@include media(mobile) {
   .button--full-width {
     padding-left: 0.5em;
   }

--- a/assets/scss/base/_grid.scss
+++ b/assets/scss/base/_grid.scss
@@ -36,7 +36,7 @@ Markup:
 </div>
 
 .grid-layout--stacked    - Stack columns in mobile
-.grid-layout--half       - Enforce half width columns on mobile
+.grid-layout--half       - Maintain half width columns on mobile
 
 Styleguide Grids
 */

--- a/assets/scss/base/_grid.scss
+++ b/assets/scss/base/_grid.scss
@@ -35,8 +35,8 @@ Markup:
   </div>
 </div>
 
-.grid-layout--stacked    - Stack columns in mobile
-.grid-layout--half       - Maintain half width columns on mobile
+.grid-layout--stacked           - Stack columns in mobile
+.grid-layout--maintain-width    - Maintain half width columns on mobile
 
 Styleguide Grids
 */
@@ -53,10 +53,24 @@ Styleguide Grids
   }
 }
 
-.grid-layout--half {
+.grid-layout--maintain-width {
   @include media(mobile) {
+    display: table;
+    float: left;
     .grid-layout__column--1-2 {
       width: $half;
+    }
+    .grid-layout__column--1-4 {
+      width: $one-quarter;
+    }
+    .grid-layout__column--3-4 {
+      width: $three-quarters;
+    }
+    .grid-layout__column--1-3 {
+      width: $one-third;
+    }
+    .grid-layout__column--2-3 {
+      width: $two-thirds;
     }
   }
 }

--- a/assets/scss/base/_grid.scss
+++ b/assets/scss/base/_grid.scss
@@ -36,6 +36,7 @@ Markup:
 </div>
 
 .grid-layout--stacked    - Stack columns in mobile
+.grid-layout--half       - Enforce half width columns on mobile
 
 Styleguide Grids
 */
@@ -48,6 +49,14 @@ Styleguide Grids
   @include media(mobile) {
     .grid-layout__column {
       display: block;
+    }
+  }
+}
+
+.grid-layout--half {
+  @include media(mobile) {
+    .grid-layout__column--1-2 {
+      width: $half;
     }
   }
 }

--- a/assets/scss/base/_icons.scss
+++ b/assets/scss/base/_icons.scss
@@ -81,7 +81,7 @@ Styleguide Icons.Calendar
   }
 }
 
-@media (max-width: 640px) {
+@include media(mobile) {
   .icon--calendar {
     background: none;
   }


### PR DESCRIPTION
Maintains the half width of the grid on mobile displays with an additional style rather than stacking elements. This is to maintain a consistent visual style between devices.

Also brings other code in-line to use the standard media query in the full width button and calendar icon.

![output](https://cloud.githubusercontent.com/assets/7779656/16229035/7eb9fad2-37b2-11e6-97af-5bfe1bcb1632.gif)

Demo in the Component library: 

![output](https://cloud.githubusercontent.com/assets/7779656/16267814/9bed92cc-3883-11e6-86ec-de00dcb2092e.gif)