### PR TITLE
Add changelog task and run it as part of build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ sudo: false
 language: node_js
 node_js:
   - 4.4.5
-before_install: npm i -g npm@2.4.1
+before_install: git fetch origin master:master
 script: ./server.sh build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- `standard` formatting for JavaScript [#736]
-- Interaction for visual regression tests [#748]
+- [standardjs](http://standardjs.com) formatting for JavaScript [#736](https://github.com/hmrc/assets-frontend/pull/736)
+- Interaction for visual regression tests [#748](https://github.com/hmrc/assets-frontend/pull/748)
+- CHANGELOG.md update check [#757](https://github.com/hmrc/assets-frontend/pull/757)
 
 ## [2.241.0] - 2017-01-20
 ### Fixed

--- a/gulpfile.js/tasks/build.js
+++ b/gulpfile.js/tasks/build.js
@@ -8,6 +8,7 @@ gulp.task('build', ['clean', 'test'], function () {
   global.location = undefined
 
   runSequence(
+    'changelog',
     ['sass', 'images', 'svg', 'error-pages'],
     ['browserify', 'concatEncryption'],
     'modernizr',

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -20,7 +20,7 @@ var runCommand = function (cmd) {
 
 var getCurrentBranch = function (travisBranch) {
   if (travisBranch) {
-    return travisBranch
+    return Promise.resolve(travisBranch)
   }
 
   var cmd = 'git symbolic-ref HEAD | sed \'s!refs/heads/!!\''
@@ -45,7 +45,7 @@ var checkForChangelog = function (files) {
 }
 
 gulp.task('changelog', function (done) {
-  getCurrentBranch(process.env.TRAVIS_PULL_REQUEST_BRANCH)
+  getCurrentBranch(process.env.TRAVIS_BRANCH)
     .then(getChangedFiles)
     .then(checkForChangelog)
     .catch(done)

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -1,0 +1,59 @@
+'use strict'
+
+var gulp = require('gulp')
+var gutil = require('gulp-util')
+var proc = require('child_process')
+
+var runCommand = function (cmd) {
+  return new Promise(function (resolve, reject) {
+    proc.exec(cmd, function (err, stdout, stderr) {
+      if (err) {
+        reject(err)
+      } else if (stderr) {
+        reject(stderr)
+      } else {
+        resolve(stdout)
+      }
+    })
+  })
+}
+
+var getCurrentBranch = function (travisBranch) {
+  if (travisBranch) {
+    return travisBranch
+  }
+
+  var cmd = 'git symbolic-ref HEAD | sed \'s!refs/heads/!!\''
+  return runCommand(cmd)
+}
+
+var getChangedFiles = function (branch) {
+  if (!branch) {
+    return new Error(gutil.log(gutil.colors.red('ERROR: No branch given')))
+  }
+
+  var cmd = 'git diff --name-only master ' + branch
+  return runCommand(cmd)
+}
+
+var checkForChangelog = function (files) {
+  if (!files.includes('CHANGELOG.md')) {
+    throw new Error(gutil.log(gutil.colors.red('ERROR: No CHANGELOG.md update')))
+  }
+
+  return true
+}
+
+gulp.task('changelog', function (done) {
+  getCurrentBranch(process.env.TRAVIS_PULL_REQUEST_BRANCH)
+    .then(getChangedFiles)
+    .then(checkForChangelog)
+    .catch(done)
+})
+
+module.exports = {
+  runCommand: runCommand,
+  getCurrentBranch: getCurrentBranch,
+  getChangedFiles: getChangedFiles,
+  checkForChangelog: checkForChangelog
+}

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -37,18 +37,26 @@ var getChangedFiles = function (branch) {
 }
 
 var checkForChangelog = function (files) {
+  console.log('files', files)
+
   if (!files.includes('CHANGELOG.md')) {
     throw new Error(gutil.log(gutil.colors.red('ERROR: No CHANGELOG.md update')))
   }
 
-  return true
+  return Promise.resolve(true)
 }
 
 gulp.task('changelog', function (done) {
   getCurrentBranch(process.env.TRAVIS_BRANCH)
     .then(getChangedFiles)
     .then(checkForChangelog)
-    .catch(done)
+    .then(function () {
+      done()
+    })
+    .catch(function (err) {
+      console.log('err', err)
+      done(err)
+    })
 })
 
 module.exports = {

--- a/gulpfile.js/tests/changelog.test.js
+++ b/gulpfile.js/tests/changelog.test.js
@@ -1,0 +1,87 @@
+var test = require('tape')
+var sinon = require('sinon')
+var gutil = require('gulp-util')
+var proc = require('child_process')
+var changelog = require('../tasks/changelog')
+
+test('changelog - runCommand', function (t) {
+  t.plan(2)
+
+  changelog.runCommand()
+    .catch(function (data) {
+      t.ok(data instanceof Error, 'returns an Error if the command fails')
+    })
+
+  changelog.runCommand('echo "test"')
+    .then(function (command) {
+      t.equal(command, 'test\n', 'should return a Promise if given a command to run')
+    })
+})
+
+test('changelog - getCurrentBranch', function (t) {
+  t.plan(4)
+
+  var execStub = sinon.stub(proc, 'exec').callsArgWith(1, null, 'test', null)
+
+  var givenBranch = changelog.getCurrentBranch('master')
+  var currentBranch = changelog.getCurrentBranch()
+
+  t.throws(function () {
+    givenBranch.then()
+  }, TypeError, 'does not return a Promise when given a branch name')
+
+  t.equal(givenBranch, 'master', 'returns the branch when given one')
+
+  t.ok(currentBranch.then(), 'returns a Promise when not given a branch name')
+
+  currentBranch.then(function (branch) {
+    t.equal(branch, 'test', 'returns the Promise value exactly')
+  })
+
+  proc.exec.restore()
+})
+
+test('changelog - getChangedFiles', function (t) {
+  t.plan(3)
+
+  sinon.stub(gutil, 'log')
+
+  var files = 'file-one.html\n' +
+    'file-two.js\n' +
+    'file-three'
+
+  var execStub = sinon.stub(proc, 'exec').callsArgWith(1, null, files, null)
+
+  var noBranch = changelog.getChangedFiles(null)
+  var changedFiles = changelog.getChangedFiles('branch')
+
+  t.throws(function () {
+    noBranch.then()
+  }, TypeError, 'throws an error when not given a branch')
+
+  t.ok(changedFiles.then(), 'returns a Promise when given a branch')
+
+  changedFiles.then(function (value) {
+    t.equal(value, files, 'returns the Promise value exactly')
+  })
+
+  gutil.log.restore()
+  proc.exec.restore()
+})
+
+test('changelog - checkForChangelog', function (t) {
+  t.plan(2)
+
+  sinon.stub(gutil, 'log')
+
+  t.true(
+    changelog.checkForChangelog('CHANGELOG.md'),
+    'returns true when CHANGELOG.md is found'
+  )
+
+  t.throws(function () {
+    changelog.checkForChangelog('CHANGELOG')
+  }, Error, 'throws an Error when CHANGELOG.md cannot be found')
+
+  gutil.log.restore()
+})

--- a/gulpfile.js/tests/changelog.test.js
+++ b/gulpfile.js/tests/changelog.test.js
@@ -19,23 +19,23 @@ test('changelog - runCommand', function (t) {
 })
 
 test('changelog - getCurrentBranch', function (t) {
-  t.plan(4)
+  t.plan(5)
 
   var execStub = sinon.stub(proc, 'exec').callsArgWith(1, null, 'test', null)
 
   var givenBranch = changelog.getCurrentBranch('master')
   var currentBranch = changelog.getCurrentBranch()
 
-  t.throws(function () {
-    givenBranch.then()
-  }, TypeError, 'does not return a Promise when given a branch name')
-
-  t.equal(givenBranch, 'master', 'returns the branch when given one')
-
+  t.ok(givenBranch.then(), 'returns a Promise when given a branch name')
   t.ok(currentBranch.then(), 'returns a Promise when not given a branch name')
+  t.ok(execStub.calledOnce, 'only calls git when not given a branch')
+
+  givenBranch.then(function (branch) {
+    t.equal(branch, 'master', 'returns the branch name exactly when given a branch')
+  })
 
   currentBranch.then(function (branch) {
-    t.equal(branch, 'test', 'returns the Promise value exactly')
+    t.equal(branch, 'test', 'returns the result of git exactly when not given a branch')
   })
 
   proc.exec.restore()
@@ -44,13 +44,12 @@ test('changelog - getCurrentBranch', function (t) {
 test('changelog - getChangedFiles', function (t) {
   t.plan(3)
 
-  sinon.stub(gutil, 'log')
-
   var files = 'file-one.html\n' +
     'file-two.js\n' +
     'file-three'
 
-  var execStub = sinon.stub(proc, 'exec').callsArgWith(1, null, files, null)
+  sinon.stub(gutil, 'log')
+  sinon.stub(proc, 'exec').callsArgWith(1, null, files, null)
 
   var noBranch = changelog.getChangedFiles(null)
   var changedFiles = changelog.getChangedFiles('branch')

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
   "devDependencies": {
     "gulp-standard": "^8.0.3",
     "gulp-tape": "0.0.9",
+    "sinon": "^1.17.7",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.3"
   }


### PR DESCRIPTION
## Problem

Having added a CHANGELOG.md we need a way to remind people to update it when they make a pull request.

## Solution

Add a gulp task that breaks the build if the CHANGELOG.md hasn't been updated as part of the pull request.

### Example Screenshot

```
> gulp "changelog"

[12:47:08] Using gulpfile ~/HMRC/assets-frontend/gulpfile.js
[12:47:08] Starting 'changelog'...
[12:47:08] ERROR: No CHANGELOG.md update
[12:47:08] 'changelog' errored after 69 ms
```