### PR TITLE
CATO-3714: Fixing the problem with 'validatorFocus'.

### DIFF
--- a/assets/javascripts/modules/validatorFocus.js
+++ b/assets/javascripts/modules/validatorFocus.js
@@ -9,14 +9,12 @@
     $('.error-summary a').on('click', function(e) {
       var $this = $(this);
       var focusId = $this.attr('data-focuses');
-      if (!focusId)
-      {
+      if (!focusId) {
         focusId = ("" + $this.attr("href")).trim();
         if (focusId.indexOf("#") !== 0)
           return;
       }
-      else
-      {
+      else {
         focusId = "#" + focusId;
       }
 

--- a/assets/javascripts/modules/validatorFocus.js
+++ b/assets/javascripts/modules/validatorFocus.js
@@ -7,9 +7,12 @@
     }
 
     $('.error-summary a').on('click', function(e) {
+      var focusId = $(this).attr('data-focuses');
+      if (!focusId)
+        return;
+
       e.preventDefault();
-      var focusId = $(this).attr('data-focuses'),
-        inputToFocus = $('#' + focusId),
+      var inputToFocus = $('#' + focusId),
         inputTagName = inputToFocus.prop("tagName").toLowerCase(),
         nodeToScrollTo = inputToFocus;
 

--- a/assets/javascripts/modules/validatorFocus.js
+++ b/assets/javascripts/modules/validatorFocus.js
@@ -10,7 +10,7 @@
       var $this = $(this);
       var focusId = $this.attr('data-focuses');
       if (!focusId) {
-        focusId = ("" + $this.attr("href")).trim();
+        focusId = $this.attr("href") || "";
         if (focusId.indexOf("#") !== 0)
           return;
       }

--- a/assets/javascripts/modules/validatorFocus.js
+++ b/assets/javascripts/modules/validatorFocus.js
@@ -19,7 +19,7 @@
       }
 
       var inputToFocus = $(focusId);
-      if (!inputToFocus.size())
+      if (!inputToFocus.length)
         return;
 
       e.preventDefault();

--- a/assets/javascripts/modules/validatorFocus.js
+++ b/assets/javascripts/modules/validatorFocus.js
@@ -7,13 +7,26 @@
     }
 
     $('.error-summary a').on('click', function(e) {
-      var focusId = $(this).attr('data-focuses');
+      var $this = $(this);
+      var focusId = $this.attr('data-focuses');
       if (!focusId)
+      {
+        focusId = ("" + $this.attr("href")).trim();
+        if (focusId.indexOf("#") !== 0)
+          return;
+      }
+      else
+      {
+        focusId = "#" + focusId;
+      }
+
+      var inputToFocus = $(focusId);
+      if (!inputToFocus.size())
         return;
 
       e.preventDefault();
-      var inputToFocus = $('#' + focusId),
-        inputTagName = inputToFocus.prop("tagName").toLowerCase(),
+
+      var inputTagName = inputToFocus.prop("tagName").toLowerCase(),
         nodeToScrollTo = inputToFocus;
 
       if (["input", "select", "button"].indexOf(inputTagName) !== -1) {


### PR DESCRIPTION
## Problem
'validatorFocus' module was throwing exception when error summary contained a link without 'data-focuses' attribute (a normal link which should just navigate to a page).

## Solution
Added check to ensure the attribute exists. Normal link behaviour is restored when a link doesn't have 'data-focuses' attribute.