### PR TITLE
Allow setting of existing value to autocomplete select input

### DIFF
--- a/assets/javascripts/modules/autoComplete.js
+++ b/assets/javascripts/modules/autoComplete.js
@@ -349,15 +349,22 @@ var suggestionsEvent = function () {
   });
 };
 
+/**
+  * Get a linked select input
+**/
+var getDataLinked = function(el){
+  var dataLinked = $('select[id="' + el.attr("data-select-elem") + '"]');
+  return dataLinked;
+};
 
 /**
   * If a select elem is being used, load value from there
 **/
-var loadExistingValue = function () {
-    var dataLinked = $('select[id="' + $autoCompleteInputElem.attr("data-select-elem") + '"]');
+var loadExistingValue = function (el) {
+    var dataLinked = getDataLinked(el);
     var selectedOption = dataLinked.find('option:selected')[0];
-    if(selectedOption.value > ""){
-        $autoCompleteInputElem.val(selectedOption.text);
+    if(selectedOption.value !== ""){
+        el.val(selectedOption.text);
     }
 };
 
@@ -366,7 +373,7 @@ var loadExistingValue = function () {
 */
 var getSuggestions = function (el) {
   var suggestions;
-  var dataLinked = $('select[id="' + el.attr("data-select-elem") + '"]');
+  var dataLinked = getDataLinked(el);
   if(dataLinked.length > 0){
     // using a select input in-page as the source for the suggestions
     // this is useful when using a select as a fallback for the autocomplete
@@ -381,7 +388,7 @@ var getSuggestions = function (el) {
     window.hmrcAutocompleteData = suggestions;
     el.attr("data-suggestions", "hmrcAutocompleteData");
     // update text input with a pre-selected select option
-    loadExistingValue();
+    loadExistingValue(el);
   } else {
     // allow custom variable
     // this works in the same way as the legacy version by passing in an existing global object name

--- a/assets/javascripts/modules/autoComplete.js
+++ b/assets/javascripts/modules/autoComplete.js
@@ -359,7 +359,7 @@ var loadExistingValue = function () {
     if(selectedOption.value > ""){
         $autoCompleteInputElem.val(selectedOption.text);
     }
-}
+};
 
 /**
   * Either grab a given global variable or generate one from a given select input

--- a/assets/javascripts/modules/autoComplete.js
+++ b/assets/javascripts/modules/autoComplete.js
@@ -351,6 +351,17 @@ var suggestionsEvent = function () {
 
 
 /**
+  * If a select elem is being used, load value from there
+**/
+var loadExistingValue = function () {
+    var dataLinked = $('select[id="' + $autoCompleteInputElem.attr("data-select-elem") + '"]');
+    var selectedOption = dataLinked.find('option:selected')[0];
+    if(selectedOption.value > ""){
+        $autoCompleteInputElem.val(selectedOption.text);
+    }
+}
+
+/**
   * Either grab a given global variable or generate one from a given select input
 */
 var getSuggestions = function (el) {
@@ -369,6 +380,8 @@ var getSuggestions = function (el) {
     // generate a global variable to hold the data and insert into data-suggestions attribute
     window.hmrcAutocompleteData = suggestions;
     el.attr("data-suggestions", "hmrcAutocompleteData");
+    // update text input with a pre-selected select option
+    loadExistingValue();
   } else {
     // allow custom variable
     // this works in the same way as the legacy version by passing in an existing global object name


### PR DESCRIPTION
Updates autocomplete where select input is used as source for suggestions

## Problem
If a select input is being used as the source of the suggestions and it has a selected option on page load, the autocomplete input does not populate.

## Solution
Added a call where if the select is being used as the source for suggestions any existing value is rendered to the autocomplete input.
