### PR TITLE
dont show any empty list items

### DIFF
--- a/assets/scss/base/_lists.scss
+++ b/assets/scss/base/_lists.scss
@@ -27,6 +27,10 @@ ul {
 
 li {
   list-style-position: inside;
+
+  &:empty {
+    display: none;
+  }
 }
 
 ul, nav ul {


### PR DESCRIPTION
sometimes lists are rendered from the backend and if they include optional values an empty `li` can be rendered. when using bullets to prefix the `li` it shows an as empty list item.

The above change will hide any `li` that doesn't have any content in it.

Should have no impact on current services, unless they are purposely showing empty lists