### PR TITLE
Replace gds urls with data uri

### DIFF
--- a/assets/govuk_elements/public/sass/service-design-manual/helpers/_breadcrumbs.scss
+++ b/assets/govuk_elements/public/sass/service-design-manual/helpers/_breadcrumbs.scss
@@ -44,7 +44,7 @@
         line-height: 1.25;
         font-weight: 300;
         text-transform: none;
-        background-image: url(https://assets.digital.cabinet-office.gov.uk/static/separator-73822610794bc3a64871f144d93d6526.png);
+        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAYAAAALCAYAAABcUvyWAAAANElEQVQYlWPYvH3H7b37DyUwoIN9Bw8t2Hfw8H96Sm7asu3dvoOH/xPWQaEgAwMDAy6fAwA24VeCFlDvTgAAAABJRU5ErkJggg==);
         background-position: 100% 50%;
         background-repeat: no-repeat;
         float: left;
@@ -59,7 +59,7 @@
         }
 
         @media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 20 / 10), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
-          background-image: url(https://assets.digital.cabinet-office.gov.uk/static/separator-2x-2ff66846b80b66edba8ce56d29daa935.png);
+          background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAWCAYAAAD0OH0aAAAAZklEQVQ4jWPYtX+/wb4Dh97v2r/fgIEYsO/Aoff7Dh7+T7SmvfsPJew7ePj/ENG0fv9+ASI0HWxAaDp8njhNBw7NH0KaqKuBJCeRpvjgoX7iFaPG9n1SFONPT4NEMQMDGVmU1EIAAAjtK5BETq5FAAAAAElFTkSuQmCC);
           background-size: 6px 11px;
         }
 

--- a/assets/scss/components/_breadcrumb.scss
+++ b/assets/scss/components/_breadcrumb.scss
@@ -62,7 +62,7 @@ Deprecated: Breadcrumbs is the `play-ui` version of breadcrumbs
 Markup:
 <div id="global-breadcrumb" class="header-context {{modifier_class}}">
   <nav>
-    <ol>
+    <ol class="group">
       <li><a href="#">Link</a></li>
       <li><a href="#">Link</a></li>
       <li>Text</li>


### PR DESCRIPTION
The https://assets.digital.cabinet-office.gov.uk/ domain is being decommissioned on Oct 1st. This work replaces the two urls we use with data-uris.

### Images
![img-urls](https://cloud.githubusercontent.com/assets/2305016/18831377/38d9bd8c-83dd-11e6-9203-2407ee2d03a3.png)

### Data-uris
![data-uris](https://cloud.githubusercontent.com/assets/2305016/18831385/4093741e-83dd-11e6-89ba-f6e6100badd6.png)



