### PR TITLE
JQuery validation add method  for require_from_group

### DIFF
--- a/assets/javascripts/validation/customValidations.js
+++ b/assets/javascripts/validation/customValidations.js
@@ -31,4 +31,40 @@ module.exports = function () {
     return regex.test(value);
   });
   
+  /*
+ * SOURCE: jquery-validation/require_from_group.js at master · jzaefferer/jquery-validation
+ *         https://github.com/jzaefferer/jquery-validation/blob/master/src/additional/require_from_group.js 
+ *
+ * Adds method to validate that x number of inputs from group (by selector) are filled
+ *
+ * Note:
+ * 
+ * ..PlayUI _dataAttributes -> s"""data-rule-require_from_group=[3,\".selector\"] """ 
+ * ..html attribute -> data-rule-require_from_group=[3,&quot;.dob&quot;] 
+ * 
+ * Where:
+ * - options[0]: number of fields that must be filled in the group
+ * - options[1]: CSS selector that defines the group of conditionally required fields
+ */
+  jQuery.validator.addMethod( "require_from_group", function( value, element, options ) {
+    var $fields = $( options[ 1 ], element.form ),
+      $fieldsFirst = $fields.eq( 0 ),
+      validator = $fieldsFirst.data( "valid_req_grp" ) ? $fieldsFirst.data( "valid_req_grp" ) : $.extend( {}, this ),
+      isValid = $fields.filter( function() {
+          return validator.elementValue( this );
+        } ).length >= options[ 0 ];
+
+    // Store the cloned validator for future validation
+    $fieldsFirst.data( "valid_req_grp", validator );
+
+    // If element isn't being validated, run each require_from_group field's validation rules
+    if ( !$( element ).data( "being_validated" ) ) {
+      $fields.data( "being_validated", true );
+      $fields.each( function() {
+        validator.element( this );
+      } );
+      $fields.data( "being_validated", false );
+    }
+    return isValid;
+  });
 };

--- a/assets/test/specs/fixtures/form-fixture.html
+++ b/assets/test/specs/fixtures/form-fixture.html
@@ -78,6 +78,51 @@
       </fieldset>
     </div>
   </fieldset>
+
+
+  <fieldset class="form-field-group" id="dob">
+    <label class="form-field ">
+      <span class="form-label-bold">Date of birth</span>
+      <div class="form-date">
+        <span class="form-hint">For example, 31 3 1980</span>
+        <ul class="error-notification--group">
+          <li class="error-notification--group-item">
+            <span id="dob-error-message" class="error-notification" role="alert" data-input-name="dob">
+                  Enter your date of birth.
+            </span>
+          </li>
+        </ul>
+
+        <div class="form-date" id="date-fields">
+          <div class="form-group form-group-day">
+            <label for="dob-day" class="form-group form-group-day">Day</label>
+            <input type="number" class="dob input--xsmall required input--no-spinner" name="dob.day" id="dob-day"
+                   data-rule-required="true"
+                   data-msg-required="Enter your date of birth."
+                   data-rule-require_from_group='[3,".dob"]'
+                   data-msg-require_from_group="Enter your date of birth.">
+          </div>
+
+          <div class="form-group form-group-month">
+            <label for="dob-month" class="form-group form-group-month">Month</label>
+            <input type="number" class="dob input--normal required  input--no-spinner" name="dob.month" id="dob-month"
+                   data-rule-required="true"
+                   data-msg-required="Enter your date of birth."
+                   data-rule-require_from_group='[3,".dob"]'
+                   data-msg-require_from_group="Enter your date of birth.">
+          </div>
+          <div class="form-date form-group-year">
+            <label for="dob-year" class="form-date form-group-year flush--bottom">Year</label>
+            <input type="number" class="dob input--xsmall form-group-year required input--no-spinner" name="dob.year" id="dob-year" 
+                   data-rule-required="true"
+                   data-msg-required="Enter your date of birth."
+                   data-rule-require_from_group='[3,".dob"]'
+                   data-msg-require_from_group="Enter your date of birth.">
+          </div>
+        </div>
+      </div>
+    </label>
+  </fieldset>
   
   <button id="submit-button" type="submit">Submit</button>
 </form>

--- a/assets/test/specs/form.spec.js
+++ b/assets/test/specs/form.spec.js
@@ -14,6 +14,9 @@ var $radioYesElement;
 var $radioNoElement;
 var $radioYesGroupElement;
 var $radioNoGroupElement;
+var $dobDayElement;
+var $dobMonthElement;
+var $dobYearElement;
 var $groupToggle;
 var toggleDynamic;
 
@@ -31,6 +34,9 @@ var setup = function () {
   $radioNoElement = $('#radio-no');
   $radioYesGroupElement = $('#radio-group-yes');
   $radioNoGroupElement = $('#radio-group-no');
+  $dobDayElement = $('#dob-day');
+  $dobMonthElement = $('#dob-month');
+  $dobYearElement = $('#dob-year');
   $groupToggle = $('#other-group-toggle');
 };
 
@@ -73,16 +79,17 @@ describe('Form Validation', function () {
         expect($errorSummaryHeading.text()).toBe(ERROR_SUMMARY_HEADER_TEXT);
       });
 
-      it('The error summary should contain 2 errors', function () {
+      it('The error summary should contain 3 errors', function () {
         var $errorMessages = $errorSummaryMessages.find('> li');
 
-        expect($errorMessages.length).toBe(2);
+        expect($errorMessages.length).toBe(3);
         expect($errorMessages.eq(0).text()).toBe($textInputExample.attr('data-msg-required'));
         expect($errorMessages.eq(1).text()).toBe($radioYesElement.attr('data-msg-required'));
+        expect($errorMessages.eq(2).text()).toBe($dobDayElement.attr('data-msg-required'));
       });
 
-      it('The form should have 2 errors', function () {
-        expect(form.getErrorMessages().length).toBe(2);
+      it('The form should have 3 errors', function () {
+        expect(form.getErrorMessages().length).toBe(3);
       });
     });
 
@@ -91,6 +98,9 @@ describe('Form Validation', function () {
       beforeEach(function () {
         $textInputExample.val('4567878');
         $radioYesElement.click();
+        $dobDayElement.val('31');
+        $dobMonthElement.val('12');
+        $dobYearElement.val('1970');
         $submitButton.on('click', function (event) {
             event.preventDefault();
             // prevent form submission - will cause page reload error in jasmine
@@ -117,6 +127,9 @@ describe('Form Validation', function () {
         // select radio button, add wrong format value to text input
         $textInputExample.val('wrong!');
         $radioYesElement.click();
+        $dobDayElement.val('31');
+        $dobMonthElement.val('12');
+        $dobYearElement.val('1970');
         $submitButton.click();
       });
 
@@ -146,6 +159,9 @@ describe('Form Validation', function () {
         // select radio button, add value below min length to text input
         $textInputExample.val('55');
         $radioYesElement.click();
+        $dobDayElement.val('31');
+        $dobMonthElement.val('12');
+        $dobYearElement.val('1970');        
         $submitButton.click();
       });
 
@@ -174,6 +190,9 @@ describe('Form Validation', function () {
       beforeEach(function () {
         // do not select radio button, add correct value for text input
         $textInputExample.val('55888');
+        $dobDayElement.val('31');
+        $dobMonthElement.val('12');
+        $dobYearElement.val('1970');
         $submitButton.click();
       });
 
@@ -228,6 +247,9 @@ describe('Form Validation', function () {
       beforeEach(function () {
         // select radio button, add value below min length to text input
         $radioYesElement.click();
+        $dobDayElement.val('31');
+        $dobMonthElement.val('12');
+        $dobYearElement.val('1970');
         $textInputExample.val('55').blur();
         $submitButton.click();
       });
@@ -254,6 +276,120 @@ describe('Form Validation', function () {
       it('The form should have the invalid pattern inline error message', function () {
         var $inlineErrorMessage = $('#text-input-example-error-message');
         expect($inlineErrorMessage.text()).toBe($textInputExample.attr('data-msg-minlength'));
+      });
+    });
+
+    describe('When I do not enter any of the date fields', function() {
+      beforeEach(function () {
+        $textInputExample.val('4567878');
+        $radioYesElement.click();
+        $submitButton.click();
+      });
+
+      it('The error summary should be visible', function () {
+        expect($errorSummary).toHaveClass('error-summary--show');
+      });
+
+      it('The error summary should not be hidden for accessibility users', function () {
+
+        expect($errorSummary).not.toHaveClass('visuallyhidden');
+      });
+
+      it('The error summary should contain 1 errors', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+        expect($errorMessages.length).toBe(1);
+        expect($errorMessages.eq(0).text()).toBe($dobDayElement.attr('data-msg-required'));
+      });
+
+      it('The form should have 1 error', function () {
+        expect(form.getErrorMessages().length).toBe(1);
+      });
+    });
+
+    describe('When I enter invalid value for the day date field', function() {
+      beforeEach(function () {
+        $textInputExample.val('4567878');
+        $radioYesElement.click();
+        $dobDayElement.val('');
+        $dobMonthElement.val('12');
+        $dobYearElement.val('1970');
+        $submitButton.click();
+      });
+
+      it('The error summary should be visible', function () {
+        expect($errorSummary).toHaveClass('error-summary--show');
+      });
+
+      it('The error summary should not be hidden for accessibility users', function () {
+        expect($errorSummary).not.toHaveClass('visuallyhidden');
+      });
+
+      it('The error summary should contain 1 errors', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+        expect($errorMessages.length).toBe(1);
+        expect($errorMessages.eq(0).text()).toBe($dobDayElement.attr('data-msg-required'));
+      });
+
+      it('The form should have 1 error', function () {
+        expect(form.getErrorMessages().length).toBe(1);
+      });
+    });
+
+    describe('When I enter invalid value for the month date field', function() {
+      beforeEach(function () {
+        $textInputExample.val('4567878');
+        $radioYesElement.click();
+        $dobDayElement.val('31');
+        $dobMonthElement.val('');
+        $dobYearElement.val('1970');
+        $submitButton.click();
+      });
+
+      it('The error summary should be visible', function () {
+        expect($errorSummary).toHaveClass('error-summary--show');
+      });
+
+      it('The error summary should not be hidden for accessibility users', function () {
+        expect($errorSummary).not.toHaveClass('visuallyhidden');
+      });
+
+      it('The error summary should contain 1 errors', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+        expect($errorMessages.length).toBe(1);
+        expect($errorMessages.eq(0).text()).toBe($dobMonthElement.attr('data-msg-required'));
+      });
+
+      it('The form should have 1 error', function () {
+        expect(form.getErrorMessages().length).toBe(1);
+      });
+    });
+
+    describe('When I enter invalid value for the year date field', function() {
+      beforeEach(function () {
+        $textInputExample.val('4567878');
+        $radioYesElement.click();
+        $dobDayElement.val('31');
+        $dobMonthElement.val('12');
+        $dobYearElement.val('');
+        $submitButton.click();
+      });
+
+      it('The error summary should be visible', function () {
+        expect($errorSummary).toHaveClass('error-summary--show');
+      });
+
+      it('The error summary should not be hidden for accessibility users', function () {
+        expect($errorSummary).not.toHaveClass('visuallyhidden');
+      });
+
+      it('The error summary should contain 1 errors', function () {
+        var $errorMessages = $errorSummaryMessages.find('> li');
+        expect($errorMessages.length).toBe(1);
+        expect($errorMessages.eq(0).text()).toBe($dobYearElement.attr('data-msg-required'));
+      });
+
+      it('The form should have 1 error', function () {
+        expect(form.getErrorMessages().length).toBe(1);
       });
     });
 


### PR DESCRIPTION
## JQuery validation add method  for require_from_group
* add jQuery.validator.addMethod("require_from_group") for validating elements as a group
* method validates that x number of inputs from group (by selector) are filled
* in the example animation the rule is used to ensure that the 3 date elements (day, month, year) are filled

**Note**
Please see issue https://github.com/hmrc/assets-frontend/issues/673

![jQuery validation - add require_from_group method](https://cloud.githubusercontent.com/assets/5468091/17217380/1120a86c-54dc-11e6-8a00-6b639aabb712.gif)
