### PR TITLE
Remove hard-coded positions

### DIFF
--- a/assets/scss/components/_datatables.scss
+++ b/assets/scss/components/_datatables.scss
@@ -142,19 +142,6 @@ Styleguide dataTable
     background: url("../images/sort_desc_disabled.png") no-repeat scroll center right;
   }
 
-  th:first-child {
-    background-position-x: 57px;
-  }
-
-  th:nth-child(3) {
-    background-position-x: 120px;
-  }
-
-  th:nth-child(4) {
-    background-position-x: 87px;
-  }
-
-  label, th {
     cursor: pointer;
   }
 }

--- a/assets/scss/components/_datatables.scss
+++ b/assets/scss/components/_datatables.scss
@@ -142,6 +142,7 @@ Styleguide dataTable
     background: url("../images/sort_desc_disabled.png") no-repeat scroll center right;
   }
 
+  label, th {
     cursor: pointer;
   }
 }


### PR DESCRIPTION
There are some hardcoded magic numbers in the styling for positioning of the sorting arrows.

I think these should be removed, as they result in values that must be overridden, unless your headings are very similar to the example in the components documentation table included in the markup.

The default is to appear at the right hand edge of the `th` tag.