### PR TITLE
added smooth scroll module

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -46,7 +46,8 @@ var sso = require('./modules/sso.js'),
     addRemove = require('./modules/addRemove.js'),
     modalDialog = require('./modules/modalDialog.js'),
     dynamicGaTags = require('./modules/dynamicGaTags.js'),
-    listCollapse = require('./modules/listCollapse.js');
+    listCollapse = require('./modules/listCollapse.js'),
+    smoothScroll = require('./modules/smoothScroll.js');
 
 //initialise mdtpf
 fingerprint();
@@ -173,5 +174,6 @@ $(function() {
   modalDialog();
   dynamicGaTags();
   listCollapse();
+  smoothScroll();
 
 });

--- a/assets/javascripts/modules/smoothScroll.js
+++ b/assets/javascripts/modules/smoothScroll.js
@@ -1,0 +1,27 @@
+require('jquery');
+
+/**
+ * Smooth Scroll
+ * Smooth scroll makes the page automatically scroll to page content 
+ * when anchor links are clicked rather than a jerky jump to the content.
+ * 
+ * With javascript disabled the page will simply jump to the content,
+ * but javascript users will get the smoother experience.
+ * 
+ * Example:
+ * <a data-smooth-scroll href="#heading></a>
+ */
+
+module.exports = function () {
+    $('[data-smooth-scroll]').on('click', function() {
+        var $el = $(this.hash);
+        var top = $el.offset().top;
+        var offset = $el.data('data-smooth-scroll-offset');
+        
+        if ($el.length) {
+            $('html, body').animate({
+                scrollTop: (offset) ? top - parseInt(offset) : top
+            }, 500);
+        }
+    });
+};

--- a/assets/scss/components/_smooth-scroll.scss
+++ b/assets/scss/components/_smooth-scroll.scss
@@ -1,0 +1,31 @@
+/*
+Smooth Scroll
+
+<<<<<<< ours
+Scrolls the page smoothly between anchor links and page content rather than jumping stright to the content.
+
+=======
+Scrolls the page smoothly between anchor links and page content rather then jumping stright to the content.
+>>>>>>> theirs
+
+Mandatory JS hooks:
+ * `data-smooth-scroll` - adds smooth scrolling functionality to the link.
+
+Optional JS hooks:
+ * `data-smooth-scroll-offset` - adds some white space above/below the target at the final scroll position.
+ 
+<hr/>
+The JavacScript for Smooth Scroll can be found here: [smoothScroll.js](https://github.com/hmrc/assets-frontend/blob/master/assets/javascripts/modules/smoothScroll.js)
+
+
+Markup:
+<a data-smooth-scroll data-smooth-scroll-offset='20' href="#heading">Scroll to the header</a>
+
+<h2 id='heading'>Scroll to me</h2>
+
+Styleguide Smooth Scroll
+<<<<<<< ours
+*/
+=======
+*/
+>>>>>>> theirs


### PR DESCRIPTION
Our on-page navigation uses smooth scrolling rather then the standard anchor/id jump to content.

We use it in our page nav (two columns under a header on guide pages) and the sticky/left hand menu. (api docs pages)

The smooth scrolling though might be useful for others, so added to this PR.

with JS disabled you get standard functionality.


n.b. no tests added, because the actually functionality would work if the JS was there or not, so a test couldn't confirm if the default browser OR this js had caused the position change
(unless you mock/spy in the jquery methods but then your just testing jquery)