### PR TITLE
[FE-222] Updates to component lib homepage

### DIFF
--- a/styleguide.md
+++ b/styleguide.md
@@ -4,10 +4,11 @@ This Component Library demonstrates styles and components for **HMRC** applicati
 * [Support Channels](#support-channels)
 * [Adding Components](#adding-components)
 * [Discussing Changes](#discussing-changes)
-* [Reporting Issues / Actioning work - Components](#reporting-issues-actioning-work-components)
+* [Reporting Issues / Actioning work](#reporting-issues--actioning-work)
+   * [Components](#components)
+   * [Template](#template)
 * [Development details](#development-details)
 * [Component Library Template](#component-library-template)
-* [Reporting Issues / Actioning work - Template](#reporting-issues-actioning-work-template)
 * [Developing on the template](#developing-on-the-template)
 
 
@@ -33,9 +34,14 @@ You can see information about how to add a comment which will enable a component
 We have setup a **Components** collection on the [HMRC Digital Hackpad](https://hmrcdigital.hackpad.com/collection/EU4v7qZDRel). Every component page in the Component Library will have a hackpad page of the same name. This will be the place to discuss what you would like for you components.
 
 
-## Reporting Issues / Actioning work - Components
+## Reporting Issues / Actioning work
+### Components
 
 Once a decision has been made by the design team on a component the work needs to be raised and the component needs to be written/changed. To do this please raise an issue in [HMRC assets-fronted issues](https://github.com/hmrc/assets-frontend/issues) and attach the `component library` label to it.
+
+### Template
+
+If you would like to discuss extra features or the design of the template itself please raise an issue in [HMRC component-library-template issues](https://github.com/hmrc/component-library-template/issues).
 
 
 ## Development details
@@ -46,11 +52,6 @@ All the information you need to know for developing and enabling Components with
 # Component Library Template
 
 This library uses the [hmrc-component-library-template](https://github.com/hmrc/component-library-template).
-
-
-## Reporting Issues / Actioning work - Template
-
-If you would like to discuss extra features or the design of the template itself please raise an issue in [HMRC component-library-template issues](https://github.com/hmrc/component-library-template/issues).
 
 
 ## Developing on the template

--- a/styleguide.md
+++ b/styleguide.md
@@ -31,7 +31,7 @@ You can see information about how to add a comment which will enable a component
 
 ## Discussing Changes
 
-We have setup a **Components** collection on the [HMRC Digital Hackpad](https://hmrcdigital.hackpad.com/collection/EU4v7qZDRel). Every component page in the Component Library will have a hackpad page of the same name. This will be the place to discuss what you would like for you components.
+We have setup a **Components** collection on the [HMRC Digital Hackpad](https://hmrcdigital.hackpad.com/collection/EU4v7qZDRel). Every component page in the Component Library has a link to the hackpad page of the same name. This is the place to discuss what you would like for you components.
 
 
 ## Reporting Issues / Actioning work

--- a/styleguide.md
+++ b/styleguide.md
@@ -1,9 +1,9 @@
 This Component Library demonstrates styles and components for **HMRC** applications. It is built on top of the [GOV.UK frontend toolkit](https://github.com/alphagov/govuk_frontend_toolkit) and the [GOV.UK template](https://github.com/alphagov/govuk_template) and it uses the [hmrc-component-library-template](https://github.com/hmrc/component-library-template).
 
 * [What is the Component Library?](#what-is-the-component-library)
-* [Support Channels](#support-channels)
 * [Adding Components](#adding-components)
 * [Discussing Changes](#discussing-changes)
+* [Support Channels](#support-channels)
 * [Reporting Issues / Actioning work](#reporting-issues--actioning-work)
    * [Components](#components)
    * [Template](#template)
@@ -17,13 +17,6 @@ This Component Library demonstrates styles and components for **HMRC** applicati
 The Component Library is the generated output of [HMRC assets-fronted](https://github.com/hmrc/assets-frontend) stylesheets. It allows Designers and Developers to see what components we have across the Tax Platform.
 
 
-## Support Channels
-
-We have Slack channels for questions around the Component Library. You'll need a government email address to join them.
-* [Slack channel for Community UX](https://hmrcdigital.slack.com/messages/community-ux/)
-* [Slack channel for Community Frontend](https://hmrcdigital.slack.com/messages/community-frontend/)
-
-
 ## Adding Components
 
 You can see information about how to add a comment which will enable a component to be rendered in the Component Library by visiting the [HMRC assets-fronted wiki](https://github.com/hmrc/assets-frontend/wiki/Component-Library).
@@ -32,6 +25,13 @@ You can see information about how to add a comment which will enable a component
 ## Discussing Changes
 
 We have setup a **Components** collection on the [HMRC Digital Hackpad](https://hmrcdigital.hackpad.com/collection/EU4v7qZDRel). Every component page in the Component Library has a link to the hackpad page of the same name. This is the place to discuss what you would like for you components.
+
+
+## Support Channels
+
+We have Slack channels for questions around the Component Library. You'll need a government email address to join them.
+* [Slack channel for Community UX](https://hmrcdigital.slack.com/messages/community-ux/)
+* [Slack channel for Community Frontend](https://hmrcdigital.slack.com/messages/community-frontend/)
 
 
 ## Reporting Issues / Actioning work

--- a/styleguide.md
+++ b/styleguide.md
@@ -1,6 +1,7 @@
 This Component Library demonstrates styles and components for **HMRC** applications. It is built on top of the [GOV.UK frontend toolkit](https://github.com/alphagov/govuk_frontend_toolkit) and the [GOV.UK template](https://github.com/alphagov/govuk_template) and it uses the [hmrc-component-library-template](https://github.com/hmrc/component-library-template).
 
 * [What is the Component Library?](#what-is-the-component-library)
+* [Support Channels](#support-channels)
 * [Adding Components](#adding-components)
 * [Discussing Changes](#discussing-changes)
 * [Reporting Issues / Actioning work - Components](#reporting-issues-actioning-work-components)
@@ -13,6 +14,13 @@ This Component Library demonstrates styles and components for **HMRC** applicati
 ## What is the Component Library?
 
 The Component Library is the generated output of [HMRC assets-fronted](https://github.com/hmrc/assets-frontend) stylesheets. It allows Designers and Developers to see what components we have across the Tax Platform.
+
+
+## Support Channels
+
+We have Slack channels for questions around the Component Library. You'll need a government email address to join them.
+* [Slack channel for Community UX](https://hmrcdigital.slack.com/messages/community-ux/)
+* [Slack channel for Community Frontend](https://hmrcdigital.slack.com/messages/community-frontend/)
 
 
 ## Adding Components


### PR DESCRIPTION
# Feedback box content

Added feedback box information to the homepage of the component library which is being linked from the feedback box.

This is related to PR [#31](https://github.com/hmrc/component-library-template/pull/31) on the component-library-template

## Screenshot (feedback box)
![screen shot 2016-07-21 at 14 45 39](https://cloud.githubusercontent.com/assets/2305016/17025436/c54eef62-4f53-11e6-87c6-41255e88d27c.png)
