### PR TITLE
Sdt 162 add interaction for vrt

### DIFF
--- a/gulpfile.js/util/backstop/backstop.template.json
+++ b/gulpfile.js/util/backstop/backstop.template.json
@@ -1,4 +1,5 @@
 {
+  "debug": false,
   "onReadyScript": "./gulpfile.js/util/backstop/onReady.js",
   "id": "assets-frontend-vrt",
   "viewports": [
@@ -23,7 +24,6 @@
   "casperFlags": [],
   "engine": "phantomjs",
   "report": ["browser", "CI"],
-  "debug": false,
   "resembleOutputOptions": {
     "errorColor": {
       "red": 255,

--- a/gulpfile.js/util/backstop/backstop.template.json
+++ b/gulpfile.js/util/backstop/backstop.template.json
@@ -1,4 +1,5 @@
 {
+  "onReadyScript": "./gulpfile.js/util/backstop/onReady.js",
   "id": "assets-frontend-vrt",
   "viewports": [
     {

--- a/gulpfile.js/util/backstop/backstop.template.json
+++ b/gulpfile.js/util/backstop/backstop.template.json
@@ -5,8 +5,8 @@
   "viewports": [
     {
       "name": "desktop",
-      "width": 770,
-      "height": 768
+      "width": 1280,
+      "height": 800
     }
   ],
   "scenarios": [],

--- a/gulpfile.js/util/backstop/onReady.js
+++ b/gulpfile.js/util/backstop/onReady.js
@@ -1,0 +1,29 @@
+/* eslint-env jquery */
+module.exports = function (casper, scenario, vp) {
+  var scenarioLabel = scenario.label.toLowerCase()
+
+  if (scenarioLabel === 'add-remove') {
+    casper.evaluate(function () {
+      // Use jQuery click() so the addRemove.js click implementation and its preventDefault() is fired
+      $('a[data-add-btn]').click()
+    })
+  }
+
+  if (scenarioLabel === 'autocomplete') {
+    casper.sendKeys('#country-code-auto-complete', 'united kingdom')
+  }
+
+  if (scenarioLabel === 'details') {
+    casper.evaluate(function () {
+      var detailElements = Array.prototype.slice.call(document.querySelectorAll('summary'))
+
+      detailElements.forEach(function (element) {
+        element.click()
+      })
+    })
+  }
+
+  if (scenarioLabel === 'form') {
+    casper.click('#continue')
+  }
+}


### PR DESCRIPTION
# Interact with JavaScript components

## Problem
Some of our components need to be interacted with before a screen capture is performed
- Details elements opened
- AutoComplete with text in the input
- Add remove with more than one input
- Form errors fired

## Solution
Use the global `onReady` functionality available via `backstopJS` to interact with components when you are on the relevant page

- This is relying on the `label` of a page as defined in the `scenarios` backstop object which is prior work that potentially [needs refactoring](https://github.com/hmrc/assets-frontend/blob/master/gulpfile.js/util/backstop/buildScenarios.js#L55)
- This is tightly coupled to the Component Library and this work will be potentially refactored out

## Example Screenshots

## Add/Remove after add button pressed
![assets-frontend-vrt_add-remove_0_comp-lib-pattern-component_0_desktop](https://cloud.githubusercontent.com/assets/2305016/22655402/fa9c8040-ec87-11e6-8d2f-e80af96c8d44.png)

## AutoComplete with "united kingdom" typed in
![assets-frontend-vrt_autocomplete_0_comp-lib-pattern-component_0_desktop](https://cloud.githubusercontent.com/assets/2305016/22655405/fab100ba-ec87-11e6-92fb-c1774a2e4d47.png)

## Details element opened
![assets-frontend-vrt_details_0_comp-lib-pattern-component_0_desktop](https://cloud.githubusercontent.com/assets/2305016/22655403/faa2489a-ec87-11e6-973d-343164928f0e.png)

## Form errors fired
![assets-frontend-vrt_form_18_comp-lib-pattern-component__n18_0_desktop](https://cloud.githubusercontent.com/assets/2305016/22655404/faaa2e20-ec87-11e6-8b9a-b5aa3556c76b.png)
