### PR TITLE
Lint config files before watch task and fix error

### DIFF
--- a/gulpfile.js/tasks/default.js
+++ b/gulpfile.js/tasks/default.js
@@ -5,7 +5,7 @@ var runSequence = require('run-sequence')
 
 gulp.task('default', ['clean'], function () {
   runSequence(
-    ['sass', 'images', 'svg', 'concatEncryption', 'error-pages'],
+    ['lint:config', 'sass', 'images', 'svg', 'concatEncryption', 'error-pages'],
     'modernizr',
     'component-library',
     'watch'

--- a/gulpfile.js/tasks/watch.js
+++ b/gulpfile.js/tasks/watch.js
@@ -11,7 +11,7 @@ gulp.task('watch', ['watchify', 'server'], function (callback) {
   gulp.watch(config.scripts.gulpTasks, ['lint:config'])
   gulp.watch([
     config.scripts.src,
-    config.scripts.entryPoint,
+    config.scripts.entryPoint
   ], ['component-library'])
   gulp.watch(config.test.src, ['test'])
   gulp.watch(config.sass.src, ['sass', 'component-library'])


### PR DESCRIPTION
# Eslint trailing comma fix

We had an eslint error being reported on a trailing comma, this fixes that error