### PR TITLE
JQuery validation for grouped inline field elements

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -10,6 +10,7 @@ var sso = require('./modules/sso.js'),
     visibility = require('./modules/visibility.js'),
     mask = require('./modules/mask.js'),
     form = require('./validation/form.js'),
+    formInlineGroup = require('./validation/formInlineGroup'),
     toggle = require('./modules/toggle.js'),
     autoCompleteFactory = require('./modules/autoCompleteFactory.js'),
     passwordReveal = require('./modules/passwordReveal.js'),
@@ -142,6 +143,8 @@ $(function() {
   sso().init();
   visibility();
   form.init();
+  formInlineGroup.init();
+
   mask();
   toggle();
   autoCompleteFactory();

--- a/assets/javascripts/validation/customValidations.js
+++ b/assets/javascripts/validation/customValidations.js
@@ -13,10 +13,10 @@ module.exports = function () {
     var validSuggestion = false;
 
     $(suggestions).each(function (index, suggestion) {
-        if (value.toLowerCase() === suggestion.title.toLowerCase() || value === suggestion.value) {
-          validSuggestion = true;
-          return false;
-        }
+      if (value.toLowerCase() === suggestion.title.toLowerCase() || value === suggestion.value) {
+        validSuggestion = true;
+        return false;
+      }
     });
 
     return validSuggestion;
@@ -30,5 +30,99 @@ module.exports = function () {
 
     return regex.test(value);
   });
-  
+
+  // Validate separate day - month - year fields as valid date within an optional min / max date range
+  jQuery.validator.addMethod('dateGroupValid', function(value, element, options) {
+    var dateRange = getDateRange(options.length ? options.split(',') : []),
+      idPrefix = '#' + $(element).data('group') + '-',
+      $fields = { year: $(idPrefix + 'year'), month: $(idPrefix + 'month'), day: $(idPrefix + 'day') },
+      values = { year: parseInt($fields.year.val()), month: parseInt($fields.month.val()) - 1, day: parseInt($fields.day.val()) },
+      isValid = getInvalidFields($fields, this, 'dateGroupValid').length === 0,
+      date;
+
+    // All other rules are valid on this element (because this method was called), so empty the element's error message(s)
+    $('#' + element.id + '-error-message').empty();
+
+    // If the other group elements are valid, create and compare a parse-able date
+    if (isValid) {
+      values.month = getMonthValue($fields.month.val(), values.month, $fields.month.data('monthStrings'));
+      values.year = getYearValue(values.year, dateRange.max, dateRange.min);
+
+      // Check date is parse-able, i.e. a real calendar date (e.g. not 30 Feb 2016 or 31 11 2016)
+      if (!(isNaN(values.year) || isNaN(values.month) || isNaN(values.day))) {
+        date = new Date(values.year, values.month, values.day);
+
+        isValid = isValidDate(date, values) && inDateRange(date, dateRange);
+
+        // Show/Hide parse error message
+        $(idPrefix + 'parse-error-message').toggleClass('hidden', isValid);
+      }
+    }
+
+    return isValid;
+  });
+
+  var getInvalidFields = function ($elements, validator, exceptions) {
+    // run each grouped field's rules, ignoring the rules in 'exceptions' string or array
+    return $.map($elements, function ($element) {
+      return $element;
+    }).filter(function ($e) {
+      var $validator = validator,
+        validRules = $.map($e.rules(), function (v, k) {
+          // run all other rules on the group fields, but ignore this rule
+          return (exceptions.indexOf(k) > -1) ? '' : $.validator.methods[k].call($validator, $e[0].value, $e[0], v);
+        });
+
+      return validRules.indexOf(false) > -1;
+    });
+  };
+
+  // Compare parsed date values to date field values
+  var isValidDate = function (date, dateFields) {
+    return date.getFullYear() === dateFields.year && date.getMonth() === dateFields.month && date.getDate() === dateFields.day;
+  };
+
+  // Compare date against the min/max range
+  var inDateRange = function(date, dateRange) {
+    return date < dateRange.max && date > dateRange.min;
+  };
+
+  // Get month value from mapping array of string abbreviations or return the value as passed
+  var getMonthValue = function($fieldValue, monthValue, monthStrings) {
+    var monthMapping = $.inArray($fieldValue.toUpperCase(), monthStrings ? monthStrings.split(',') : []);
+
+    return isNaN(monthValue) && monthMapping > -1 ? monthMapping : monthValue;
+  };
+
+  // Get year value if two digits, by comparison to min / max date range, or return the value as passed
+  var getYearValue = function(yearValue, maxDate, minDate) {
+    var thisMillennium = Math.floor(new Date().getFullYear() / 100) * 100;
+
+    // If two-digit year entered create a four digit year by assuming century intended from min / max range
+    if (yearValue < 100) {
+      // A 2 digit year will be interpreted as 19th century by JavaScript date
+      if (thisMillennium + yearValue <= maxDate.getFullYear()) {
+        // ...so assume should be this millennium if year in this millennium LESS THAN OR EQUAL TO the max date year
+        return thisMillennium + yearValue;
+      }
+      else if (thisMillennium - 100 + yearValue >= minDate.getFullYear()) {
+        // ...or assume should be last millennium if year in last millennium GREATER THAN OR EQUAL TO the min date year
+        return thisMillennium - 100 + yearValue;
+      }
+    }
+
+    return yearValue;
+  };
+
+  // Get date range object {min: '...', max: '...'}, with default "min" value of 'epoch' start and "max" value of tomorrow
+  var getDateRange = function(dates) {
+    var minValue = dates[0],
+      maxValue = dates[1];
+
+    return {
+      min: minValue ? new Date(minValue) : new Date(0), // start of epoch
+      max: maxValue ? new Date(maxValue) : new Date(new Date().getTime() + 24 * 60 * 60 * 1000) // tomorrow
+    };
+  };
 };
+

--- a/assets/javascripts/validation/form.js
+++ b/assets/javascripts/validation/form.js
@@ -86,8 +86,9 @@ Summary Error Markup example:
  )
  */
 
-var $forms;
-
+var $forms,
+    submitted = false;
+    
 var renderGlobalErrorSummary = function (validator, errorMessages) {
   var $template = $('<li role="tooltip"><a></a></li>');
   var $errorSummaryListElement;
@@ -95,8 +96,10 @@ var renderGlobalErrorSummary = function (validator, errorMessages) {
   if (errorMessages.length) {
 
     $(errorMessages).each(function (index, errorDetail) {
-      $errorSummaryListElement = $template.clone();
-      createErrorSummaryListItem($errorSummaryListElement, validator, errorDetail);
+      if (errorDetail.name &&!$('[data-input-name="'+errorDetail.name+'"]').hasClass('error-summary--ignore')) {
+        $errorSummaryListElement = $template.clone();
+        createErrorSummaryListItem($errorSummaryListElement, validator, errorDetail);
+      }
     });
   }
 };
@@ -189,18 +192,26 @@ var getErrorMessages = function () {
 
 
 var setupForm = function ($formElem) {
-  var submitted = false;
   var validator = $formElem.validate({
     onfocusout: false,
     errorPlacement: function ($error, $element) {
       var $formFieldGroup = $element.closest('.form-field-group');
+
+      // don't set error text if the element is in a group
+      if (!$element.data('group')) {
       $formFieldGroup.find('.error-notification').text($error.text());
+      }
     },
     highlight: function (element) {
       $(element).closest('.form-field-group').addClass('form-field-group--error');
     },
     unhighlight: function (element) {
-      $(element).closest('.form-field-group').removeClass('form-field-group--error');
+      var $element = $(element);
+
+      // don't remove error class if the element is in a group
+      if (!$element.data('group')) {
+        $element.closest('.form-field-group').removeClass('form-field-group--error');
+      }
     },
     showErrors: function () {
       handleErrors(validator, submitted);
@@ -238,5 +249,7 @@ var init = function () {
 
 module.exports = {
   init: init,
-  getErrorMessages: getErrorMessages
+  getErrorMessages: getErrorMessages,
+  handleErrors: handleErrors,
+  submitted: submitted
 };

--- a/assets/javascripts/validation/formInlineGroup.js
+++ b/assets/javascripts/validation/formInlineGroup.js
@@ -1,0 +1,226 @@
+require('jquery');
+/**
+ Extend generic form validation to handle grouped inline form elements
+ (e.g. date of birth, dob: dob.day dob.month dob.year):
+ - updates generic form validator:
+   * adds groups setting for validator to dynamically declare;
+   * overrides validation callbacks where grouped elements present:
+      + change `errorPlacement` to ignore updating of error text when field is part of an inline group;
+      + change `unhighlight` to removal of highlighting class when field is part of an inline group;
+      + change `showErrors` to display inline field error messages inline with group error;
+      + add `success` callback to empty the valid inline group field(s) error message text
+
+ Inline group fields and inline error markup example:
+
+ <form action="..." method="POST"
+      class="form js-form js-form-inline-group"
+      data-groups="date: date-day date-month date-year"
+      autocomplete="off"
+      novalidate="novalidate">
+   <fieldset class="form-field-group touch" id="date">
+      <legend class="form-label-bold">Date</legend>
+      <div class="form-date form-field-group  full-width">
+        <span class="form-hint">For example, 31 MAR 26</span>
+        <ul class="error-notification error-notification--group list--inline group" data-group-error-list="date">
+          <li class="error-notification--group-item list__item inline-block flush">
+             @uk.gov.hmrc.play.views.html.helpers.errorInline(
+               errorKey = "date",
+               errorMessage = Messages("date.required"),
+               classes = Seq("flush", "hard", "float--left"))
+          </li>
+          <li class="error-notification--group-item list__item inline-block flush">
+             @uk.gov.hmrc.play.views.html.helpers.errorInline(
+             errorKey = "date-day",
+             errorMessage = Messages("date.day.required"),
+             classes = Seq("error-summary--ignore", "flush", "hard", "float--left"))
+          </li>
+          <li class="error-notification--group-item list__item inline-block flush">
+             @uk.gov.hmrc.play.views.html.helpers.errorInline(
+               errorKey = "date-month",
+               errorMessage = Messages("date.month.required"),
+               classes = Seq("error-summary--ignore", "flush", "hard", "float--left"))
+          </li>
+          <li class="error-notification--group-item list__item inline-block flush">
+             @uk.gov.hmrc.play.views.html.helpers.errorInline(
+               errorKey = "date-year",
+               errorMessage = Messages("date.year.required"),
+               classes = Seq("error-summary--ignore", "flush", "hard", "float--left"))
+          </li>
+        </ul>
+        <div class="no-touch native-date-picker" id="date-fields">
+          <div class="form-group form-group-day">
+            <label for="date-day" class="form-group form-group-day">Day</label>
+            <input
+              id="date-day"
+              data-group="date"
+              name="date.day"
+              type="number"
+              class="date input--xsmall input--no-spinner"
+              required
+              max="31"
+              min="1"
+              data-rule-range="1,31"
+              data-rule-dategroupvalid="yyyy/mm/dd,yyyy/mm/dd"
+              data-msg-range="..." data-msg-required="..." data-msg-dategroupvalid="...">
+          </div>
+          <div class="form-group form-group-month">
+            <label for="date-month" class="form-group form-group-month">Month</label>
+            <input
+              id="date-month"
+              data-group="date"
+              name="date.month"
+              type="number"
+              class="date input--normal" type="text"
+              data-month-abbrs="'JAN,FEB,MAR,APR,MAY,JUN,JUL,AUG,SEP,OCT,NOV,DEC"
+              required
+              max="12"
+              min="1"
+              maxlength="3"
+              data-rule-range="1,12"
+              data-rule-dategroupvalid="yyyy/mm/dd,yyyy/mm/dd"
+              data-msg-range="..." data-msg-required="..." data-msg-dategroupvalid="...">
+          </div>
+          <div class="form-date form-group-year">
+            <label for="date-year" class="form-date form-group-year flush--bottom">Year</label>
+            <input
+              id="date-year"
+              data-group="date"
+              name="date.year"
+              type="number"
+              class="date input--xsmall form-group-year input--no-spinner"
+              required
+              maxlength="4"
+              minlength="4"
+              data-rule-pattern="^\d{4})$"
+              data-rule-dategroupvalid="yyyy/mm/dd,yyyy/mm/dd"
+              data-msg-pattern="..." data-msg-required="..." data-msg-dategroupvalid="...">
+          </div>
+        </div>
+      </div>
+    </fieldset>
+ </form>
+ */
+
+var form = require('./form.js'),
+  $groups,
+  setupFormGroups = function($groupElem) {
+    var $formElem = $groupElem.closest('.js-form'),
+      validator = $formElem.data('validator'),
+      groupOptions = {
+        onfocusout: function(element, event) {
+          if (!$(element).data('group')) {
+            return false;
+          }
+
+          $.validator.defaults.onfocusout.call(validator, element);
+        },
+
+        errorPlacement: function($error, $element) {
+          var $formFieldGroup = $element.closest('.form-field-group');
+
+          // don't set error text if the element is in a group
+          if (!$element.data('group')) {
+            $formFieldGroup.find('.error-notification').text($error.text());
+          }
+        },
+
+        unhighlight: function(element) {
+          var $element = $(element);
+
+          // don't remove error class if the element is in a group
+          if (!$element.data('group')) {
+            $element.closest('.form-field-group').removeClass('form-field-group--error');
+          }
+        },
+
+        showErrors: function(messages, elements) {
+          // process form errors generically
+          form.handleErrors(validator, form.submitted);
+          form.submitted = false;
+
+          $.each(elements, function(i, val) {
+            var $element = $(val.element),
+              group = $element.data('group'),
+              $group = $('.error-notification--group'),
+              errMsg = $('<a/>').html(val.message).text();
+
+            if ($element.has('[data-group]') && $group.text().indexOf(val.message) === -1) {
+              // set the element error text
+              $('#' + $element.attr('id') + '-error-message').text(errMsg);
+            }
+          });
+        },
+
+        success: function($label, element) {
+          // if validated element is in a group, empty the valid element(s) error message text
+          var $element = $(element),
+            $errMessage = $('[data-input-name="' + $element.attr('id') + '"]'),
+            groupName = $element.data('group');
+
+          if (groupName && $errMessage.length && !$errMessage.is(':hidden')) {
+            $errMessage.empty();
+
+            if (!$('#' + groupName + ' .error-notification--group-item > .error-summary--ignore').text().trim().length) {
+              $element.closest('.form-field-group').removeClass('form-field-group--error');
+            }
+          }
+        },
+
+        groups: (function() {
+          // add groups defined in <form/> data-groups attribute (will be empty {} if not defined)
+          var groups = {},
+            definedGroups = $groupElem.data('groups');
+
+          // when groups defined in form element data attribute  (comma separated list with format: dob: dob-day dob-month dob-year)
+          if (definedGroups) {
+            // for each comma separated value in list
+            $.each(definedGroups.split(','), function(idx, val) {
+              // group is key / value pair
+              var group = val.trim().split(':'),
+                groupName,
+                fields;
+
+              if (group.length) {
+                groupName = group[0].trim();
+                fields = group[1].trim();
+
+                // add group to  groups config { key: "values" }
+                groups[groupName] = fields;
+
+                // add data group property to field element
+                $.each(fields.split(' '), function(i, v) {
+                  var $field = $('#' + v);
+                  $field.data('group', groupName);
+                  $field.attr('data-group', groupName);
+                });
+              }
+            });
+          }
+
+          return groups;
+        })()
+      },
+
+      // extend/merge validator options in generic validation (javascripts/validation/form.js)
+      options = $.extend({}, validator.settings, $groupElem.data('groups') ? groupOptions : {});
+
+    $formElem.removeData('validator');
+    validator = $formElem.validate(options);
+  },
+
+  setupGroupValidation = function() {
+    $groups.each(function(index, elem) {
+      setupFormGroups($(elem));
+    });
+  },
+
+  init = function() {
+    $groups = $('.js-form-inline-group');
+    if ($groups.length) {
+      setupGroupValidation();
+    }
+  };
+
+module.exports = {
+  init: init
+};

--- a/assets/test/specs/fixtures/formInlineGroup-fixture.html
+++ b/assets/test/specs/fixtures/formInlineGroup-fixture.html
@@ -1,0 +1,252 @@
+<form class="js-form js-form-inline-group" autocomplete="off" novalidate="novalidate"  data-dynamic-form data-groups="fromDate: fromDate-day fromDate-month fromDate-year,toDate:toDate-day toDate-month toDate-year, noMinMaxDate: noMinMaxDate-day noMinMaxDate-month noMinMaxDate-year">
+
+  <div class="flash error-summary" id="Search-failure" role="group" aria-labelledby="errorSummaryHeading" tabindex="-1">
+    <h2 id="errorSummaryHeading" class="h3-heading">There are errors on the page.</h2>
+    <ul class="js-error-summary-messages"></ul>
+  </div>
+
+  <fieldset class="form-field-group touch" id="fromDate">
+    <legend class="form-label-bold">From Date</legend>
+    <div class="form-date form-field-group  full-width">
+      <span class="form-hint">For example, 31 DEC 16</span>
+      <ul class="error-notification error-notification--group list--inline group" data-group-error-list="fromDate">
+        <li class="error-notification--group-item list__item inline-block flush">
+          <span id="fromDate-error-message" class="error-notification flush hard float--left" role="alert" data-input-name="fromDate">
+                Enter a ‘from date’.
+          </span>
+        </li>
+        <li class="error-notification--group-item list__item inline-block flush">
+          <span id="fromDate-parse-error-message" class="error-notification hidden flush hard float--left" role="alert" data-input-name="fromDate-parse">
+                Enter a valid ‘from date’.
+          </span>        
+        </li>
+        <li class="error-notification--group-item list__item inline-block flush">
+          <span id="fromDate-day-error-message" class="error-notification error-summary--ignore flush hard float--left" role="alert" data-input-name="fromDate-day"></span>
+        </li>
+        <li class="error-notification--group-item list__item inline-block flush">
+          <span id="fromDate-month-error-message" class="error-notification error-summary--ignore flush hard float--left" role="alert" data-input-name="fromDate-month"></span>
+        </li>
+        <li class="error-notification--group-item list__item inline-block flush">
+          <span id="fromDate-year-error-message" class="error-notification error-summary--ignore flush hard float--left" role="alert" data-input-name="fromDate-year"></span>
+        </li>
+      </ul>
+      <div class="no-touch native-date-picker" id="from-date-fields">
+        <div class="form-group form-group-day">
+          <label for="fromDate-day" class="form-group form-group-day">Day</label>
+          <input
+            id="fromDate-day"
+            data-group="fromDate"
+            name="fromDate.day"
+            type="number"
+            class="fromDate input--xsmall input--no-spinner"
+            data-msg-range= "The ‘from date’ day entered is not valid. Enter a number between 1 and 31."
+            data-msg-dategroupvalid="Enter a valid ‘from date’."
+            data-msg-required="Enter the day of month for the ‘from date’."
+            data-rule-required="true"
+            data-rule-range="1,31"
+            data-rule-dategroupvalid="2016/01/01,2016/12/31"
+            tabindex="1">
+        </div>
+        <div class="form-group form-group-month">
+          <label for="fromDate-month" class="form-group form-group-month">Month</label>
+          <input
+            id="fromDate-month"
+            data-group="fromDate"
+            name="fromDate.month"
+            type="text"
+            class="fromDate input--normal"
+            maxlength="3"
+            data-month-strings="JAN,FEB,MAR,APR,MAY,JUN,JUL,AUG,SEP,OCT,NOV,DEC"
+            data-msg-pattern="The ‘from date’ month you have entered is invalid. Enter the first 3 letters of the month or write the month as a number between 1 and 12."
+            data-msg-required="Enter the month for the ‘from date’."
+            data-msg-dategroupvalid="Enter a valid ‘from date’."
+            data-rule-required="true"
+            data-rule-pattern="^(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|0?[1-9]|1[012])$"
+            data-pattern-flags="i"
+            data-rule-dategroupvalid="2016/01/01,2016/12/31"
+            tabindex="1">
+        </div>
+        <div class="form-date form-group-year">
+          <label for="fromDate-year" class="form-date form-group-year flush--bottom">Year</label>
+          <input
+            id="fromDate-year"
+            data-group="fromDate"
+            name="fromDate.year"
+            type="number"
+            class="fromDate input--xsmall form-group-year input--no-spinner"
+            data-msg-pattern= "The ‘from date’ year entered is not valid. Enter the year as a 4 digit number."
+            data-msg-dategroupvalid="Enter a valid ‘from date’."
+            data-msg-required="Enter the year for the ‘from date’."
+            data-rule-required="true"
+            data-rule-pattern="^(\d{4})$"
+            data-rule-dategroupvalid="2016/01/01,2016/12/31"
+            tabindex="1">
+        </div>
+      </div>
+    </div>
+  </fieldset>
+  
+  <fieldset class="form-field-group touch" id="toDate">
+    <legend class="form-label-bold">To Date</legend>
+    <div class="form-date form-field-group  full-width">
+      <span class="form-hint">For example, 31 12 17</span>
+      <ul class="error-notification error-notification--group list--inline group" data-group-error-list="toDate">
+        <li class="error-notification--group-item list__item inline-block flush">
+          <span id="toDate-error-message" class="error-notification flush hard float--left" role="alert" data-input-name="toDate">
+                Enter a ‘to date’.
+          </span>
+        </li>
+        <li class="error-notification--group-item list__item inline-block flush">
+          <span id="toDate-parse-error-message" class="error-notification hidden flush hard float--left" role="alert" data-input-name="toDate-parse">
+                Enter a valid ‘to date’.
+          </span>
+        </li>
+        <li class="error-notification--group-item list__item inline-block flush">
+          <span id="toDate-day-error-message" class="error-notification error-summary--ignore flush hard float--left" role="alert" data-input-name="toDate-day"></span>
+        </li>
+        <li class="error-notification--group-item list__item inline-block flush">
+          <span id="toDate-month-error-message" class="error-notification error-summary--ignore flush hard float--left" role="alert" data-input-name="toDate-month"></span>
+        </li>
+        <li class="error-notification--group-item list__item inline-block flush">
+          <span id="toDate-year-error-message" class="error-notification error-summary--ignore flush hard float--left" role="alert" data-input-name="toDate-year"></span>
+        </li>
+      </ul>
+      <div class="no-touch native-date-picker" id="to-date-fields">
+        <div class="form-group form-group-day">
+          <label for="toDate-day" class="form-group form-group-day">Day</label>
+          <input
+            id="toDate-day"
+            data-group="toDate"
+            name="toDate.day"
+            type="number"
+            class="toDate input--xsmall input--no-spinner"
+            data-msg-range= "The ‘to date’ day entered is not valid. Enter a number between 1 and 31."
+            data-msg-dategroupvalid="Enter a valid ‘to date’."
+            data-msg-required="Enter the day of month for the ‘to date’."
+            data-rule-required="true"
+            data-rule-range="1,31"
+            data-rule-dategroupvalid="2017/01/01,2017/12/31"
+            >
+        </div>
+        <div class="form-group form-group-month">
+          <label for="toDate-month" class="form-group form-group-month">Month</label>
+          <input
+            id="toDate-month"
+            data-group="toDate"
+            name="toDate.month"
+            type="number"
+            class="toDate input--normal"
+            data-msg-range= "The ‘to date’ month entered is not valid. Enter a number between 1 and 12"
+            data-rule-range="1,12"
+            data-rule-pattern="^(0?[1-9]|1[012])$"
+            data-msg-pattern="The ‘to date’ month you have entered is invalid. Enter the month as a number between 1 and 12."
+            data-msg-dategroupvalid="Enter a valid ‘to date’."
+            data-msg-required="Enter the month for the ‘to date’."
+            data-rule-dategroupvalid="2017/01/01,2017/12/31"
+            >
+        </div>
+        <div class="form-date form-group-year">
+          <label for="toDate-year" class="form-date form-group-year flush--bottom">Year</label>
+          <input
+            id="toDate-year"
+            data-group="toDate"
+            name="toDate.year"
+            type="number"
+            class="toDate input--xsmall form-group-year input--no-spinner"
+            max="2017"
+            min="0"
+            data-msg-pattern= "The ‘to date’ year entered is not valid. Enter the year as a 2 or 4 digit number."
+            data-msg-dategroupvalid="Enter a valid ‘to date’."
+            data-msg-required="Enter the year for the ‘to date’."
+            data-rule-required="true"
+            data-rule-pattern="^((?:19|20)?\d{2})$"
+            data-rule-dategroupvalid="2017/01/01,2017/12/31"
+            >
+        </div>
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset class="form-field-group touch" id="noMinMaxDate">
+    <legend class="form-label-bold">No Min Max Date</legend>
+    <div class="form-date form-field-group  full-width">
+      <span class="form-hint">For example, 31 12 17</span>
+      <ul class="error-notification error-notification--group list--inline group" data-group-error-list="noMinMaxDate">
+        <li class="error-notification--group-item list__item inline-block flush">
+          <span id="noMinMaxDate-error-message" class="error-notification flush hard float--left" role="alert" data-input-name="noMinMaxDate">
+                Enter a ‘no min/max date’.
+          </span>
+        </li>
+        <li class="error-notification--group-item list__item inline-block flush">
+          <span id="noMinMaxDate-parse-error-message" class="error-notification hidden flush hard float--left" role="alert" data-input-name="noMinMaxDate-parse">
+                Enter a valid ‘no min/max date’.
+          </span>
+        </li>
+        <li class="error-notification--group-item list__item inline-block flush">
+          <span id="noMinMaxDate-day-error-message" class="error-notification error-summary--ignore flush hard float--left" role="alert" data-input-name="noMinMaxDate-day"></span>
+        </li>
+        <li class="error-notification--group-item list__item inline-block flush">
+          <span id="noMinMaxDate-month-error-message" class="error-notification error-summary--ignore flush hard float--left" role="alert" data-input-name="noMinMaxDate-month"></span>
+        </li>
+        <li class="error-notification--group-item list__item inline-block flush">
+          <span id="noMinMaxDate-year-error-message" class="error-notification error-summary--ignore flush hard float--left" role="alert" data-input-name="noMinMaxDate-year"></span>
+        </li>
+      </ul>
+      <div class="no-touch native-date-picker" id="noMinMax-date-fields">
+        <div class="form-group form-group-day">
+          <label for="noMinMaxDate-day" class="form-group form-group-day">Day</label>
+          <input
+            id="noMinMaxDate-day"
+            data-group="noMinMaxDate"
+            name="noMinMaxDate.day"
+            type="number"
+            class="noMinMaxDate input--xsmall input--no-spinner"
+            data-msg-range= "The ‘no min/max date’ day entered is not valid. Enter a number between 1 and 31."
+            data-msg-dategroupvalid="Enter a valid ‘no min/max date’."
+            data-msg-required="Enter the day of month for the ‘no min/max date’."
+            data-rule-required="true"
+            data-rule-range="1,31"
+            data-rule-dategroupvalid
+          >
+        </div>
+        <div class="form-group form-group-month">
+          <label for="noMinMaxDate-month" class="form-group form-group-month">Month</label>
+          <input
+            id="noMinMaxDate-month"
+            data-group="noMinMaxDate"
+            name="noMinMaxDate.month"
+            type="number"
+            class="noMinMaxDate input--normal"
+            data-msg-range= "The ‘no min/max date’ month entered is not valid. Enter a number between 1 and 12"
+            data-rule-range="1,12"
+            data-rule-pattern="^(0?[1-9]|1[012])$"
+            data-msg-pattern="The ‘no min/max date’ month you have entered is invalid. Enter the month as a number between 1 and 12."
+            data-msg-dategroupvalid="Enter a valid ‘no min/max date’."
+            data-msg-required="Enter the month for the ‘no min/max date’."
+            data-rule-dategroupvalid
+          >
+        </div>
+        <div class="form-date form-group-year">
+          <label for="noMinMaxDate-year" class="form-date form-group-year flush--bottom">Year</label>
+          <input
+            id="noMinMaxDate-year"
+            data-group="noMinMaxDate"
+            name="noMinMaxDate.year"
+            type="number"
+            class="noMinMaxDate input--xsmall form-group-year input--no-spinner"
+            max="2017"
+            min="0"
+            data-msg-pattern= "The ‘no min/max date’ year entered is not valid. Enter the year as a 2 or 4 digit number."
+            data-msg-dategroupvalid="Enter a valid ‘no min/max date’."
+            data-msg-required="Enter the year for the ‘no min/max date’."
+            data-rule-required="true"
+            data-rule-pattern="^((?:19|20)?\d{2})$"
+            data-rule-dategroupvalid
+          >
+        </div>
+      </div>
+    </div>
+  </fieldset>
+
+  <button id="submit-button" type="submit">Submit</button>
+</form>

--- a/assets/test/specs/formInlineGroup.spec.js
+++ b/assets/test/specs/formInlineGroup.spec.js
@@ -1,0 +1,646 @@
+require('jquery');
+require('validate');
+
+var form, formInline, $formElement,
+	customValidations,
+	$errorSummary, $errorSummaryMessages, $errorSummaryHeading,
+	$submitButton,
+	$fromDateGroup, $toDateGroup, $noMinMaxDateGroup,
+	$errorMessageItems,
+	$noMinMaxDateSummaryError, $noMinMaxDateCustomSummaryError,
+	$toDateSummaryError, $toDateCustomSummaryError,
+	$fromDateSummaryError, $fromDateCustomSummaryError,
+	$dateGroupError = function (groupPrefix) { return $('#' + groupPrefix + 'Date-error-message'); },
+	$dateParseError = function (groupPrefix) { return $('#' + groupPrefix + 'Date-parse-error-message'); },
+	$inlineDateGroupErrorList = function(group) { return $('ul.error-notification--group[data-group-error-list="' + group + '"]'); },
+	$summaryLinkById = function($element) { return $('[id="' + $element.attr('id') + '-error"]'); },
+	dateGeneralErrorText = function(groupPrefix) { return 'Enter a ‘' + groupPrefix + ' date’.'; },
+	dateCustomErrorText = function(groupPrefix) { return 'Enter a valid ‘' + groupPrefix + ' date’.'; },
+	dateDayRequiredText = function(groupPrefix) { return 'Enter the day of month for the ‘' + groupPrefix + ' date’.'; },
+	dateMonthRequiredText = function(groupPrefix) { return 'Enter the month for the ‘' + groupPrefix + ' date’.'; },
+	dateYearRequiredText = function(groupPrefix) { return 'Enter the year for the ‘' + groupPrefix + ' date’.'; },
+	$dateGroupField = function(groupPrefix, field) { return $('[name="' + groupPrefix + 'Date.' + field + '"]'); },
+	$dateGroupFieldError = function(groupPrefix, field) { return $('.error-notification[data-input-name="' + groupPrefix + 'Date-' + field + '"]'); },
+  setup = function() {
+    form.init();
+    formInline.init();
+    $formElement = $('.js-form');
+    customValidations();
+    $errorSummary = $('.error-summary');
+    $errorSummaryMessages = $('.js-error-summary-messages');
+    $submitButton = $('#submit-button');
+    $errorSummaryHeading = $('#errorSummaryHeading');
+    $fromDateGroup = $('#fromDate');
+    $toDateGroup = $('#toDate');
+    $noMinMaxDateGroup = $('#noMinMaxDate');
+
+
+    $formElement.on('submit', function() {
+      $errorMessageItems = $errorSummaryMessages.find('> li');
+      $fromDateCustomSummaryError = $('#fromDate-parse-error');
+      $fromDateSummaryError = $('#fromDate-error');
+      $toDateCustomSummaryError = $('#toDate-parse-error');
+      $toDateSummaryError = $('#toDate-error');
+      $noMinMaxDateCustomSummaryError = $('#noMinMaxDate-parse-error');
+      $noMinMaxDateSummaryError = $('#noMinMaxDate-error');
+    });
+  };
+
+describe('Form Validation for inline group elements', function() {
+
+  beforeEach(function() {
+    jasmine.getFixtures().fixturesPath = 'base/specs/fixtures/';
+    loadFixtures('formInlineGroup-fixture.html');
+    form = require('../../javascripts/validation/form.js');
+    formInline = require('../../javascripts/validation/formInlineGroup.js');
+    document.getElementById(jasmine.getFixtures().containerId).classList.add('js');
+    customValidations = require('../../javascripts/validation/customValidations.js');
+  });
+
+  describe('', function() {
+    beforeEach(function() {
+      setup();
+    });
+
+    describe('When I load the page', function() {
+      it('The error summary should be hidden', function() {
+        expect($errorSummary).not.toHaveClass('error-summary--show');
+      });
+
+      it('The error summary should contain no errors', function() {
+        expect($errorSummaryMessages.find('> li').length).toBe(0);
+      });
+
+      it('The form should have no errors', function() {
+        expect(form.getErrorMessages().length).toBe(0);
+      });
+    });
+
+    describe('When I use date elements with min and max ‘dateGroupValid’ parameters', function() {
+
+      describe('And I submit empty date field values', function() {
+        beforeEach(function() {
+          $submitButton.click();
+        });
+
+        it('The form error summary should display the ‘fromDate’ group general error message and not the group’s field specific inline error messages', function() {
+          expect($fromDateSummaryError).toBeInDOM();
+          expect($errorMessageItems.text()).toContain(dateGeneralErrorText('from'));
+          expect($fromDateCustomSummaryError).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateCustomErrorText('from'));
+
+          expect($summaryLinkById($dateGroupField('from', 'day'))).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateDayRequiredText('from'));
+          expect($summaryLinkById($dateGroupField('from', 'month'))).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateMonthRequiredText('from'));
+          expect($summaryLinkById($dateGroupField('from', 'year'))).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateYearRequiredText('from'));
+        });
+
+        it('The form error summary should display the ‘toDate’ group general error message and not the group’s field specific inline error messages', function() {
+          expect($toDateSummaryError).toBeInDOM();
+          expect($errorMessageItems.text()).toContain(dateGeneralErrorText('to'));
+          expect($toDateCustomSummaryError).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateCustomErrorText('to'));
+
+
+          expect($summaryLinkById($dateGroupField('to', 'day'))).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateDayRequiredText('to'));
+          expect($summaryLinkById($dateGroupField('to', 'month'))).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateMonthRequiredText('to'));
+          expect($summaryLinkById($dateGroupField('to', 'year'))).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateYearRequiredText('to'));
+        });
+
+        it('The ‘fromDate’ inline errors should display the group’s error message and the field specific inline error messages', function() {
+          var $inlineDateErrors = $inlineDateGroupErrorList('fromDate').find('> li');
+          expect($inlineDateErrors.find($dateGroupError('from')).is(':visible')).toBe(true);
+          expect($inlineDateErrors.find($dateParseError('from')).is(':visible')).toBe(false);
+          expect($inlineDateErrors.find($dateGroupFieldError('from', 'day')).is(':visible')).toBe(true);
+          expect($inlineDateErrors.find($dateGroupFieldError('from', 'month')).is(':visible')).toBe(true);
+          expect($inlineDateErrors.find($dateGroupFieldError('from', 'year')).is(':visible')).toBe(true);
+        });
+
+        it('The ‘toDate’ inline errors should display the group’s error message and the field specific inline error messages', function() {
+          var $inlineDateErrors = $inlineDateGroupErrorList('toDate').find('> li');
+          expect($inlineDateErrors.find($dateGroupError('to')).is(':visible')).toBe(true);
+          expect($inlineDateErrors.find($dateParseError('to')).is(':visible')).toBe(false);
+          expect($inlineDateErrors.find($dateGroupFieldError('to', 'day')).is(':visible')).toBe(true);
+          expect($inlineDateErrors.find($dateGroupFieldError('to', 'month')).is(':visible')).toBe(true);
+          expect($inlineDateErrors.find($dateGroupFieldError('to', 'year')).is(':visible')).toBe(true);
+        });
+      });
+
+      describe('And I update submitted empty date field values without re-submitting', function() {
+        beforeEach(function() {
+          $submitButton.click();
+        });
+
+        it('The form error summary does not show error messages relating to ‘fromDate’ group when valid values entered', function() {
+          var $inlineDateErrors = $inlineDateGroupErrorList('fromDate').find('> li');
+          expect($inlineDateErrors.find($dateGroupError('from')).is(':visible')).toBe(true);
+          expect($inlineDateErrors.find($dateParseError('from')).is(':visible')).toBe(false);
+
+          expect($inlineDateErrors.find($dateGroupFieldError('from', 'day')).is(':visible')).toBe(true);
+          $dateGroupField('from', 'day').focus().val(2);
+
+          expect($inlineDateErrors.find($dateGroupFieldError('from', 'month')).is(':visible')).toBe(true);
+          $dateGroupField('from', 'month').focus().val('Aug');
+
+          expect($inlineDateErrors.find($dateGroupFieldError('from', 'year')).is(':visible')).toBe(true);
+          $dateGroupField('from', 'year').focus().val('2016');
+
+          $submitButton.focus();
+
+          expect($inlineDateErrors.find($dateGroupFieldError('from', 'day'))).toHaveText('');
+          expect($inlineDateErrors.find($dateGroupFieldError('from', 'month'))).toHaveText('');
+          expect($inlineDateErrors.find($dateGroupFieldError('from', 'year'))).toHaveText('');
+
+          expect($inlineDateErrors.find($dateGroupError('from'))).not.toBeVisible();
+          expect($inlineDateErrors.find($dateParseError('from'))).not.toBeVisible();
+
+          expect($summaryLinkById($dateGroupField('from', 'day'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('from', 'month'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('from', 'year'))).not.toBeInDOM();
+
+
+          expect($fromDateSummaryError).not.toBeInDOM();
+          expect($fromDateCustomSummaryError).not.toBeInDOM();
+        });
+
+        it('The form error summary does not show error messages relating to ‘toDate’ group when valid values entered', function() {
+          var $inlineDateErrors = $inlineDateGroupErrorList('toDate').find('> li');
+
+          expect($inlineDateErrors.find($dateGroupError('to')).is(':visible')).toBe(true);
+          expect($inlineDateErrors.find($dateParseError('to')).is(':visible')).toBe(false);
+
+          expect($inlineDateErrors.find($dateGroupFieldError('to', 'day')).is(':visible')).toBe(true);
+          $dateGroupField('to', 'day').focus().val(2);
+
+          expect($inlineDateErrors.find($dateGroupFieldError('to', 'month')).is(':visible')).toBe(true);
+          $dateGroupField('to', 'month').focus().val('8');
+
+          expect($inlineDateErrors.find($dateGroupFieldError('to', 'year')).is(':visible')).toBe(true);
+          $dateGroupField('to', 'year').focus().val('2017');
+
+          $submitButton.focus();
+
+          expect($inlineDateErrors.find($dateGroupFieldError('to', 'day'))).toHaveText('');
+          expect($inlineDateErrors.find($dateGroupFieldError('to', 'month'))).toHaveText('');
+          expect($inlineDateErrors.find($dateGroupFieldError('to', 'year'))).toHaveText('');
+
+          expect($inlineDateErrors.find($dateGroupError('to'))).not.toBeVisible();
+          expect($inlineDateErrors.find($dateParseError('to'))).not.toBeVisible();
+
+          expect($summaryLinkById($dateGroupField('to', 'day'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('to', 'month'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('to', 'year'))).not.toBeInDOM();
+
+          expect($toDateSummaryError).not.toBeInDOM();
+          expect($toDateCustomSummaryError).not.toBeInDOM();
+        });
+      });
+      
+      describe('And when I submit valid date field values', function() {
+        beforeEach(function() {
+          $dateGroupField('from', 'day').val('01');
+          $dateGroupField('from', 'month').val('Jul');
+          $dateGroupField('from', 'year').val('2016');
+          $dateGroupField('to', 'day').val('01');
+          $dateGroupField('to', 'month').val('7');
+          $dateGroupField('to', 'year').val('17');
+          $submitButton.click();
+        });
+
+        it('The form error summary should not display the ‘fromDate’ group general error message or any of the group’s field specific inline error messages', function() {
+          expect($fromDateSummaryError).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateGeneralErrorText('from'));
+          expect($toDateSummaryError).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateCustomErrorText('from'));
+
+          expect($summaryLinkById($dateGroupField('from', 'day'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('from', 'month'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('from', 'year'))).not.toBeInDOM();
+        });
+
+        it('The form error summary should not display the ‘toDate’ group general error message or any of the group’s field specific inline error messages', function() {
+          expect($toDateSummaryError).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateGeneralErrorText('to'));
+          expect($toDateCustomSummaryError).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateCustomErrorText('to'));
+
+          expect($summaryLinkById($dateGroupField('to', 'day'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('to', 'month'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('to', 'year'))).not.toBeInDOM();
+        });
+
+        it('The ‘fromDate’ inline errors should not display the group’s error message and the field specific inline error messages', function() {
+          var $inlineDateErrors = $inlineDateGroupErrorList('fromDate').find('> li');
+          expect($inlineDateErrors.find($dateGroupError('from')).is(':visible')).toBe(false);
+          expect($inlineDateErrors.find($dateParseError('from')).is(':visible')).toBe(false);
+          expect($inlineDateErrors.find($dateGroupFieldError('from', 'day')).is(':visible')).toBe(false);
+          expect($inlineDateErrors.find($dateGroupFieldError('from', 'month')).is(':visible')).toBe(false);
+          expect($inlineDateErrors.find($dateGroupFieldError('from', 'year')).is(':visible')).toBe(false);
+        });
+
+        it('The ‘toDate’ inline errors should display the group’s error message and the field specific inline error messages', function() {
+          var $inlineDateErrors = $inlineDateGroupErrorList('toDate').find('> li');
+          expect($inlineDateErrors.find($dateGroupError('to')).is(':visible')).toBe(false);
+          expect($inlineDateErrors.find($dateParseError('to')).is(':visible')).toBe(false);
+          expect($inlineDateErrors.find($dateGroupFieldError('to', 'day')).is(':visible')).toBe(false);
+          expect($inlineDateErrors.find($dateGroupFieldError('to', 'month')).is(':visible')).toBe(false);
+          expect($inlineDateErrors.find($dateGroupFieldError('to', 'year')).is(':visible')).toBe(false);
+        });
+      });
+
+      describe('And when I submit a pattern invalid abbreviation string in the ‘fromDate’ group month field value', function () {
+
+        beforeEach(function() {
+          $dateGroupField('from', 'day').val('31');
+          $dateGroupField('from', 'month').val('xXx');
+          $dateGroupField('from', 'year').val('2016');
+          $dateGroupField('to', 'day').val('01');
+          $dateGroupField('to', 'month').val('7');
+          $dateGroupField('to', 'year').val('17');
+          $submitButton.click();
+        });
+
+        it('The ‘fromDate’ group month field should have the input type ‘text’', function() {
+          expect($dateGroupField('from', 'month').is('[type="text"]')).toBe(true);
+        });
+
+        it('The form error summary should display the ‘fromDate’ group general error message and not the group’s field specific inline error messages', function() {
+          expect($fromDateSummaryError).toBeInDOM();
+          expect($errorMessageItems.text()).toContain(dateGeneralErrorText('from'));
+          expect($fromDateCustomSummaryError).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateCustomErrorText('from'));
+
+          expect($summaryLinkById($dateGroupField('from', 'day'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('from', 'month'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('from', 'year'))).not.toBeInDOM();
+        });
+
+        it('The form should display the ‘fromDate’ inline group error message and the ‘fromDate’ month field inline error message', function() {
+          var fieldError = 'The ‘from date’ month you have entered is invalid. Enter the first 3 letters of the month or write the month as a number between 1 and 12.';
+          var $inlineDateErrors = $inlineDateGroupErrorList('fromDate').find('> li');
+
+          expect($inlineDateErrors.text()).toContain(dateGeneralErrorText('from'));
+          expect($inlineDateErrors.text()).toContain(fieldError);
+
+          expect($dateGroupField('from', 'month').closest('.form-field-group--error').is(':visible')).toBe(true);
+          expect($dateGroupFieldError('from', 'month').is(':visible')).toBe(true);
+        });
+      });
+
+      describe('And when I submit a range invalid number in the ‘toDate’ group month field value', function() {
+
+        beforeEach(function () {
+          $dateGroupField('from', 'day').val('31');
+          $dateGroupField('from', 'month').val('Jul');
+          $dateGroupField('from', 'year').val('2016');
+          $dateGroupField('to', 'day').val('01');
+          $dateGroupField('to', 'month').val('13');
+          $dateGroupField('to', 'year').val('17');
+          $submitButton.click();
+        });
+
+        it('The ‘toDate’ group month field should have the input type ‘number’', function() {
+          expect($dateGroupField('to', 'month').is('[type="number"]')).toBe(true);
+        });
+
+        it('The form error summary should display the ‘toDate’ group general error message and not the group’s field specific inline error messages', function() {
+          expect($toDateSummaryError).toBeInDOM();
+          expect($errorMessageItems.text()).toContain(dateGeneralErrorText('to'));
+          expect($toDateCustomSummaryError).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateCustomErrorText('to'));
+
+
+          expect($summaryLinkById($dateGroupField('to', 'day'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('to', 'month'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('to', 'year'))).not.toBeInDOM();
+        });
+
+        it('The form should display the ‘toDate’ inline group error message and the ‘toDate’ month field inline error message', function () {
+          var fieldError = 'The ‘to date’ month entered is not valid. Enter a number between 1 and 12';
+          var $inlineDateErrors = $inlineDateGroupErrorList('toDate').find('> li');
+
+          expect($inlineDateErrors.text()).toContain(dateGeneralErrorText('to'));
+          expect($inlineDateErrors.text()).toContain(fieldError);
+
+          expect($dateGroupField('to', 'month').closest('.form-field-group--error').is(':visible')).toBe(true);
+          expect($dateGroupFieldError('to', 'month').is(':visible')).toBe(true);
+        });
+      });
+
+      describe('And when I submit a pattern invalid in the ‘fromDate’ group year field value', function() {
+        beforeEach(function() {
+          $dateGroupField('from', 'day').val('31');
+          $dateGroupField('from', 'month').val('Jul');
+          $dateGroupField('from', 'year').val('20166');
+          $dateGroupField('to', 'day').val('01');
+          $dateGroupField('to', 'month').val('7');
+          $dateGroupField('to', 'year').val('17');
+          $submitButton.click();
+        });
+
+        it('The year field should have the input type ‘number’', function() {
+          expect($dateGroupField('from', 'year').is('[type="number"]')).toBe(true);
+        });
+
+        it('The form error summary should display the ‘fromDate’ group general error message and not the group’s field specific inline error messages', function() {
+          expect($fromDateSummaryError).toBeInDOM();
+          expect($errorMessageItems.text()).toContain(dateGeneralErrorText('from'));
+          expect($fromDateCustomSummaryError).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateCustomErrorText('from'));
+
+
+          expect($summaryLinkById($dateGroupField('to', 'day'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('to', 'month'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('to', 'year'))).not.toBeInDOM();
+        });
+
+        it('The form should display the ‘fromDate’ inline group error message and the ‘fromDate’ month field inline error message', function () {
+          var fieldError = 'The ‘from date’ year entered is not valid. Enter the year as a 4 digit number.';
+          var $inlineDateErrors = $inlineDateGroupErrorList('fromDate').find('> li');
+
+          expect($inlineDateErrors.text()).toContain(dateGeneralErrorText('from'));
+          expect($inlineDateErrors.text()).toContain(fieldError);
+
+          expect($dateGroupField('from', 'month').closest('.form-field-group--error').is(':visible')).toBe(true);
+          expect($dateGroupFieldError('from', 'month').is(':visible')).toBe(true);
+        });
+      });
+
+      describe('And when I submit an invalid minimum value in the ‘fromDate’ group year field', function() {
+        beforeEach(function() {
+          $dateGroupField('from', 'day').val('31');
+          $dateGroupField('from', 'month').val('12');
+          $dateGroupField('from', 'year').val('2015');
+          $dateGroupField('to', 'day').val('01');
+          $dateGroupField('to', 'month').val('7');
+          $dateGroupField('to', 'year').val('17');
+          $submitButton.click();
+        });
+
+        it('The form error summary should display the ‘fromDate’ group general error and custom ‘dategroupvalid’ message and not the group’s field specific inline error messages', function() {
+          expect($fromDateSummaryError).toBeInDOM();
+          expect($errorMessageItems.text()).toContain(dateGeneralErrorText('from'));
+          expect($fromDateCustomSummaryError).toBeInDOM();
+          expect($errorMessageItems.text()).toContain(dateCustomErrorText('from'));
+
+          expect($summaryLinkById($dateGroupField('to', 'day'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('to', 'month'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('to', 'year'))).not.toBeInDOM();
+        });
+
+        it('The form should display the ‘fromDate’ inline group error and custom ‘dategroupvalid’ messages', function () {
+          var $inlineDateErrors = $inlineDateGroupErrorList('fromDate').find('> li');
+
+          expect($inlineDateErrors.text()).toContain(dateGeneralErrorText('from'));
+          expect($inlineDateErrors.text()).toContain(dateCustomErrorText('from'));
+
+          expect($dateGroupField('from', 'day').closest('.form-field-group--error').is(':visible')).toBe(true);
+          expect($dateGroupError('from').is(':visible')).toBe(true);
+          expect($dateParseError('from').is(':visible')).toBe(true);        
+        });
+      });
+     
+      describe('And when I submit an invalid two-digit value in the ‘toDate’ group year field', function() {
+
+        beforeEach(function() {
+          $dateGroupField('from', 'day').val('31');
+          $dateGroupField('from', 'month').val('Jul');
+          $dateGroupField('from', 'year').val('2016');
+          $dateGroupField('to', 'day').val('01');
+          $dateGroupField('to', 'month').val('7');
+          $dateGroupField('to', 'year').val('18');
+          $submitButton.click();
+        });
+
+        it('The year field should have the input type ‘number’', function() {
+          expect($dateGroupField('to', 'year').is('[type="number"]')).toBe(true);
+        });
+
+        it('The form error summary should display the ‘toDate’ group general error and custom ‘dategroupvalid’ message and not the group’s field specific inline error messages', function() {
+          expect($toDateSummaryError).toBeInDOM();
+          expect($errorMessageItems.text()).toContain(dateGeneralErrorText('to'));
+          expect($toDateCustomSummaryError).toBeInDOM();
+          expect($errorMessageItems.text()).toContain(dateCustomErrorText('to'));
+
+          expect($summaryLinkById($dateGroupField('to', 'day'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('to', 'month'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('to', 'year'))).not.toBeInDOM();
+        });
+
+        it('The form should display the ‘toDate’ inline group error and custom ‘dategroupvalid’ messages', function () {
+          var $inlineDateErrors = $inlineDateGroupErrorList('toDate').find('> li');
+
+          expect($inlineDateErrors.text()).toContain(dateGeneralErrorText('to'));
+          expect($inlineDateErrors.text()).toContain(dateCustomErrorText('to'));
+
+          expect($dateGroupField('to', 'day').closest('.form-field-group--error').is(':visible')).toBe(true);
+          expect($dateGroupError('to').is(':visible')).toBe(true);
+          expect($dateParseError('to').is(':visible')).toBe(true);
+        });
+      });
+     
+      describe('And when I submit an invalid day for the month in the ‘fromDate’ fields', function() {
+        beforeEach(function() {
+          $dateGroupField('from', 'day').val('31');
+          $dateGroupField('from', 'month').val('Nov');
+          $dateGroupField('from', 'year').val('2016');
+          $dateGroupField('to', 'day').val('01');
+          $dateGroupField('to', 'month').val('7');
+          $dateGroupField('to', 'year').val('17');
+          $submitButton.click();
+        });
+
+        it('The form error summary should display the ‘fromDate’ group general error and custom ‘dategroupvalid’ message and not the group’s field specific inline error messages', function() {
+          expect($fromDateSummaryError).toBeInDOM();
+          expect($errorMessageItems.text()).toContain(dateGeneralErrorText('from'));
+          expect($fromDateCustomSummaryError).toBeInDOM();
+          expect($errorMessageItems.text()).toContain(dateCustomErrorText('from'));
+
+          expect($summaryLinkById($dateGroupField('from', 'day'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('from', 'month'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('from', 'year'))).not.toBeInDOM();
+        });
+
+        it('The form should display the ‘fromDate’ inline group error and custom ‘dategroupvalid’ messages', function () {
+          var $inlineDateErrors = $inlineDateGroupErrorList('fromDate').find('> li');
+
+          expect($inlineDateErrors.text()).toContain(dateGeneralErrorText('from'));
+          expect($inlineDateErrors.text()).toContain(dateCustomErrorText('from'));
+
+          expect($dateGroupField('from', 'day').closest('.form-field-group--error').is(':visible')).toBe(true);
+          expect($dateGroupError('from').is(':visible')).toBe(true);
+          expect($dateParseError('from').is(':visible')).toBe(true);
+        });
+      });
+
+      describe('And when I submit an invalid leap year date  in the ‘toDate’ fields', function() {
+        beforeEach(function() {
+          $dateGroupField('to', 'day').val('29');
+          $dateGroupField('to', 'month').val('Feb');
+          $dateGroupField('to', 'year').val('2016');
+          $dateGroupField('to', 'day').val('29');
+          $dateGroupField('to', 'month').val('2');
+          $dateGroupField('to', 'year').val('17');
+          $submitButton.click();
+        });
+
+        it('The form error summary should display the ‘toDate’ group general error and custom ‘dategroupvalid’ message and not the group’s field specific inline error messages', function() {
+          expect($toDateSummaryError).toBeInDOM();
+          expect($errorMessageItems.text()).toContain(dateGeneralErrorText('to'));
+          expect($toDateCustomSummaryError).toBeInDOM();
+          expect($errorMessageItems.text()).toContain(dateCustomErrorText('to'));
+
+          expect($summaryLinkById($dateGroupField('to', 'day'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('to', 'month'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('to', 'year'))).not.toBeInDOM();
+        });
+
+        it('The form should display the ‘toDate’ inline group error and custom ‘dategroupvalid’ messages', function () {
+          var $inlineDateErrors = $inlineDateGroupErrorList('toDate').find('> li');
+
+          expect($inlineDateErrors.text()).toContain(dateGeneralErrorText('to'));
+          expect($inlineDateErrors.text()).toContain(dateCustomErrorText('to'));
+
+          expect($dateGroupField('to', 'day').closest('.form-field-group--error').is(':visible')).toBe(true);
+          expect($dateGroupError('to').is(':visible')).toBe(true);
+          expect($dateParseError('to').is(':visible')).toBe(true);
+        });
+      });
+
+      describe('And when I submit an valid leap year date  in the ‘fromDate’ fields', function() {
+
+        beforeEach(function() {
+          $dateGroupField('from', 'day').val('29');
+          $dateGroupField('from', 'month').val('Feb');
+          $dateGroupField('from', 'year').val('2016');
+          $dateGroupField('to', 'day').val('01');
+          $dateGroupField('to', 'month').val('7');
+          $dateGroupField('to', 'year').val('17');
+          $submitButton.click();
+        });
+
+        it('The form error summary should display the ‘fromDate’ group general error and custom ‘dategroupvalid’ message and not the group’s field specific inline error messages', function() {
+          expect($fromDateSummaryError).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateGeneralErrorText('from'));
+          expect($fromDateCustomSummaryError).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateCustomErrorText('from'));
+
+          expect($summaryLinkById($dateGroupField('from', 'day'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('from', 'month'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('from', 'year'))).not.toBeInDOM();
+        });
+
+        it('The form should display the ‘fromDate’ inline group error and custom ‘dategroupvalid’ messages', function () {
+          expect($dateGroupField('from', 'day').closest('.form-field-group--error').is(':visible')).not.toBe(true);
+          expect($dateGroupError('from').is(':visible')).not.toBe(true);
+          expect($dateParseError('from').is(':visible')).not.toBe(true);
+        });
+      });
+    });
+
+    describe('When I use date elements without min and max ‘dateGroupValid’ parameters', function() {
+      describe('And I submit empty date field values', function() {
+        beforeEach(function() {
+          $submitButton.click();
+        });
+
+        it('The form error summary should display the ‘noMinMaxDate’ group general error message and not the group’s field specific inline error messages', function() {
+          expect($noMinMaxDateSummaryError).toBeInDOM();
+          expect($errorMessageItems.text()).toContain(dateGeneralErrorText('no min/max'));
+          expect($noMinMaxDateCustomSummaryError).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateCustomErrorText('no min/max'));
+
+          expect($summaryLinkById($dateGroupField('noMinMax', 'day'))).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateDayRequiredText('noMinMax'));
+          expect($summaryLinkById($dateGroupField('noMinMax', 'month'))).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateMonthRequiredText('noMinMax'));
+          expect($summaryLinkById($dateGroupField('noMinMax', 'year'))).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateYearRequiredText('noMinMax'));
+        });
+        
+        it('The ‘noMinMaxDate’ inline errors should display the group’s error message and the field specific inline error messages', function() {
+          var $inlineDateErrors = $inlineDateGroupErrorList('noMinMaxDate').find('> li');
+          expect($inlineDateErrors.find($dateGroupError('noMinMax')).is(':visible')).toBe(true);
+          expect($inlineDateErrors.find($dateParseError('noMinMax')).is(':visible')).toBe(false);
+          expect($inlineDateErrors.find($dateGroupFieldError('noMinMax', 'day')).is(':visible')).toBe(true);
+          expect($inlineDateErrors.find($dateGroupFieldError('noMinMax', 'month')).is(':visible')).toBe(true);
+          expect($inlineDateErrors.find($dateGroupFieldError('noMinMax', 'year')).is(':visible')).toBe(true);
+        });
+      });
+
+      describe('And I update submitted empty date field values without re-submitting', function() {
+        beforeEach(function() {
+          $submitButton.click();
+        });
+        
+        it('The form error summary does not show error messages relating to ‘noMinMaxDate’ group when valid values entered', function() {
+          var $inlineDateErrors = $inlineDateGroupErrorList('noMinMaxDate').find('> li');
+          expect($inlineDateErrors.find($dateGroupError('noMinMax')).is(':visible')).toBe(true);
+          expect($inlineDateErrors.find($dateParseError('noMinMax')).is(':visible')).toBe(false);
+          
+          expect($inlineDateErrors.find($dateGroupFieldError('noMinMax', 'day')).is(':visible')).toBe(true);
+          $dateGroupField('noMinMax', 'day').focus().val(2);
+          
+          expect($inlineDateErrors.find($dateGroupFieldError('noMinMax', 'month')).is(':visible')).toBe(true);
+          $dateGroupField('noMinMax', 'month').focus().val('07');
+          
+          expect($inlineDateErrors.find($dateGroupFieldError('noMinMax', 'year')).is(':visible')).toBe(true);
+          $dateGroupField('noMinMax', 'year').focus().val('2016');
+          
+          $submitButton.focus();
+          
+          expect($inlineDateErrors.find($dateGroupFieldError('noMinMax', 'day'))).toHaveText('');
+          expect($inlineDateErrors.find($dateGroupFieldError('noMinMax', 'month'))).toHaveText('');
+          expect($inlineDateErrors.find($dateGroupFieldError('noMinMax', 'year'))).toHaveText('');
+          
+          expect($inlineDateErrors.find($dateGroupError('noMinMax'))).not.toBeVisible();
+          expect($inlineDateErrors.find($dateParseError('noMinMax'))).not.toBeVisible();
+          
+          expect($summaryLinkById($dateGroupField('noMinMax', 'day'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('noMinMax', 'month'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('noMinMax', 'year'))).not.toBeInDOM();
+          
+          
+          expect($noMinMaxDateSummaryError).not.toBeInDOM();
+          expect($noMinMaxDateCustomSummaryError).not.toBeInDOM();
+        });
+      });
+
+      describe('And when I submit valid date field values', function() {
+        beforeEach(function(){
+          $dateGroupField('noMinMax', 'day').val('01');
+          $dateGroupField('noMinMax', 'month').val('7');
+          $dateGroupField('noMinMax', 'year').val('2016');
+
+          $submitButton.click();
+        });
+
+        it('The form error summary should not display the ‘noMinMaxDate’ group general error message or any of the group’s field specific inline error messages', function() {
+          expect($noMinMaxDateSummaryError).not.toBeInDOM();
+          expect($errorMessageItems.text()).not.toContain(dateGeneralErrorText('no ‘min/max’'));
+          expect($errorMessageItems.text()).not.toContain(dateCustomErrorText('no ‘min/max’'));
+
+          expect($summaryLinkById($dateGroupField('noMinMax', 'day'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('noMinMax', 'month'))).not.toBeInDOM();
+          expect($summaryLinkById($dateGroupField('noMinMax', 'year'))).not.toBeInDOM();
+        });
+
+
+        it('The ‘noMinMaxDate’ inline errors should not display the group’s error message and the field specific inline error messages', function() {
+          var $inlineDateErrors = $inlineDateGroupErrorList('noMinMaxDate').find('> li');
+          expect($inlineDateErrors.find($dateGroupError('noMinMax')).is(':visible')).toBe(false);
+          expect($inlineDateErrors.find($dateParseError('noMinMax')).is(':visible')).toBe(false);
+          expect($inlineDateErrors.find($dateGroupFieldError('noMinMax', 'day')).is(':visible')).toBe(false);
+          expect($inlineDateErrors.find($dateGroupFieldError('noMinMax', 'month')).is(':visible')).toBe(false);
+          expect($inlineDateErrors.find($dateGroupFieldError('noMinMax', 'year')).is(':visible')).toBe(false);
+        });
+
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Problem

Error handling for grouped inline fields, such as a date group with day:month:year elements, needs to be enable field specific and group level validation messages.
# Issue

Form validation does not support the presentation of group and field specific validation messages on grouped inline field elements. 

At present the validation message specific to the last field:
- is the only message displayed inline when validation occurs;
- is the group error message displayed in the error summary;
## Issue Example
### Current inline date field validation & errors - date of birth

![dates - current inline date field validation & errors - date of birth](https://cloud.githubusercontent.com/assets/5468091/19444247/98d4d072-9487-11e6-8f2b-8c945de3dc56.gif)
# Solution

Add validation for handling grouped inline field elements to display group and field error's inline and group error only in error-summary list. The changes have been UX approved.
- adds 'formInlineGroup' for handling grouped inline form elements (i.e. dates: dob.day dob.month dob.year):
  - merges generic form validation logic and overrides the validation callbacks where grouped elements present;
  - adds groups setting for validator;
  - display error messages inline with group error;
  - display only group error in error summary block;
- adds 'dateGroupValid', specific for _date_ groups, handling inline fields to check valid date is created from day / month / year values entered by user
  - called once rule(s) pass for the grouped field element is the validation context;
  - runs rules for non-context fields in the group to ensure passed;
  - ensures date is a parse-able calendar date (i.e. 30 Feb 2016 or 31 11 2016 is not accepted) 
    - converts 3 character month abbreviations to numeric value
    - converts 2 digit year to 4 digit with logical assumed century
## Solution Examples:
### Inline date field validation & errors - date of birth

![dates - date of birth solution example](https://cloud.githubusercontent.com/assets/5468091/19442516/75d6329c-9481-11e6-9c29-cd35f56bcca4.gif)
