### PR TITLE
Update the node version used on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - 0.12
+  - 4.4.5
 before_install: npm i -g npm@2.4.1
 script: ./server.sh build


### PR DESCRIPTION
Some of our dependencies rely on a newer version of node that we were using. This was therefore breaking our build.

This PR updates the version of node to reflect what's on our internal build boxes.