### PR TITLE
API-1234 : Added callback for new role (developer) in API creation.

### DIFF
--- a/assets/javascripts/modules/ajaxCallbacks.js
+++ b/assets/javascripts/modules/ajaxCallbacks.js
@@ -136,9 +136,12 @@ var ajaxCallbacks = {
         var message =  emailMessage + (response.registeredUser ?
                     ' confirming they have been added to this application.' :
                     ' inviting them to register with the API Developer Hub. They cannot access the application until they register.');
+        var role = $element.find('[name=role]:checked').val();
 
-        if ($element.find('[name=role]:checked').val() === 'ADMINISTRATOR') {
+        if (role === 'ADMINISTRATOR') {
           $permission.append($('<span class="faded-text">Admin</span>'));
+        } else if (role === 'DEVELOPER') {
+          $permission.append($('<span class="faded-text">Developer</span>'));
         }
 
         // add to the list


### PR DESCRIPTION
The Ajax callback from registering a new user previously only handled creation of an admin user.
We would like the functionality to handle creation of a developer user type in order to display their role in the application.

![developer role displayed in manage applications page](https://cloud.githubusercontent.com/assets/383343/18433101/af68f27a-78dd-11e6-9f6f-86f8fb0e6490.png)
