### PR TITLE
Changed important-icon css to 35 pixels

### DIFF
--- a/assets/govuk_elements/public/sass/elements/_icons.scss
+++ b/assets/govuk_elements/public/sass/elements/_icons.scss
@@ -31,8 +31,8 @@
     background-image: url("../images/icons/icon-important-2x.png");
     background-size: 100%;
   }
-  width: 34px;
-  height: 34px;
+  width: 35px;
+  height: 35px;
 }
 
 .icon-information {


### PR DESCRIPTION
Currently the css sets the size of the icon to 34x34 pixels which crops off the edges of the icon when used in a frontend application. This PR changes the css to match the size of the image.