### PR TITLE
Fix GOV.UK template url for error pages

### DIFF
--- a/assets/error_pages/401.html
+++ b/assets/error_pages/401.html
@@ -10,18 +10,18 @@
     (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
   </script>
 
-  <!--[if gt IE 8]><!--><link href="/template/stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
-  <!--[if IE 6]><link href="/template/stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 7]><link href="/template/stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 8]><link href="/template/stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href="/template/assets/stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+  <!--[if IE 6]><link href="/template/assets/stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 7]><link href="/template/assets/stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 8]><link href="/template/assets/stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
 
-  <link href="/template/stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
+  <link href="/template/assets/stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
 
   <!--[if IE 8]>
   <script type="text/javascript">
     (function(){if(window.opera){return;}
      setTimeout(function(){var a=document,g,b={families:(g=
-     ["nta"]),urls:["/template/stylesheets/fonts-ie8.css"]},
+     ["nta"]),urls:["/template/assets/stylesheets/fonts-ie8.css"]},
      c="javascripts/vendor/goog/webfont-debug.js",d="script",
      e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
      ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
@@ -30,23 +30,23 @@
   </script>
   <![endif]-->
   <!--[if gte IE 9]><!-->
-  <link href="/template/stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" />
+  <link href="/template/assets/stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" />
   <!--<![endif]-->
 
-  <!--[if lt IE 9]><script src="/template/javascripts/ie.js" type="text/javascript"></script><![endif]-->
+  <!--[if lt IE 9]><script src="/template/assets/javascripts/ie.js" type="text/javascript"></script><![endif]-->
 
-  <link rel="shortcut icon" href="/template/images/favicon.ico" type="image/x-icon" />
+  <link rel="shortcut icon" href="/template/assets/images/favicon.ico" type="image/x-icon" />
   <!-- For third-generation iPad with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/template/images/apple-touch-icon-144x144.png">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/template/assets/images/apple-touch-icon-144x144.png">
   <!-- For iPhone with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/template/images/apple-touch-icon-114x114.png">
+  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/template/assets/images/apple-touch-icon-114x114.png">
   <!-- For first- and second-generation iPad: -->
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/template/images/apple-touch-icon-72x72.png">
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/template/assets/images/apple-touch-icon-72x72.png">
   <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-  <link rel="apple-touch-icon-precomposed" href="/template/images/apple-touch-icon-57x57.png">
+  <link rel="apple-touch-icon-precomposed" href="/template/assets/images/apple-touch-icon-57x57.png">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta property="og:image" content="/template/images/opengraph-image.png">
+  <meta property="og:image" content="/template/assets/images/opengraph-image.png">
 
 	<!--[if lt IE 8 ]><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application-ie7.min.css' />	<![endif]-->
 	<!--[if IE 8 ]><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application-ie.min.css' /><![endif]-->
@@ -69,7 +69,7 @@
       <div class="header-global">
         <div class="header-logo">
           <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
-            <img src="/template/images/gov.uk_logotype_crown.png" alt=""> GOV.UK
+            <img src="/template/assets/images/gov.uk_logotype_crown.png" alt=""> GOV.UK
           </a>
         </div>
       </div>
@@ -111,7 +111,7 @@
           <div class="open-government-licence">
             <h2>
               <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2" target="_blank">
-                <img src="/template/images/open-government-licence_2x.png" alt="OGL">
+                <img src="/template/assets/images/open-government-licence_2x.png" alt="OGL">
               </a>
             </h2>
 
@@ -127,7 +127,7 @@
   </footer>
   <!--end footer-->
 
-  <script src="/template/javascripts/govuk-template.js" type="text/javascript"></script>
+  <script src="/template/assets/javascripts/govuk-template.js" type="text/javascript"></script>
   <script src="{{ assetsPath }}javascripts/application.js" type="text/javascript"></script>
 </body>
 </html>

--- a/assets/error_pages/403.html
+++ b/assets/error_pages/403.html
@@ -10,18 +10,18 @@
     (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
   </script>
 
-  <!--[if gt IE 8]><!--><link href="/template/stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
-  <!--[if IE 6]><link href="/template/stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 7]><link href="/template/stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 8]><link href="/template/stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href="/template/assets/stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+  <!--[if IE 6]><link href="/template/assets/stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 7]><link href="/template/assets/stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 8]><link href="/template/assets/stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
 
-  <link href="/template/stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
+  <link href="/template/assets/stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
 
   <!--[if IE 8]>
   <script type="text/javascript">
     (function(){if(window.opera){return;}
      setTimeout(function(){var a=document,g,b={families:(g=
-     ["nta"]),urls:["/template/stylesheets/fonts-ie8.css"]},
+     ["nta"]),urls:["/template/assets/stylesheets/fonts-ie8.css"]},
      c="javascripts/vendor/goog/webfont-debug.js",d="script",
      e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
      ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
@@ -30,23 +30,23 @@
   </script>
   <![endif]-->
   <!--[if gte IE 9]><!-->
-  <link href="/template/stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" />
+  <link href="/template/assets/stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" />
   <!--<![endif]-->
 
-  <!--[if lt IE 9]><script src="/template/javascripts/ie.js" type="text/javascript"></script><![endif]-->
+  <!--[if lt IE 9]><script src="/template/assets/javascripts/ie.js" type="text/javascript"></script><![endif]-->
 
-  <link rel="shortcut icon" href="/template/images/favicon.ico" type="image/x-icon" />
+  <link rel="shortcut icon" href="/template/assets/images/favicon.ico" type="image/x-icon" />
   <!-- For third-generation iPad with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/template/images/apple-touch-icon-144x144.png">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/template/assets/images/apple-touch-icon-144x144.png">
   <!-- For iPhone with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/template/images/apple-touch-icon-114x114.png">
+  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/template/assets/images/apple-touch-icon-114x114.png">
   <!-- For first- and second-generation iPad: -->
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/template/images/apple-touch-icon-72x72.png">
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/template/assets/images/apple-touch-icon-72x72.png">
   <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-  <link rel="apple-touch-icon-precomposed" href="/template/images/apple-touch-icon-57x57.png">
+  <link rel="apple-touch-icon-precomposed" href="/template/assets/images/apple-touch-icon-57x57.png">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta property="og:image" content="/template/images/opengraph-image.png">
+  <meta property="og:image" content="/template/assets/images/opengraph-image.png">
 
 	<!--[if lt IE 8 ]><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application-ie7.min.css' />	<![endif]-->
 	<!--[if IE 8 ]><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application-ie.min.css' /><![endif]-->
@@ -69,7 +69,7 @@
       <div class="header-global">
         <div class="header-logo">
           <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
-            <img src="/template/images/gov.uk_logotype_crown.png" alt=""> GOV.UK
+            <img src="/template/assets/images/gov.uk_logotype_crown.png" alt=""> GOV.UK
           </a>
         </div>
       </div>
@@ -111,7 +111,7 @@
           <div class="open-government-licence">
             <h2>
               <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2" target="_blank">
-                <img src="/template/images/open-government-licence_2x.png" alt="OGL">
+                <img src="/template/assets/images/open-government-licence_2x.png" alt="OGL">
               </a>
             </h2>
 
@@ -127,7 +127,7 @@
   </footer>
   <!--end footer-->
 
-  <script src="/template/javascripts/govuk-template.js" type="text/javascript"></script>
+  <script src="/template/assets/javascripts/govuk-template.js" type="text/javascript"></script>
   <script src="{{ assetsPath }}javascripts/application.js" type="text/javascript"></script>
 </body>
 </html>

--- a/assets/error_pages/404.html
+++ b/assets/error_pages/404.html
@@ -10,18 +10,18 @@
     (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
   </script>
 
-  <!--[if gt IE 8]><!--><link href="/template/stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
-  <!--[if IE 6]><link href="/template/stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 7]><link href="/template/stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 8]><link href="/template/stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href="/template/assets/stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+  <!--[if IE 6]><link href="/template/assets/stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 7]><link href="/template/assets/stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 8]><link href="/template/assets/stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
 
-  <link href="/template/stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
+  <link href="/template/assets/stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
 
   <!--[if IE 8]>
   <script type="text/javascript">
     (function(){if(window.opera){return;}
      setTimeout(function(){var a=document,g,b={families:(g=
-     ["nta"]),urls:["/template/stylesheets/fonts-ie8.css"]},
+     ["nta"]),urls:["/template/assets/stylesheets/fonts-ie8.css"]},
      c="javascripts/vendor/goog/webfont-debug.js",d="script",
      e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
      ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
@@ -30,20 +30,20 @@
   </script>
   <![endif]-->
   <!--[if gte IE 9]><!-->
-  <link href="/template/stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" />
+  <link href="/template/assets/stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" />
   <!--<![endif]-->
 
-  <!--[if lt IE 9]><script src="/template/javascripts/ie.js" type="text/javascript"></script><![endif]-->
+  <!--[if lt IE 9]><script src="/template/assets/javascripts/ie.js" type="text/javascript"></script><![endif]-->
 
-  <link rel="shortcut icon" href="/template/images/favicon.ico" type="image/x-icon" />
+  <link rel="shortcut icon" href="/template/assets/images/favicon.ico" type="image/x-icon" />
   <!-- For third-generation iPad with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/template/images/apple-touch-icon-144x144.png">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/template/assets/images/apple-touch-icon-144x144.png">
   <!-- For iPhone with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/template/images/apple-touch-icon-114x114.png">
+  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/template/assets/images/apple-touch-icon-114x114.png">
   <!-- For first- and second-generation iPad: -->
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/template/images/apple-touch-icon-72x72.png">
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/template/assets/images/apple-touch-icon-72x72.png">
   <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-  <link rel="apple-touch-icon-precomposed" href="/template/images/apple-touch-icon-57x57.png">
+  <link rel="apple-touch-icon-precomposed" href="/template/assets/images/apple-touch-icon-57x57.png">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:image" content="images/opengraph-image.png">
@@ -69,7 +69,7 @@
       <div class="header-global">
         <div class="header-logo">
           <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
-            <img src="/template/images/gov.uk_logotype_crown.png" alt=""> GOV.UK
+            <img src="/template/assets/images/gov.uk_logotype_crown.png" alt=""> GOV.UK
           </a>
         </div>
       </div>
@@ -111,7 +111,7 @@
           <div class="open-government-licence">
             <h2>
               <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2" target="_blank">
-                <img src="/template/images/open-government-licence_2x.png" alt="OGL">
+                <img src="/template/assets/images/open-government-licence_2x.png" alt="OGL">
               </a>
             </h2>
 
@@ -127,7 +127,7 @@
   </footer>
   <!--end footer-->
 
-  <script src="/template/javascripts/govuk-template.js" type="text/javascript"></script>
+  <script src="/template/assets/javascripts/govuk-template.js" type="text/javascript"></script>
   <script src="{{ assetsPath }}javascripts/application.js" type="text/javascript"></script>
 </body>
 </html>

--- a/assets/error_pages/500.html
+++ b/assets/error_pages/500.html
@@ -10,18 +10,18 @@
     (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
   </script>
 
-  <!--[if gt IE 8]><!--><link href="/template/stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
-  <!--[if IE 6]><link href="/template/stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 7]><link href="/template/stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 8]><link href="/template/stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href="/template/assets/stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+  <!--[if IE 6]><link href="/template/assets/stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 7]><link href="/template/assets/stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 8]><link href="/template/assets/stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
 
-  <link href="/template/stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
+  <link href="/template/assets/stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
 
   <!--[if IE 8]>
   <script type="text/javascript">
     (function(){if(window.opera){return;}
      setTimeout(function(){var a=document,g,b={families:(g=
-     ["nta"]),urls:["/template/stylesheets/fonts-ie8.css"]},
+     ["nta"]),urls:["/template/assets/stylesheets/fonts-ie8.css"]},
      c="javascripts/vendor/goog/webfont-debug.js",d="script",
      e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
      ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
@@ -30,21 +30,21 @@
   </script>
   <![endif]-->
 
-  <!--[if gte IE 9]><!--><link href="/template/stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
-  <!--[if lt IE 9]><script src="/template/javascripts/ie.js" type="text/javascript"></script><![endif]-->
+  <!--[if gte IE 9]><!--><link href="/template/assets/stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
+  <!--[if lt IE 9]><script src="/template/assets/javascripts/ie.js" type="text/javascript"></script><![endif]-->
 
-  <link rel="shortcut icon" href="/template/images/favicon.ico" type="image/x-icon" />
+  <link rel="shortcut icon" href="/template/assets/images/favicon.ico" type="image/x-icon" />
   <!-- For third-generation iPad with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/template/images/apple-touch-icon-144x144.png">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/template/assets/images/apple-touch-icon-144x144.png">
   <!-- For iPhone with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/template/images/apple-touch-icon-114x114.png">
+  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/template/assets/images/apple-touch-icon-114x114.png">
   <!-- For first- and second-generation iPad: -->
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/template/images/apple-touch-icon-72x72.png">
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/template/assets/images/apple-touch-icon-72x72.png">
   <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-  <link rel="apple-touch-icon-precomposed" href="/template/images/apple-touch-icon-57x57.png">
+  <link rel="apple-touch-icon-precomposed" href="/template/assets/images/apple-touch-icon-57x57.png">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta property="og:image" content="/template/images/opengraph-image.png">
+  <meta property="og:image" content="/template/assets/images/opengraph-image.png">
 
 	<!--[if lt IE 8 ]><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application-ie7.min.css' /><![endif]-->
   <!--[if IE 8 ]><link rel='stylesheet' href='{{ assetsPath }}stylesheets/application-ie.min.css' /><![endif]-->
@@ -67,7 +67,7 @@
       <div class="header-global">
         <div class="header-logo">
           <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
-            <img src="/template/images/gov.uk_logotype_crown.png" alt=""> GOV.UK
+            <img src="/template/assets/images/gov.uk_logotype_crown.png" alt=""> GOV.UK
           </a>
         </div>
       </div>
@@ -107,7 +107,7 @@
           </ul>
 
           <div class="open-government-licence">
-            <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2" target="_blank"><img src="/template/images/open-government-licence_2x.png" alt="OGL"></a></h2>
+            <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2" target="_blank"><img src="/template/assets/images/open-government-licence_2x.png" alt="OGL"></a></h2>
             <p>All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2" target="_blank">Open Government Licence v2.0</a>, except where otherwise stated</p>
           </div>
         </div>
@@ -120,7 +120,7 @@
   </footer>
   <!--end footer-->
 
-  <script src="/template/javascripts/govuk-template.js" type="text/javascript"></script>
+  <script src="/template/assets/javascripts/govuk-template.js" type="text/javascript"></script>
   <script src="{{ assetsPath }}javascripts/application.js" type="text/javascript"></script>
 </body>
 </html>


### PR DESCRIPTION
## Problem
The URLs for GOV.UK Template assets were missing `/assets` resulting in 404s

## Solution
Update the URLs to point at the right files.
