### PR TITLE
Added module to allow toggling visibility based on input value

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -11,6 +11,7 @@ var sso = require('./modules/sso.js'),
     mask = require('./modules/mask.js'),
     form = require('./validation/form.js'),
     toggle = require('./modules/toggle.js'),
+    toggleOnValue = require('./modules/toggleOnValue.js'),
     autoCompleteFactory = require('./modules/autoCompleteFactory.js'),
     passwordReveal = require('./modules/passwordReveal.js'),
     formHintHelper = require('./modules/formHintHelper.js'),
@@ -144,6 +145,7 @@ $(function() {
   form.init();
   mask();
   toggle();
+  toggleOnValue();
   autoCompleteFactory();
   control();
   masker();

--- a/assets/javascripts/modules/toggleOnValue.js
+++ b/assets/javascripts/modules/toggleOnValue.js
@@ -1,0 +1,65 @@
+/*
+ Helper to enable elements to toggle other elements on the page specified by data attribute
+ Attach event to parent as delegate, open close dependant on triggers id.
+
+ Toggle markup example:
+
+ <input class="js-toggle-on-value id="uk-number" value="0" name="uk-number" required />
+
+ Target markup example:
+ <div data-toggle-on-value-id="uk-phone-number" data-toggle-on-value="1" class="hidden">
+ A......
+ </div>
+ <div data-toggle-on-value-id="uk-phone-number" data-toggle-on-value="2" class="hidden">
+ .B.....
+ </div>
+ <div data-toggle-on-value-id="uk-phone-number" data-toggle-on-value="3" class="hidden">
+ ..C....
+ </div>
+ */
+var $toggleOnValueElems;
+/**
+ * Controls for triggering toggle
+ * @param $elem
+ */
+var toggleOnValueEvent = function ($elem) {
+  $elem.on('change', $elem, function () {
+    var $targetElems = $("[data-toggle-on-value-id='" + $elem.attr("id") + "']");
+    $targetElems.each(function (index, targetElem) {
+      var $targetElem = $(targetElem);
+      if ($targetElem.data("toggle-on-value") == $elem.val()) {
+        show($targetElem);
+      } else {
+        hide($targetElem);
+      }
+    });
+  });
+};
+
+var show = function ($element) {
+  $element.removeClass('hidden').attr('aria-expanded', 'true').attr('aria-visible', 'true');
+};
+
+var hide = function ($element) {
+  $element.addClass('hidden').attr('aria-expanded', 'false').attr('aria-visible', 'false');
+};
+
+var addListeners = function () {
+  $toggleOnValueElems.each(function (index, elem) {
+    toggleOnValueEvent($(elem));
+    $(elem).change(); //Trigger a change event to update display for initial value
+  });
+};
+
+var setup = function () {
+  $toggleOnValueElems = $('.js-toggle-on-value');
+};
+
+module.exports = function () {
+  setup();
+
+  if ($toggleOnValueElems.length) {
+    addListeners();
+  }
+};
+

--- a/assets/test/specs/fixtures/toggle-on-value-fixture.html
+++ b/assets/test/specs/fixtures/toggle-on-value-fixture.html
@@ -1,0 +1,11 @@
+<input type="number" id="toggle-element" class="js-toggle-on-value" value="1">
+
+<div id="item1" data-toggle-on-value-id="toggle-element" data-toggle-on-value="1">
+  Value 1: I should be visible on load
+</div>
+<div id="item2" data-toggle-on-value-id="toggle-element" data-toggle-on-value="2">
+  Value 2: I should be visible on change
+</div>
+<div id="item3" data-toggle-on-value-id="toggle-element" data-toggle-on-value="3">
+  Value 3: I will never be visible
+</div>

--- a/assets/test/specs/toggleOnValue.spec.js
+++ b/assets/test/specs/toggleOnValue.spec.js
@@ -1,0 +1,107 @@
+require('jquery');
+
+describe("Given I have a toggle on value module an input and three targets on the page", function() {
+
+  var hidden = 'hidden';
+
+  var toggleOnValue,
+      $input,
+      $target1,
+      $target2,
+      $target3;
+
+  beforeEach(function() {
+
+    jasmine.getFixtures().fixturesPath = "base/specs/fixtures/";
+    loadFixtures('toggle-on-value-fixture.html');
+
+    toggleOnValue = require('../../javascripts/modules/toggleOnValue.js');
+
+  });
+
+  describe("When I load the page", function() {
+
+    beforeEach(function() {
+
+      loadFixtures('toggle-on-value-fixture.html');
+      toggleOnValue();
+
+      $input = $('#toggle-element');
+
+      $target1 = $('#item1');
+      $target2 = $('#item2');
+      $target3 = $('#item3');
+    });
+
+    it("Item 1 should be visible", function() {
+      expect($target1).not.toHaveClass(hidden);
+    });
+
+    it("Item 2 and 3 should be hidden", function() {
+      expect($target2).toHaveClass(hidden);
+      expect($target3).toHaveClass(hidden);
+    });
+  });
+
+  describe("When the input value is set to 2", function() {
+
+    beforeEach(function() {
+
+      loadFixtures('toggle-on-value-fixture.html');
+      toggleOnValue();
+
+      $input = $('#toggle-element');
+
+      $target1 = $('#item1');
+      $target2 = $('#item2');
+      $target3 = $('#item3');
+
+      $input.val("2").change();
+    });
+
+    it("Item 2 should be visible", function() {
+      expect($target2).not.toHaveClass(hidden);
+    });
+
+    it("Item 1 and 3 should be hidden", function() {
+      expect($target1).toHaveClass(hidden);
+      expect($target3).toHaveClass(hidden);
+    });
+
+  });
+
+  describe("When the input value is set to 0", function() {
+
+    beforeEach(function() {
+
+      loadFixtures('toggle-on-value-fixture.html');
+      toggleOnValue();
+
+      $input = $('#toggle-element');
+
+      $target1 = $('#item1');
+      $target2 = $('#item2');
+      $target3 = $('#item3');
+
+      $input.val("0").change();
+    });
+
+    it("Item 1, 2 and 3 should be hidden", function() {
+      expect($target1).toHaveClass(hidden);
+      expect($target2).toHaveClass(hidden);
+      expect($target3).toHaveClass(hidden);
+    });
+  });
+
+
+});
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This code adds the capability to toggle visibility of elements in a page based on the value of an input element.

It is similar to toggle.js in that toggle has binary state open/closed that elements can be toggled by. This is equivalent to a _case_ whereas toggle is an _if_.

```htmp
<div><input type="number" id="monthly-payments" class="js-toggle-on-value input--xsmall input--no-spinner input--left-padding" value="2" /> months</div>

<span class="js-hidden">Instalments over: 2 months</span>
<div data-toggle-on-value-id="monthly-payments" data-toggle-on-value="2">Monthly payments of: <strong>£ 505 per month</strong></div>
    
<span class="js-hidden">Instalments over: 3 months</span>
<div data-toggle-on-value-id="monthly-payments" data-toggle-on-value="3">Monthly payments of: <strong>£ 336 per month</strong></div>

<span class="js-hidden">Instalments over: 4 months</span>
<div data-toggle-on-value-id="monthly-payments" data-toggle-on-value="4">Monthly payments of:<strong>£ 252 per month</strong></div>
```
