### PR TITLE
GPK - Added gov.uk elements stylesheet images to the copy task so that they are available in the versioned assets directory.

### DIFF
--- a/gulpfile.js/config.js
+++ b/gulpfile.js/config.js
@@ -27,7 +27,8 @@ var src = './assets/',
     govuk = {
       elements: src + 'govuk_elements',
       template: src + 'govuk_elements/govuk',
-      images: src + 'govuk_elements/govuk/public/images/'
+      images: src + 'govuk_elements/govuk/public/images/',
+      cssimgs: src + 'govuk_elements/govuk/public/stylesheets/images/'
     };
 
 module.exports = {
@@ -105,7 +106,7 @@ module.exports = {
   },
   
   images: {
-    govuk: govuk.images + '**/*',
+    govuk: [govuk.images, govuk.cssimgs].map(function (folder) { return folder  + '**/*'; }),
     dev: {
       src: [src + 'images/**/*', '!' + src + 'images/**/*.svg'],
       dest: snapshotDir + 'images'

--- a/gulpfile.js/tasks/images.js
+++ b/gulpfile.js/tasks/images.js
@@ -5,6 +5,6 @@ var gulp   = require('gulp'),
 
 gulp.task('images', function() {
   var env = global.runmode;
-  return gulp.src([config.images.govuk].concat(config.images.dev.src))
+  return gulp.src(config.images.govuk.concat(config.images.dev.src))
 				.pipe(gulp.dest(config.images[env].dest));
 });


### PR DESCRIPTION
**Use case:**

As a user of emails, I want to use versioned copies of images used within gov_uk_elements stylesheets.

**Resolution**

Add govuk_elements/govuk/public/stylesheets/images to the directories to copy into the versioned assets image folder.

