### PR TITLE
Fix incorect hiding of elements.

### DIFF
--- a/assets/javascripts/modules/toggle.js
+++ b/assets/javascripts/modules/toggle.js
@@ -112,7 +112,7 @@ var toggleEvent = function ($elem) {
       if (event.which === 1 || 32) {
         var $input = $(event.target)
         if ($input.prop('tagName') === 'LABEL') $input = $input.find('input').first()
-        if ($input.prop('tagName') === 'INPUT') {
+        if ($input.prop('tagName') === 'INPUT' && $input.data('target')) {
           show($('#' + $input.data('target')))
           $inputs.not($input).each(function (i, input) {
             hide($('#' + $(input).data('target')))


### PR DESCRIPTION
Fixes a bug where clicking on an input element inside of
a previously unhidden div hides it.

<!-- Provide a short summary of the issue in the Title above. -->

<!-- Make sure your work follows to our CONTRIBUTING guidelines. -->
<!-- There's a link to them above. -->

## Problem
If there is an input box inside of a toggleable target div, clicking on it will close the div.  

### Example Screenshot
![toggle-js-bug](https://cloud.githubusercontent.com/assets/11072914/22472262/04e2452c-e7cd-11e6-8577-bd70c6845778.gif)

### Example Markup
note an input text with id of "foo"
```
          <fieldset class="form-field-group js-visible js-aria-show js-toggle"
          id="us-number"
          data-trigger="js-toggle-trigger">
            <label class="block-label" for="us-phone-number-toggle-open">Yes
              <input type="radio"
              id="us-phone-number-toggle-open"
              class="js-toggle-trigger"
              data-target="us-phone-number-open-target"
              value="yes"
              name="us-number"
              required />
            </label>
            <div id="us-phone-number-open-target" class="panel-indent hidden">
              <h2>Open</h2>
              <p>Example paragraph text</p>
              <input id="foo" type="text" name="foo"/>
            </div>
            <label class="block-label" for="us-phone-number-toggle-close">No
              <input type="radio"
              id="us-phone-number-toggle-close"
              class="js-toggle-trigger"
              data-target="us-phone-number-close-target"
              value="no"
              name="us-number"
              required/>
            </label>
            <div id="us-phone-number-close-target" class="panel-indent hidden">
              <h2>Close</h2>
              <p>Example paragraph text</p>
            </div>
          </fieldset>
```

## Solution
only hide when clicked element had a data-target attribute

### Example Screenshot
![after_fix](https://cloud.githubusercontent.com/assets/11072914/22472371/54ac0b6a-e7cd-11e6-9311-61b0fe0fd35f.gif)

