### PR TITLE
TAI-1415 adding paragraph workaround to _shame.scss

### DIFF
--- a/assets/scss/_shame.scss
+++ b/assets/scss/_shame.scss
@@ -126,3 +126,15 @@ html {
 body {
   background: $white;
 }
+
+/* Headings with `p` added due to the specificity of `.content__body p`.
+ * To be removed once specificity lowered. */
+p.heading-48 {
+  @include bold-48();
+  margin: em(10) 0 em(10) 0;
+}
+
+p.heading-24,
+p.heading-24--normal {
+  @include core-24();
+}


### PR DESCRIPTION
## Problem
Currently heading styles cannot be applied to `p` elements as `.content__body p` is more specific.

## Temporary solution
I have added `p.h*-heading` and `p.heading-*` to `_shame.scss` in order to temporarily resolve this issue. I'll add a note to remove this code on the relevant issue once it has been merged.