### PR TITLE
Leave default cursor on disabled headings

### DIFF
--- a/assets/scss/components/_datatables.scss
+++ b/assets/scss/components/_datatables.scss
@@ -157,6 +157,10 @@ Styleguide dataTable
   label, th {
     cursor: pointer;
   }
+
+  .sorting_disabled {
+    cursor: default;
+  }
 }
 
 .dataTable tbody {


### PR DESCRIPTION
In Datatables, all headings are given a pointer cursor, even those not sortable. Where the javascript adds the class `.sorting_disabled`

Exclude these from the cursor styling as another visual queue that the heading is not clickable.