### PR TITLE
OPS-420 : email address - ‘hmrcsupport@tax.service.gov.uk.’ not to be used.

### DIFF
--- a/assets/javascripts/modules/reportAProblem.js
+++ b/assets/javascripts/modules/reportAProblem.js
@@ -5,10 +5,7 @@ module.exports = function() {
       var feedbackForms = require('./feedbackForms.js');
   
       var showErrorMessage = function() {
-        var response = '<p>There was a problem sending your query.</p>' +
-          '<p>Please try again later or email ' +
-          '<a href="mailto:hmrcsupport@tax.service.gov.uk">hmrcsupport@tax.service.gov.uk</a> ' +
-          'if you need technical help with this website.</p>';
+        var response = '<p>There was a problem sending your query.</p><p>Please try again later.</p>';
         reportErrorContainer().html(response);
         enableSubmitButton();
       },


### PR DESCRIPTION
**Issue:**
Users are prompted to email an unsupported account when a deskpro message fails to submit.

**Action:**
Shorten message to "Please try again later".  Affects payments-frontend, ei-frontend and assets-frontend.

**Ownership:**
Decided by BTA after consulting Digital Contact.