### PR TITLE
Collapse tables to heading-detail columns in mobile

### DIFF
--- a/assets/scss/base/_table.scss
+++ b/assets/scss/base/_table.scss
@@ -281,7 +281,8 @@ Styleguide Table.Marker
 /*
 Responsive
 
-Responsive Table
+Responsive Table: shrink the browser to see how rows and columns behave
+with examples of different lengths of content in headings and details
 
 Markup:
 <table>
@@ -309,32 +310,32 @@ Markup:
       </td>
     </tr>
     <tr class="table__row--responsive">
-      <td class="table__detail--responsive" data-heading="Really quite a long heading for column 1">
+      <td class="table__detail--responsive" data-heading="Heading 1 - Example heading that exceeds cell width">
         <p class="table__cell-content--responsive">Row 3 Detail 1</p>
       </td>
-      <td class="table__detail--responsive" data-heading="Really quite a long heading for column 2">
+      <td class="table__detail--responsive" data-heading="Heading 2 - Example heading that exceeds cell width">
         <p class="table__cell-content--responsive">Row 3 Detail 2</p>
       </td>
     </tr>
     <tr class="table__row--responsive">
       <td class="table__detail--responsive" data-heading="Heading 1">
-        <p class="table__cell-content--responsive">Row 4 Detail 1 - has really quite a lot of content to include.</p>
+        <p class="table__cell-content--responsive">Row 4 Detail 1 - example content that exceeds cell width to create multiple lines</p>
       </td>
       <td class="table__detail--responsive" data-heading="Heading 2">
-        <p class="table__cell-content--responsive">Row 4 Detail 2 - has really quite a lot of content to include also.</p>
+        <p class="table__cell-content--responsive">Row 4 Detail 2 - example content that exceeds cell width to create multiple lines</p>
       </td>
     </tr>
     <tr class="table__row--responsive">
       <td class="table__detail--responsive" data-heading="Heading 1">
         <div class="table__cell-content--responsive">
-          <p>Row 5 Detail 1 - paragraph One</p>
+          <p>Row 5 Detail 1 - example content with multiple paragraphs</p>
           <p>Row 5 Detail 1 - paragraph Two</p>
           <p>Row 5 Detail 1 - paragraph Three</p>
         </div>
       </td>
       <td class="table__detail--responsive" data-heading="Heading 2">
         <div class="table__cell-content--responsive">
-          <p>Row 5 Detail 2 - paragraph One</p>
+          <p>Row 5 Detail 2 - example content with multiple paragraphs</p>
           <p>Row 5 Detail 2 - paragraph Two</p>
           <p>Row 5 Detail 2 - paragraph Three</p>
         </div>
@@ -347,13 +348,13 @@ Markup:
 Styleguide Table.Responsive
 */
 
-@media (max-width: 639px) {
+@include media(mobile) {
   .table__row--desktop-headings {
     display: none;
   }
 
   .table__row--responsive {
-    margin-bottom: 10px;
+    margin-bottom: em(8);
     display: block;
   }
 
@@ -386,12 +387,13 @@ Styleguide Table.Responsive
   }
 
   .table__detail--responsive:last-of-type {
+    padding-bottom: em(16);
     border-bottom: 1px solid $border-colour;
   }
 
   .table__cell-content--responsive {
     display: block;
     margin-left: 30%;
-    padding-left: 8px;
+    padding-left: em(12);
   }
 }

--- a/assets/scss/base/_table.scss
+++ b/assets/scss/base/_table.scss
@@ -277,3 +277,77 @@ Styleguide Table.Marker
   height: 10px;
   border-radius: 50%;
 }
+
+/*
+Responsive
+
+Responsive Table
+
+Markup:
+<table>
+  <thead>
+    <tr class="table__row--desktop-headings">
+      <th>Heading 1</th>
+      <th>Heading 2</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr class="table__row--responsive">
+      <td class="table__detail--responsive" data-heading="Heading 1">Row 1 Detail 1</td>
+      <td class="table__detail--responsive" data-heading="Heading 2">Row 1 Detail 2</td>
+    </tr>
+    <tr class="table__row--responsive">
+      <td class="table__detail--responsive" data-heading="Heading 1">Row 2 Detail 1</td>
+      <td class="table__detail--responsive" data-heading="Heading 2">Row 2 Detail 2</td>
+    </tr>
+  </tbody>
+</table>
+
+
+Styleguide Table.Responsive
+*/
+
+@media (max-width: 639px) {
+  .table__row--desktop-headings {
+    display: none;
+  }
+
+  .table__row--responsive {
+    margin-bottom: 10px;
+    display: block;
+  }
+
+  .table__row--responsive:after {
+    content: "";
+    display: table;
+    clear: both;
+  }
+
+  .table__row--responsive:before {
+    display: block;
+    border-bottom: 2px solid $border-colour;
+  }
+
+  .table__detail--responsive {
+    box-sizing: border-box;
+    display: block;
+    float: left;
+    clear: left;
+    width: 100%;
+    border: none;
+  }
+
+  .table__detail--responsive:before {
+    content: attr(data-heading);
+    font-weight: normal;
+    color: $grey-1;
+    float: left;
+    width: 35%;
+    padding-right: 10px;
+    white-space: nowrap;
+  }
+
+  .table__detail--responsive:last-of-type {
+    border-bottom: 1px solid $border-colour;
+  }
+}

--- a/assets/scss/base/_table.scss
+++ b/assets/scss/base/_table.scss
@@ -293,12 +293,52 @@ Markup:
   </thead>
   <tbody>
     <tr class="table__row--responsive">
-      <td class="table__detail--responsive" data-heading="Heading 1">Row 1 Detail 1</td>
-      <td class="table__detail--responsive" data-heading="Heading 2">Row 1 Detail 2</td>
+      <td class="table__detail--responsive" data-heading="Heading 1">
+        <p class="table__cell-content--responsive">Row 1 Detail 1<p>
+      </td>
+      <td class="table__detail--responsive" data-heading="Heading 2">
+        <p class="table__cell-content--responsive">Row 1 Detail 2</p>
+      </td>
     </tr>
     <tr class="table__row--responsive">
-      <td class="table__detail--responsive" data-heading="Heading 1">Row 2 Detail 1</td>
-      <td class="table__detail--responsive" data-heading="Heading 2">Row 2 Detail 2</td>
+      <td class="table__detail--responsive" data-heading="Heading 1">
+        <p class="table__cell-content--responsive">Row 2 Detail 1</p>
+      </td>
+      <td class="table__detail--responsive" data-heading="Heading 2">
+        <p class="table__cell-content--responsive">Row 2 Detail 2</p>
+      </td>
+    </tr>
+    <tr class="table__row--responsive">
+      <td class="table__detail--responsive" data-heading="Really quite a long heading for column 1">
+        <p class="table__cell-content--responsive">Row 3 Detail 1</p>
+      </td>
+      <td class="table__detail--responsive" data-heading="Really quite a long heading for column 2">
+        <p class="table__cell-content--responsive">Row 3 Detail 2</p>
+      </td>
+    </tr>
+    <tr class="table__row--responsive">
+      <td class="table__detail--responsive" data-heading="Heading 1">
+        <p class="table__cell-content--responsive">Row 4 Detail 1 - has really quite a lot of content to include.</p>
+      </td>
+      <td class="table__detail--responsive" data-heading="Heading 2">
+        <p class="table__cell-content--responsive">Row 4 Detail 2 - has really quite a lot of content to include also.</p>
+      </td>
+    </tr>
+    <tr class="table__row--responsive">
+      <td class="table__detail--responsive" data-heading="Heading 1">
+        <div class="table__cell-content--responsive">
+          <p>Row 5 Detail 1 - paragraph One</p>
+          <p>Row 5 Detail 1 - paragraph Two</p>
+          <p>Row 5 Detail 1 - paragraph Three</p>
+        </div>
+      </td>
+      <td class="table__detail--responsive" data-heading="Heading 2">
+        <div class="table__cell-content--responsive">
+          <p>Row 5 Detail 2 - paragraph One</p>
+          <p>Row 5 Detail 2 - paragraph Two</p>
+          <p>Row 5 Detail 2 - paragraph Three</p>
+        </div>
+      </td>
     </tr>
   </tbody>
 </table>
@@ -342,12 +382,16 @@ Styleguide Table.Responsive
     font-weight: normal;
     color: $grey-1;
     float: left;
-    width: 35%;
-    padding-right: 10px;
-    white-space: nowrap;
+    width: 30%;
   }
 
   .table__detail--responsive:last-of-type {
     border-bottom: 1px solid $border-colour;
+  }
+
+  .table__cell-content--responsive {
+    display: block;
+    margin-left: 30%;
+    padding-left: 8px;
   }
 }


### PR DESCRIPTION
- make tables more responsive as per Developer API page requirements

Designs for the Developer API pages require tables to collapse to heading-detail columns on mobile as per the pictures below.

These changes should leave IE8 and below unaffected, displaying tables as per current functionality as it requires support for media queries.

IE9 and above, and modern browsers should all work as per the pictures attached.

(Aware that the tables are responsive to an extent already - not sure of a better naming convention for these classes.)

### Standard Table on Mobile
<img width="651" alt="screen shot 2016-11-07 at 08 19 20" src="https://cloud.githubusercontent.com/assets/8742105/20050791/15d61874-a4c3-11e6-82ee-eb433a20153f.png">

### New Classes on Mobile
<img width="645" alt="screen shot 2016-11-07 at 08 19 55" src="https://cloud.githubusercontent.com/assets/8742105/20050793/1db57fb2-a4c3-11e6-9a12-1dbd3a2e2431.png">
