### PR TITLE
[WEBOPS 4032] Add nginx error pages to the output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ test_results/
 test_coverage/
 assets/public/
 target/
-assets/error_pages/assets/
 component-library/
 vrt-output/
 backstop.json

--- a/assets/error_pages/401.html
+++ b/assets/error_pages/401.html
@@ -10,18 +10,18 @@
     (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
   </script>
 
-  <!--[if gt IE 8]><!--><link href="stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
-  <!--[if IE 6]><link href="stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 7]><link href="stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 8]><link href="stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href="/template/stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+  <!--[if IE 6]><link href="/template/stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 7]><link href="/template/stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 8]><link href="/template/stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
 
-  <link href="stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
+  <link href="/template/stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
 
   <!--[if IE 8]>
   <script type="text/javascript">
     (function(){if(window.opera){return;}
      setTimeout(function(){var a=document,g,b={families:(g=
-     ["nta"]),urls:["stylesheets/fonts-ie8.css"]},
+     ["nta"]),urls:["/template/stylesheets/fonts-ie8.css"]},
      c="javascripts/vendor/goog/webfont-debug.js",d="script",
      e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
      ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
@@ -30,29 +30,29 @@
   </script>
   <![endif]-->
   <!--[if gte IE 9]><!-->
-  <link href="stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" />
+  <link href="/template/stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" />
   <!--<![endif]-->
 
-  <!--[if lt IE 9]><script src="javascripts/ie.js" type="text/javascript"></script><![endif]-->
+  <!--[if lt IE 9]><script src="/template/javascripts/ie.js" type="text/javascript"></script><![endif]-->
 
-  <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
+  <link rel="shortcut icon" href="/template/images/favicon.ico" type="image/x-icon" />
   <!-- For third-generation iPad with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="images/apple-touch-icon-144x144.png">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/template/images/apple-touch-icon-144x144.png">
   <!-- For iPhone with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="images/apple-touch-icon-114x114.png">
+  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/template/images/apple-touch-icon-114x114.png">
   <!-- For first- and second-generation iPad: -->
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="images/apple-touch-icon-72x72.png">
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/template/images/apple-touch-icon-72x72.png">
   <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-  <link rel="apple-touch-icon-precomposed" href="images/apple-touch-icon-57x57.png">
+  <link rel="apple-touch-icon-precomposed" href="/template/images/apple-touch-icon-57x57.png">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta property="og:image" content="images/opengraph-image.png">
+  <meta property="og:image" content="/template/images/opengraph-image.png">
 
-	<!--[if lt IE 8 ]><link rel='stylesheet' href='stylesheets/application-ie7.min.css' />	<![endif]-->
-	<!--[if IE 8 ]><link rel='stylesheet' href='stylesheets/application-ie.min.css' /><![endif]-->
-	<!--[if gt IE 8]><!--><link rel='stylesheet' href='stylesheets/application.min.css' /><!--<![endif]-->
+	<!--[if lt IE 8 ]><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application-ie7.min.css' />	<![endif]-->
+	<!--[if IE 8 ]><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application-ie.min.css' /><![endif]-->
+	<!--[if gt IE 8]><!--><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application.min.css' /><!--<![endif]-->
 
-	<script src='javascripts/vendor/modernizr.js' type='text/javascript'></script>
+	<script src='{{ assetsPath }}javascripts/vendor/modernizr.js' type='text/javascript'></script>
 </head>
 
 <body class="">
@@ -69,7 +69,7 @@
       <div class="header-global">
         <div class="header-logo">
           <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
-            <img src="images/gov.uk_logotype_crown.png" alt=""> GOV.UK
+            <img src="/template/images/gov.uk_logotype_crown.png" alt=""> GOV.UK
           </a>
         </div>
       </div>
@@ -111,7 +111,7 @@
           <div class="open-government-licence">
             <h2>
               <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2" target="_blank">
-                <img src="images/open-government-licence_2x.png" alt="OGL">
+                <img src="/template/images/open-government-licence_2x.png" alt="OGL">
               </a>
             </h2>
 
@@ -127,7 +127,7 @@
   </footer>
   <!--end footer-->
 
-  <script src="javascripts/govuk-template.js" type="text/javascript"></script>
-  <script src="javascripts/application.js" type="text/javascript"></script>
+  <script src="/template/javascripts/govuk-template.js" type="text/javascript"></script>
+  <script src="{{ assetsPath }}javascripts/application.js" type="text/javascript"></script>
 </body>
 </html>

--- a/assets/error_pages/403.html
+++ b/assets/error_pages/403.html
@@ -10,18 +10,18 @@
     (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
   </script>
 
-  <!--[if gt IE 8]><!--><link href="stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
-  <!--[if IE 6]><link href="stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 7]><link href="stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 8]><link href="stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href="/template/stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+  <!--[if IE 6]><link href="/template/stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 7]><link href="/template/stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 8]><link href="/template/stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
 
-  <link href="stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
+  <link href="/template/stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
 
   <!--[if IE 8]>
   <script type="text/javascript">
     (function(){if(window.opera){return;}
      setTimeout(function(){var a=document,g,b={families:(g=
-     ["nta"]),urls:["stylesheets/fonts-ie8.css"]},
+     ["nta"]),urls:["/template/stylesheets/fonts-ie8.css"]},
      c="javascripts/vendor/goog/webfont-debug.js",d="script",
      e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
      ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
@@ -30,29 +30,29 @@
   </script>
   <![endif]-->
   <!--[if gte IE 9]><!-->
-  <link href="stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" />
+  <link href="/template/stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" />
   <!--<![endif]-->
 
-  <!--[if lt IE 9]><script src="javascripts/ie.js" type="text/javascript"></script><![endif]-->
+  <!--[if lt IE 9]><script src="/template/javascripts/ie.js" type="text/javascript"></script><![endif]-->
 
-  <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
+  <link rel="shortcut icon" href="/template/images/favicon.ico" type="image/x-icon" />
   <!-- For third-generation iPad with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="images/apple-touch-icon-144x144.png">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/template/images/apple-touch-icon-144x144.png">
   <!-- For iPhone with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="images/apple-touch-icon-114x114.png">
+  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/template/images/apple-touch-icon-114x114.png">
   <!-- For first- and second-generation iPad: -->
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="images/apple-touch-icon-72x72.png">
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/template/images/apple-touch-icon-72x72.png">
   <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-  <link rel="apple-touch-icon-precomposed" href="images/apple-touch-icon-57x57.png">
+  <link rel="apple-touch-icon-precomposed" href="/template/images/apple-touch-icon-57x57.png">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta property="og:image" content="images/opengraph-image.png">
+  <meta property="og:image" content="/template/images/opengraph-image.png">
 
-	<!--[if lt IE 8 ]><link rel='stylesheet' href='stylesheets/application-ie7.min.css' />	<![endif]-->
-	<!--[if IE 8 ]><link rel='stylesheet' href='stylesheets/application-ie.min.css' /><![endif]-->
-	<!--[if gt IE 8]><!--><link rel='stylesheet' href='stylesheets/application.min.css' /><!--<![endif]-->
+	<!--[if lt IE 8 ]><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application-ie7.min.css' />	<![endif]-->
+	<!--[if IE 8 ]><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application-ie.min.css' /><![endif]-->
+	<!--[if gt IE 8]><!--><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application.min.css' /><!--<![endif]-->
 
-	<script src='javascripts/vendor/modernizr.js' type='text/javascript'></script>
+	<script src='{{ assetsPath }}javascripts/vendor/modernizr.js' type='text/javascript'></script>
 </head>
 
 <body class="">
@@ -69,7 +69,7 @@
       <div class="header-global">
         <div class="header-logo">
           <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
-            <img src="images/gov.uk_logotype_crown.png" alt=""> GOV.UK
+            <img src="/template/images/gov.uk_logotype_crown.png" alt=""> GOV.UK
           </a>
         </div>
       </div>
@@ -111,7 +111,7 @@
           <div class="open-government-licence">
             <h2>
               <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2" target="_blank">
-                <img src="images/open-government-licence_2x.png" alt="OGL">
+                <img src="/template/images/open-government-licence_2x.png" alt="OGL">
               </a>
             </h2>
 
@@ -127,7 +127,7 @@
   </footer>
   <!--end footer-->
 
-  <script src="javascripts/govuk-template.js" type="text/javascript"></script>
-  <script src="javascripts/application.js" type="text/javascript"></script>
+  <script src="/template/javascripts/govuk-template.js" type="text/javascript"></script>
+  <script src="{{ assetsPath }}javascripts/application.js" type="text/javascript"></script>
 </body>
 </html>

--- a/assets/error_pages/404.html
+++ b/assets/error_pages/404.html
@@ -10,18 +10,18 @@
     (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
   </script>
 
-  <!--[if gt IE 8]><!--><link href="stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
-  <!--[if IE 6]><link href="stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 7]><link href="stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 8]><link href="stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href="/template/stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+  <!--[if IE 6]><link href="/template/stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 7]><link href="/template/stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 8]><link href="/template/stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
 
-  <link href="stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
+  <link href="/template/stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
 
   <!--[if IE 8]>
   <script type="text/javascript">
     (function(){if(window.opera){return;}
      setTimeout(function(){var a=document,g,b={families:(g=
-     ["nta"]),urls:["stylesheets/fonts-ie8.css"]},
+     ["nta"]),urls:["/template/stylesheets/fonts-ie8.css"]},
      c="javascripts/vendor/goog/webfont-debug.js",d="script",
      e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
      ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
@@ -30,29 +30,29 @@
   </script>
   <![endif]-->
   <!--[if gte IE 9]><!-->
-  <link href="stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" />
+  <link href="/template/stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" />
   <!--<![endif]-->
 
-  <!--[if lt IE 9]><script src="javascripts/ie.js" type="text/javascript"></script><![endif]-->
+  <!--[if lt IE 9]><script src="/template/javascripts/ie.js" type="text/javascript"></script><![endif]-->
 
-  <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
+  <link rel="shortcut icon" href="/template/images/favicon.ico" type="image/x-icon" />
   <!-- For third-generation iPad with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="images/apple-touch-icon-144x144.png">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/template/images/apple-touch-icon-144x144.png">
   <!-- For iPhone with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="images/apple-touch-icon-114x114.png">
+  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/template/images/apple-touch-icon-114x114.png">
   <!-- For first- and second-generation iPad: -->
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="images/apple-touch-icon-72x72.png">
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/template/images/apple-touch-icon-72x72.png">
   <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-  <link rel="apple-touch-icon-precomposed" href="images/apple-touch-icon-57x57.png">
+  <link rel="apple-touch-icon-precomposed" href="/template/images/apple-touch-icon-57x57.png">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:image" content="images/opengraph-image.png">
 
-	<!--[if lt IE 8 ]><link rel='stylesheet' href='stylesheets/application-ie7.min.css' />	<![endif]-->
-	<!--[if IE 8 ]><link rel='stylesheet' href='stylesheets/application-ie.min.css' /><![endif]-->
-	<!--[if gt IE 8]><!--><link rel='stylesheet' href='stylesheets/application.min.css' /><!--<![endif]-->
+	<!--[if lt IE 8 ]><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application-ie7.min.css' />	<![endif]-->
+	<!--[if IE 8 ]><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application-ie.min.css' /><![endif]-->
+	<!--[if gt IE 8]><!--><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application.min.css' /><!--<![endif]-->
 
-	<script src='javascripts/vendor/modernizr.js' type='text/javascript'></script>
+	<script src='{{ assetsPath }}javascripts/vendor/modernizr.js' type='text/javascript'></script>
 </head>
 
 <body class="">
@@ -69,7 +69,7 @@
       <div class="header-global">
         <div class="header-logo">
           <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
-            <img src="images/gov.uk_logotype_crown.png" alt=""> GOV.UK
+            <img src="/template/images/gov.uk_logotype_crown.png" alt=""> GOV.UK
           </a>
         </div>
       </div>
@@ -111,7 +111,7 @@
           <div class="open-government-licence">
             <h2>
               <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2" target="_blank">
-                <img src="images/open-government-licence_2x.png" alt="OGL">
+                <img src="/template/images/open-government-licence_2x.png" alt="OGL">
               </a>
             </h2>
 
@@ -127,7 +127,7 @@
   </footer>
   <!--end footer-->
 
-  <script src="javascripts/govuk-template.js" type="text/javascript"></script>
-  <script src="javascripts/application.js" type="text/javascript"></script>
+  <script src="/template/javascripts/govuk-template.js" type="text/javascript"></script>
+  <script src="{{ assetsPath }}javascripts/application.js" type="text/javascript"></script>
 </body>
 </html>

--- a/assets/error_pages/500.html
+++ b/assets/error_pages/500.html
@@ -10,18 +10,18 @@
     (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
   </script>
 
-  <!--[if gt IE 8]><!--><link href="stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
-  <!--[if IE 6]><link href="stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 7]><link href="stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 8]><link href="stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href="/template/stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+  <!--[if IE 6]><link href="/template/stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 7]><link href="/template/stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 8]><link href="/template/stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
 
-  <link href="stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
+  <link href="/template/stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
 
   <!--[if IE 8]>
   <script type="text/javascript">
     (function(){if(window.opera){return;}
      setTimeout(function(){var a=document,g,b={families:(g=
-     ["nta"]),urls:["stylesheets/fonts-ie8.css"]},
+     ["nta"]),urls:["/template/stylesheets/fonts-ie8.css"]},
      c="javascripts/vendor/goog/webfont-debug.js",d="script",
      e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
      ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
@@ -30,27 +30,27 @@
   </script>
   <![endif]-->
 
-  <!--[if gte IE 9]><!--><link href="stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
-  <!--[if lt IE 9]><script src="javascripts/ie.js" type="text/javascript"></script><![endif]-->
+  <!--[if gte IE 9]><!--><link href="/template/stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
+  <!--[if lt IE 9]><script src="/template/javascripts/ie.js" type="text/javascript"></script><![endif]-->
 
-  <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
+  <link rel="shortcut icon" href="/template/images/favicon.ico" type="image/x-icon" />
   <!-- For third-generation iPad with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="images/apple-touch-icon-144x144.png">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/template/images/apple-touch-icon-144x144.png">
   <!-- For iPhone with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="images/apple-touch-icon-114x114.png">
+  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/template/images/apple-touch-icon-114x114.png">
   <!-- For first- and second-generation iPad: -->
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="images/apple-touch-icon-72x72.png">
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/template/images/apple-touch-icon-72x72.png">
   <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-  <link rel="apple-touch-icon-precomposed" href="images/apple-touch-icon-57x57.png">
+  <link rel="apple-touch-icon-precomposed" href="/template/images/apple-touch-icon-57x57.png">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta property="og:image" content="images/opengraph-image.png">
+  <meta property="og:image" content="/template/images/opengraph-image.png">
 
-	<!--[if lt IE 8 ]><link rel='stylesheet' href='stylesheets/application-ie7.min.css' /><![endif]-->
-  <!--[if IE 8 ]><link rel='stylesheet' href='stylesheets/application-ie.min.css' /><![endif]-->
-	<!--[if gt IE 8]><!--><link rel='stylesheet' href='stylesheets/application.min.css' /><!--<![endif]-->
+	<!--[if lt IE 8 ]><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application-ie7.min.css' /><![endif]-->
+  <!--[if IE 8 ]><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application-ie.min.css' /><![endif]-->
+	<!--[if gt IE 8]><!--><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application.min.css' /><!--<![endif]-->
 
-	<script src='javascripts/vendor/modernizr.js' type='text/javascript'></script>
+	<script src='{{ assetsPath }}javascripts/vendor/modernizr.js' type='text/javascript'></script>
 </head>
 
 <body class="">
@@ -67,7 +67,7 @@
       <div class="header-global">
         <div class="header-logo">
           <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
-            <img src="images/gov.uk_logotype_crown.png" alt=""> GOV.UK
+            <img src="/template/images/gov.uk_logotype_crown.png" alt=""> GOV.UK
           </a>
         </div>
       </div>
@@ -107,7 +107,7 @@
           </ul>
 
           <div class="open-government-licence">
-            <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2" target="_blank"><img src="images/open-government-licence_2x.png" alt="OGL"></a></h2>
+            <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2" target="_blank"><img src="/template/images/open-government-licence_2x.png" alt="OGL"></a></h2>
             <p>All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2" target="_blank">Open Government Licence v2.0</a>, except where otherwise stated</p>
           </div>
         </div>
@@ -120,7 +120,7 @@
   </footer>
   <!--end footer-->
 
-  <script src="javascripts/govuk-template.js" type="text/javascript"></script>
-  <script src="javascripts/application.js" type="text/javascript"></script>
+  <script src="/template/javascripts/govuk-template.js" type="text/javascript"></script>
+  <script src="{{ assetsPath }}javascripts/application.js" type="text/javascript"></script>
 </body>
 </html>

--- a/gulpfile.js/config.js
+++ b/gulpfile.js/config.js
@@ -173,10 +173,12 @@ module.exports = {
   errorPages: {
     src: src + 'error_pages/*.html',
     dev:{
-      dest: snapshotDir
+      dest: snapshotDir,
+      assetsPath: '/' + snapshotDir
     },
     prod:{
-      dest: distDir
+      dest: distDir,
+      assetsPath: process.env.TAG ? '/assets/' + process.env.TAG + '/' : '/assets/999-SNAPSHOT/'
     }
   },
 

--- a/gulpfile.js/config.js
+++ b/gulpfile.js/config.js
@@ -170,6 +170,16 @@ module.exports = {
     karmaConfig: src + 'test/config/karma.conf.js'
   },
 
+  errorPages: {
+    src: src + 'error_pages/*.html',
+    dev:{
+      dest: snapshotDir
+    },
+    prod:{
+      dest: distDir
+    }
+  },
+
   compLib: {
     port: '9042',
     host: 'http://localhost',

--- a/gulpfile.js/config.js
+++ b/gulpfile.js/config.js
@@ -35,10 +35,10 @@ module.exports = {
   distDir: distDir,
 
   dev: {
-    dest: snapshotDir,
+    dest: snapshotDir
   },
   prod: {
-    dest: distDir,
+    dest: distDir
   },
 
   production: {
@@ -85,7 +85,7 @@ module.exports = {
         'flash',
         'hidden'
       ],
-      files : {
+      files: {
         src: [
           src + '{javascripts,scss,govuk_*}/**/*.{js,scss}',
           '!**[^node_modules]/**/modernizr.js'
@@ -103,7 +103,7 @@ module.exports = {
       dest: distDir + 'images'
     }
   },
-  
+
   images: {
     govuk: govuk.images + '**/*',
     dev: {
@@ -149,7 +149,8 @@ module.exports = {
         dest: distDir + 'javascripts'
       },
       outputName: 'application.js'
-    },{
+    },
+    {
       entries: [
         src + 'javascripts/export/fingerprint.js'
       ],
@@ -172,7 +173,7 @@ module.exports = {
   compLib: {
     port: '9042',
     host: 'http://localhost',
-    baseDir: './component-library/',
+    baseDir: './component-library/'
   },
 
   vrt: {

--- a/gulpfile.js/tasks/build.js
+++ b/gulpfile.js/tasks/build.js
@@ -1,14 +1,14 @@
 'use strict';
 
 var gulp           = require('gulp'),
-	  runSequence    = require('run-sequence'),
+    runSequence    = require('run-sequence'),
     browserifyTask = require('./browserify');
 
 gulp.task('build', ['clean', 'test'], function() {
   global.runmode = 'prod';
   global.location = undefined;
   runSequence(
-    ['sass', 'images', 'svg'],
+    ['sass', 'images', 'svg', 'error-pages'],
     ['browserify', 'concatEncryption'],
     'modernizr',
     'version',

--- a/gulpfile.js/tasks/default.js
+++ b/gulpfile.js/tasks/default.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var gulp        = require('gulp'),
+var gulp = require('gulp'),
     runSequence = require('run-sequence');
 
-gulp.task('default', ['clean'], function () {
+gulp.task('default', ['clean'], function() {
   runSequence(
-    ['sass', 'images', 'svg', 'concatEncryption'],
+    ['sass', 'images', 'svg', 'concatEncryption', 'error-pages'],
     'modernizr',
     'component-library',
     'watch'

--- a/gulpfile.js/tasks/error-pages.js
+++ b/gulpfile.js/tasks/error-pages.js
@@ -1,11 +1,13 @@
 'use strict';
 
 var gulp = require('gulp'),
+    replace = require('gulp-replace'),
     config = require('../config').errorPages;
 
 gulp.task('error-pages', function() {
   var env = global.runmode;
 
   gulp.src(config.src)
+      .pipe(replace('{{ assetsPath }}', config[env].assetsPath))
       .pipe(gulp.dest(config[env].dest));
 });

--- a/gulpfile.js/tasks/error-pages.js
+++ b/gulpfile.js/tasks/error-pages.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var gulp = require('gulp'),
+    config = require('../config').errorPages;
+
+gulp.task('error-pages', function() {
+  var env = global.runmode;
+
+  gulp.src(config.src)
+      .pipe(gulp.dest(config[env].dest));
+});

--- a/package.json
+++ b/package.json
@@ -48,8 +48,11 @@
     "gulp-notify": "^2.2.0",
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.0",
+    "gulp-replace": "^0.5.4",
     "gulp-sass": "^2.3.0",
     "gulp-sourcemaps": "^1.5.1",
+    "gulp-stylelint": "^2.0.2",
+    "gulp-svgmin": "^1.2.2",
     "gulp-uglify": "^1.1.0",
     "gulp-util": "^3.0.4",
     "gulp-zip": "^2.0.3",
@@ -87,9 +90,7 @@
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "vinyl-transform": "^1.0.0",
-    "watchify": "^2.6.0",
-    "gulp-stylelint": "^2.0.2",
-    "gulp-svgmin": "^1.2.2"
+    "watchify": "^2.6.0"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
## Problem
Error pages for nginx weren't being added to the final `zip` that gets deployed.

The assets paths in the error pages were also relative so the assets weren't loading if you were on a non-existent page (i.e. `/broken-page` would try and load `/broken-page/stylesheets/application.min.css`)

## Solution
* Updated the govuk-template paths in the error files.
* Added an `error-pages` gulp task that copies the files to the correct output directory (depending on the `process.runmode` set by either `npm start` or `npm run build`) and updates any paths based on the version being built