### PR TITLE
Update subscription counts in correct category 

### DIFF
--- a/assets/javascripts/modules/ajaxCallbacks.js
+++ b/assets/javascripts/modules/ajaxCallbacks.js
@@ -253,7 +253,7 @@ var ajaxCallbacks = {
         }
 
         // update no of subscriptions
-        $('[data-api-subscriptions="'+ response.apiName +'"]').text(response.numberOfSubscriptionText);
+        $('[data-api-subscriptions="'+ response.apiName +'-' + response.group + '"]').text(response.numberOfSubscriptionText);
 
         helpers.base.success.apply(null, arguments);
       },


### PR DESCRIPTION
Service specific ajax callback is updated to select correct element from the page based on the category group and update no of subscriptions message.

![ftd90gwxxk](https://cloud.githubusercontent.com/assets/1984591/16229521/26384500-37b5-11e6-985b-6602daf8a5d4.gif)

