### PR TITLE
added javascript to toggleDynamicFormField to clear numeric field

### DIFF
--- a/assets/javascripts/modules/toggleDynamicFormFields.js
+++ b/assets/javascripts/modules/toggleDynamicFormFields.js
@@ -19,6 +19,7 @@ module.exports = function() {
 
       $toggledField.addClass('js-hidden');
       $toggledField.find(':text').val('');
+      $toggledField.find(':input[type="number"]').val('');
       $toggledField.find(':checked').prop('checked', false);
       $toggledField.find('*[data-default]').prop('checked', true);
     } else {


### PR DESCRIPTION
Currently when the user triggers the hide attribute, the javascript in toggleDynamicFormField.js file finds text fields and deletes the contents of that field. This doesn't work if the input field is of type number.

In our service we have income pages that take the amount in input fields of type number. Currently in our service if user enters a number and then clicks "No" to cancel, the value in the field isn't cleared and hence the validation prevents the user from continuing until they manually clear the field.
 
The new code finds the number field as well as text field and clears that too.

Please see attached gifs.

![incomeafter](https://cloud.githubusercontent.com/assets/17907161/21524665/cf6fbb90-cd0f-11e6-81a2-03c96abbb3a3.gif)
![incomebefore](https://cloud.githubusercontent.com/assets/17907161/21524666/cf728618-cd0f-11e6-9c22-dee57f2bd108.gif)
