### PR TITLE
Visual regression tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ assets/public/
 target/
 assets/error_pages/assets/
 component-library/
+vrt-output/
+backstop.json

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Frontend assets for the Tax Platform
 - [Running tests whilst developing](#running-js-tests-whilst-developing)
 - [Running a Production build](#running-a-production-build)
 - [Component Library](#component-library)
+- [Component Library](#component-library)
 - [Contributing](#contributing)
 - [More info](#more-info)
 - [License](#license)
@@ -159,6 +160,23 @@ or
 ```
 $ npm install --force hmrc/component-library-template
 ```
+
+## Visual Regression Testing
+Provides a tool to visually compare Component Library changes from Assets Frontend.
+
+## Usage
+To get a base reference for your visual regression tests please save any work on your development branch, checkout your master branch and capture the baseline component screen shots via:
+
+```
+$ npm run vrt:baseline
+```
+
+To compare your changes please checkout the branch with your changes on then run the comparision tests.
+```
+$ npm run vrt:compare
+```
+
+Your results will be output to `vrt-output/report`
 
 
 ## Contributing

--- a/gulpfile.js/config.js
+++ b/gulpfile.js/config.js
@@ -169,6 +169,17 @@ module.exports = {
     karmaConfig: src + 'test/config/karma.conf.js'
   },
 
+  compLib: {
+    port: '9042',
+    host: 'http://localhost',
+    baseDir: './component-library/',
+  },
+
+  vrt: {
+    backstopConfigTemplate: './gulpfile.js/util/backstop/backstop.template.json',
+    backstopConfig: './backstop.json'
+  },
+
   browserSync: {
     ui: false,
     port: 9032,

--- a/gulpfile.js/tasks/vrt.js
+++ b/gulpfile.js/tasks/vrt.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var gulp = require('gulp');
+var backstop = require('backstopjs');
+var runSequence = require('run-sequence');
+var st = require('st');
+var http = require('http');
+var config = require('../config');
+var backstopConfigGenerator = require('./../util/backstop/configGenerator');
+var compLibServer;
+
+gulp.task('build-vrt-config', function () {
+  return backstopConfigGenerator();
+});
+
+gulp.task('vrt-baseline', function () {
+  runSequence(
+    'component-library',
+    'vrt-server',
+    'build-vrt-config',
+    function () {
+      backstop('reference')
+        .then(function () {
+          compLibServer.close();
+        })
+        .catch(function (err) {
+          console.log(err);
+          compLibServer.close();
+        });
+    }
+  );
+});
+
+gulp.task('vrt-compare', function () {
+  runSequence(
+    'component-library',
+    'vrt-server',
+    'build-vrt-config',
+    function () {
+      backstop('test')
+        .then(function () {
+          compLibServer.close()
+        })
+        .catch(function (err) {
+          console.log(err);
+          compLibServer.close();
+        });
+    }
+  );
+});
+
+gulp.task('vrt-server', function () {
+  compLibServer = http.createServer(
+    st(config.compLib.baseDir)
+  ).listen(config.compLib.port);
+});

--- a/gulpfile.js/util/backstop/backstop.template.json
+++ b/gulpfile.js/util/backstop/backstop.template.json
@@ -1,0 +1,35 @@
+{
+  "id": "assets-frontend-vrt",
+  "viewports": [
+    {
+      "name": "desktop",
+      "width": 770,
+      "height": 768
+    }
+  ],
+  "scenarios": [],
+  "ci": {
+    "format" :  "junit" ,
+    "testReportFileName": "component-library-xunit",
+    "testSuiteName" :  "Assets Frontend Visual Regression Tests"
+  },
+  "paths": {
+    "bitmaps_reference": "vrt-output/baseline",
+    "bitmaps_test": "vrt-output/compare",
+    "html_report": "vrt-output/report",
+    "ci_report": "vrt-output/ci-report"
+  },
+  "casperFlags": [],
+  "engine": "phantomjs",
+  "report": ["browser", "CI"],
+  "debug": false,
+  "resembleOutputOptions": {
+    "errorColor": {
+      "red": 255,
+      "green": 0,
+      "blue": 255
+    },
+    "errorType": "movement",
+    "transparency": 0.3
+  }
+}

--- a/gulpfile.js/util/backstop/buildScenarios.js
+++ b/gulpfile.js/util/backstop/buildScenarios.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var mergeObj = require('./../mergeObj');
+var sep = require('path').sep;
+var Transform = require('stream').Transform;
+var util = require('util');
+var config = require('./../../config');
+var componentLibraryUrl = config.compLib.host + ':' + config.compLib.port;
+var scenarioTemplate = {
+  selectors: [
+    '.comp-lib-pattern-component'
+  ],
+  misMatchThreshold: 0.1,
+  'selectorExpansion': true
+};
+var AddScenarios = function (options, pagePaths) {
+  Transform.call(this, options)
+  this.pagePaths = pagePaths
+  this.data = []
+};
+
+util.inherits(AddScenarios, Transform);
+
+AddScenarios.prototype._transform = function (chunk, encoding, done) {
+  this.data.push(chunk)
+  done()
+};
+
+AddScenarios.prototype._flush = function (done) {
+  let jsonData;
+  let stringData;
+
+  try {
+    jsonData = JSON.parse(this.data);
+  } catch (err) {
+    throw err;
+  }
+
+  Array.prototype.push.apply(jsonData.scenarios, this.createScenarios());
+
+  try {
+    stringData = JSON.stringify(jsonData, null, 2);
+  } catch (err) {
+    throw err;
+  }
+
+  this.push(stringData);
+  done();
+}
+
+AddScenarios.prototype.createScenarios = function () {
+  return this.pagePaths.map(function (path) {
+    var pageName = path.slice(8, -5);
+    var scenario = mergeObj({
+      label: pageName[0].toUpperCase() + pageName.slice(1),
+      url: componentLibraryUrl + sep + path
+    }, scenarioTemplate);
+
+    return scenario;
+  });
+};
+
+module.exports = AddScenarios;

--- a/gulpfile.js/util/backstop/configGenerator.js
+++ b/gulpfile.js/util/backstop/configGenerator.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var fs =  require('fs');
+var config = require('./../../config');
+var BuildScenarios = require('./buildScenarios');
+
+var getCompLibPaths = function () {
+  var files = fs.readdirSync(config.compLib.baseDir);
+
+  return files.filter(function (file) {
+    return file !== 'index.html' && file.includes('.html');
+  });
+}
+
+module.exports = function () {
+  var compLibPaths = getCompLibPaths();
+  var addScenarios = new BuildScenarios({objectMode: true}, compLibPaths);
+  var readConfig = fs.createReadStream(config.vrt.backstopConfigTemplate);
+  var writeConfig = fs.createWriteStream(config.vrt.backstopConfig);
+
+  return new Promise(function (resolve, reject) {
+    readConfig.setEncoding('utf8')
+    readConfig
+      .pipe(addScenarios)
+      .pipe(writeConfig)
+      .on('finish', function () {
+        resolve('backstop.json created')
+      })
+      .on('error', function (err) {
+        reject(err)
+      });
+  });
+};

--- a/gulpfile.js/util/mergeObj.js
+++ b/gulpfile.js/util/mergeObj.js
@@ -1,0 +1,9 @@
+module.exports = function (parent, child) {
+  Object.keys(child).forEach(function (prop) {
+    if (child.hasOwnProperty(prop)) {
+      parent[prop] = child[prop];
+    }
+  });
+
+  return parent;
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "test:dev": "karma start assets/test/config/karma.conf.js no-single-run",
     "comp-lib": "gulp component-library",
     "comp-lib:watch": "nodemon -e html,js,css,png,jpeg -x 'npm run comp-lib:link && npm run comp-lib'",
-    "comp-lib:link": "npm link hmrc-component-library-template"
+    "comp-lib:link": "npm link hmrc-component-library-template",
+    "vrt:baseline": "gulp vrt-baseline",
+    "vrt:compare": "gulp vrt-compare"
   },
   "keywords": [
     "HMRC",
@@ -27,6 +29,7 @@
   "author": "HMRC",
   "license": "Apache-2.0",
   "dependencies": {
+    "backstopjs": "^2.3.3",
     "browser-sync": "^2.4.0",
     "browserify-istanbul": "^0.1.3",
     "browserify-shim": "^3.8.2",
@@ -78,6 +81,7 @@
     "pretty-hrtime": "^1.0.0",
     "require-dir": "^0.2.0",
     "run-sequence": "^1.0.2",
+    "st": "^1.2.0",
     "stageprompt": "hmrc/stageprompt",
     "sticky-header": "^0.2.1",
     "vinyl-buffer": "^1.0.0",


### PR DESCRIPTION
Add Visual Regression suit to test the Component Library to help developers when making style changes.
- `backstop.json` config creation from `Component Library` files
- Serve `Component-Library` locally




