### PR TITLE
Update gulp-autoprefixer to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "del": "^1.1.1",
     "fingerprintjs": "^0.5.3",
     "gulp": "^3.8.11",
-    "gulp-autoprefixer": "^2.3.0",
+    "gulp-autoprefixer": "^3.0.0",
     "gulp-concat": "^2.5.2",
     "gulp-if": "^1.2.5",
     "gulp-jscs": "^1.6.0",


### PR DESCRIPTION
# Update gulp-autoprefixer

Number type input fields still display increment / decrement control in Firefox when the `.input--no-spinner` rule is applied (as shown below).

![pe-2390-firefox-update-input--no-spinner](https://cloud.githubusercontent.com/assets/5468091/17103647/47d20458-5277-11e6-8745-942086a8a01d.png)

## Issue
Firefox doesn't recognise `appearance` property value of `textfield`, as applied by `.input--no-spinner` and `gulp-autoprefixer` versions pre 3.0.0. does not add the `-moz-appearance` property in the application.min.css build. 

## Solution
Update `gulp-autoprefixer` to most recent major version (3.0.0) or above.