### PR TITLE
update deprecated className in Js example

### DIFF
--- a/assets/javascripts/modules/toggle.js
+++ b/assets/javascripts/modules/toggle.js
@@ -6,7 +6,7 @@ Attach event to parent as delegate, open close dependant on triggers id.
 
 Toggle markup example:
 
-<fieldset class="form-field-group visible-javascript-on js-aria-show js-toggle"
+<fieldset class="form-field-group js-visible js-aria-show js-toggle"
           id="uk-number"
           data-target="uk-phone-number-toggle-target"
           data-trigger="js-toggle-trigger"
@@ -40,7 +40,7 @@ Target markup example:
 
 Toggle markup example:
 
-<fieldset class="form-field-group visible-javascript-on js-aria-show js-toggle"
+<fieldset class="form-field-group js-visible js-aria-show js-toggle"
           id="us-number"
           data-trigger="js-toggle-trigger">
     <label class="block-label" for="us-phone-number-toggle-open">Yes


### PR DESCRIPTION
`visible-javascript-on` has been replaced with `js-visible`