### PR TITLE
# Fix validation error summary link behaviour

### DIFF
--- a/assets/javascripts/validation/form.js
+++ b/assets/javascripts/validation/form.js
@@ -110,7 +110,7 @@ var createErrorSummaryListItem = function ($liElement, validator, errorDetail) {
                 .attr('href', '#' + errorDetail.name)
                 .text(errorDetail.message);
   $errorSummaryMessages.append($liElement);
-}
+};
 
 /**
  * Clear the following for hidden inputs error messages, reset inputs and remove errors from validator.invalid
@@ -191,6 +191,7 @@ var getErrorMessages = function () {
 var setupForm = function ($formElem) {
   var submitted = false;
   var validator = $formElem.validate({
+    onfocusout: false,
     errorPlacement: function ($error, $element) {
       var $formFieldGroup = $element.closest('.form-field-group');
       $formFieldGroup.find('.error-notification').text($error.text());
@@ -238,4 +239,4 @@ var init = function () {
 module.exports = {
   init: init,
   getErrorMessages: getErrorMessages
-}
+};

--- a/assets/test/specs/form.spec.js
+++ b/assets/test/specs/form.spec.js
@@ -209,8 +209,36 @@ describe('Form Validation', function () {
         expect($errorSummary).not.toHaveClass('error-summary--show');
       });
 
-      it('The error summary should be visible for accessibility users', function () {
-        expect($errorSummary).toHaveClass('visuallyhidden');
+      it('The error summary should not be visible for accessibility users', function () {
+        expect($errorSummary).not.toHaveClass('visuallyhidden');
+      });
+
+      it('The error summary should not contain errors', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+        expect($errorMessages.length).toBe(0);
+      });
+
+      it('The form should have no error', function () {
+        expect(form.getErrorMessages().length).toBe(0);
+      });
+    });
+    
+    describe('When I enter value below min length and submit', function () {
+
+      beforeEach(function () {
+        // select radio button, add value below min length to text input
+        $radioYesElement.click();
+        $textInputExample.val('55').blur();
+        $submitButton.click();
+      });
+
+      it('The error summary should be visible', function () {
+        expect($errorSummary).toHaveClass('error-summary--show');
+      });
+
+      it('The error summary should not be hidden for accessibility users', function () {
+      
+        expect($errorSummary).not.toHaveClass('visuallyhidden');
       });
 
       it('The error summary should contain 1 errors', function () {


### PR DESCRIPTION

# Fix validation error summary link behaviour 

## Problem :interrobang:  
Links in an `error-summary` list with multiple errors listed require *two* clicks to:
 1. scroll the associated invalid form element
 2. setting the associated element state as focused

![fix-summary-error-link-bug](https://cloud.githubusercontent.com/assets/5468091/16564034/3f04c142-41fd-11e6-9643-64c035d60b63.gif)

### Reproduction steps :repeat_one:
To reproduce:
 1. Goto a page with a form with client validation rules for multiple fields
 2. Submit the form with invalid data
 3. On the displayed `error-summary` link list click a link

#### Current behaviour :x:
The page *does not* scroll to and set the focus state on the invalid form element that the clicked `error-summary` link is associated with.

#### Expected behaviour :white_check_mark: 
The page scrolls to and sets the focus state on the invalid form element that the clicked `error-summary` link is associated with.

## Solution :boom: 
Override the `$.validator.defaults.onfocusout` handler passed to `$formElem.validate` by adding the validation setting:
```JSON
{
    onfocusout: false
}
```
![fix-summary-error-link](https://cloud.githubusercontent.com/assets/5468091/16564072/7adcc106-41fd-11e6-8bc4-61b5156d5d37.gif)

*Note*:
The solution will remove the default jQuery behaviour of validation messages being displayed when form elements trigger a blur event. Error messages will be displayed as normal when the form is submitted. The relevant form validation tests have been updated to reflect this change.

----------
## Explanation:
Assuming a form has multiple client validation errors:

 1. when the `error-summary` is displayed:
     - first invalid field in the client validation scope becomes the focus element
     - clicking on an `error-summary` link calls the `$.validator.defaults.onfocusout` handler
     - the handler prevents the associated invalid field from scrolling into view & receiving focus, as
       - the clicked link is not in the validations scope
       - and is therefore not listed in the element list processed by the handler

 2. the next click works as `step 1` has removed focus from the form elements in the validation's scope, so both validation and the `$.validator.defaults.onfocusout` handler are not executed