### PR TITLE
Auto complete accessibility ios

### DIFF
--- a/assets/javascripts/modules/autoComplete.js
+++ b/assets/javascripts/modules/autoComplete.js
@@ -217,10 +217,12 @@ var addEventListeners = function () {
  * keydown event for auto complete input
  * keydown used to capture enter key (13) before form is submitted if we have suggestions
  * allow suggestion list key controls through
+ * tab key will close the suggestions
  * 40 (down)
  * 38 (up)
  * 27 (esc)
  * 13 (enter)
+ * 9  (tab)
  */
 var inputKeyDownEvent = function () {
   $autoCompleteInputElem.on('keydown', function (event) {
@@ -228,6 +230,10 @@ var inputKeyDownEvent = function () {
 
     if (keyCode === 13 && $suggestionsContainer.html()) {
       event.preventDefault();
+    }
+
+    if (keyCode === 9 && $suggestionsContainer.html()) {
+      closeSuggestions();
     }
 
     if (keyCode === 38 || keyCode === 40 || keyCode === 13 || keyCode === 27) {

--- a/assets/javascripts/modules/autoComplete.js
+++ b/assets/javascripts/modules/autoComplete.js
@@ -30,11 +30,12 @@ Auto complete html markup:
 
            data-rule-suggestion="true"
            aria-autocomplete="list"
-           aria-haspopup="country-code-suggestions"
+           aria-haspopup="true"
+           aria-controls="suggestions-list-container"
            aria-activedescendant />
     <i class="suggestions-clear js-suggestions-clear"></i>
-    <span role="status" aria-live="polite" class="visuallyhidden js-suggestions-status"></span>
-    <div class="suggestions js-suggestions" id="country-code-suggestions"></div>
+    <span role="status" aria-live="assertive" aria-relevant="additions" class="visuallyhidden js-suggestions-status-message" id="autoCompleteSuggestionStatus"></span>
+    <div class="suggestions js-suggestions" id="suggestions-list-container" aria-describedby="autoCompleteSuggestionStatus"></div>
  </div>
 
 
@@ -86,6 +87,7 @@ var displaySuggestions = function ($suggestionsContainer, matches, match) {
     li.setAttribute('data-suggestion-value', suggestion.value);
     li.setAttribute('data-suggestion-title', suggestion.title);
     li.setAttribute('role', 'option');
+    li.setAttribute('tabindex', '-1');
     ulHtmlFragment.className = 'suggestions-list';
     ulHtmlFragment.setAttribute('role', 'listbox');
     ulHtmlFragment.appendChild(li);
@@ -95,7 +97,7 @@ var displaySuggestions = function ($suggestionsContainer, matches, match) {
     createSuggestion(index, suggestion);
   });
 
-  $suggestionsStatusMessage.text(matches.length + ' suggestion' + (matches.length > 1 ? 's' : '') + ' available, please navigate by using up and down');
+  $suggestionsStatusMessage.text(matches.length + ' suggestion' + (matches.length > 1 ? 's' : '') + ' available, please navigate moving up and down');
   $autoCompleteInputElem.addClass('has-suggestions');
 
   containerFragment.appendChild(ulHtmlFragment);
@@ -107,6 +109,7 @@ var displaySuggestions = function ($suggestionsContainer, matches, match) {
  */
 var closeSuggestions = function () {
   $suggestionsContainer.html('');
+  $suggestionsStatusMessage.text("");
   $autoCompleteInputElem.removeClass('has-suggestions');
 };
 
@@ -286,7 +289,6 @@ var inputKeyupEvent = function () {
 var inputBlurEvent = function () {
   $autoCompleteInputElem.on('blur', function (event) {
     isMatchingSuggestion(event.target.value);
-    closeSuggestions();
   });
 };
 
@@ -345,7 +347,7 @@ var suggestionsEvent = function () {
     event.preventDefault();
 
     updateInput($suggestion.data('suggestion-title'), $suggestion.data('suggestion-value'));
-    closeSuggestions();
+    closeSuggestionsAndFocus();
   });
 };
 


### PR DESCRIPTION
This improves the accessibility of the autocomplete component, specifically on iOS

## Problem
Fixes #724 

## Solution
This tackles the issue in a few ways:
1. Fixing some of the aria attributes - these weren't defined in the best way and so weren't working as expected.
2. Allowing VoiceOver to navigate the suggestions list
3. Slight change to the copy used
4. Preventing the suggestion list from closing on blur (added a tab key check to close it when tabbing off to next input to maintain keyboard behaviour). This prevents the suggestions list from closing when a VoiceOver user is navigating via touch or swipe gestures.
5. Ensure when a suggestion is selected, the input is focussed.
