### PR TITLE
Grid layout modifier - nogutter

### DIFF
--- a/assets/scss/base/_grid.scss
+++ b/assets/scss/base/_grid.scss
@@ -35,6 +35,7 @@ Markup:
   </div>
 </div>
 
+.grid-layout--no-gutter          - Removes edge gutters to allow horizontal alignment with neighbouring content
 .grid-layout--stacked           - Stack columns in mobile
 .grid-layout--maintain-width    - Maintain half width columns on mobile
 
@@ -43,6 +44,11 @@ Styleguide Layout.Grid
 
 .grid-layout {
   @extend %grid-row-table;
+}
+
+.grid-layout--no-gutter {
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .grid-layout--stacked {


### PR DESCRIPTION
Removes edge gutters to allow horizontal alignment with neighbouring content. Prevents the indenting which otherwise happens when using the grid.