### PR TITLE
Add bail to break CI builds when tests fail

### DIFF
--- a/gulpfile.js/tasks/test.js
+++ b/gulpfile.js/tasks/test.js
@@ -20,6 +20,7 @@ var karmaTask = function (done) {
 gulp.task('test:gulpTasks', function () {
   return gulp.src(config.gulpTasks)
     .pipe(tape({
+      bail: true,
       reporter: tapSpec()
     }))
 })

--- a/gulpfile.js/tests/mergeObj.test.js
+++ b/gulpfile.js/tests/mergeObj.test.js
@@ -8,7 +8,7 @@ test('mergeObj - objects should merged as expected', function (t) {
 
   t.plan(4)
 
-  t.equal(typeof resultObj.parent, 'string', 'parent key value should be a string')
+  t.notEqual(typeof resultObj.parent, 'string', 'parent key value should be a string')
   t.equal(resultObj.parent, 'parent', 'parent key value should equal "parent"')
   t.equal(typeof resultObj.child, 'string', 'child value should be a string')
   t.equal(resultObj.child, 'child', 'child value should equal "child"')

--- a/gulpfile.js/tests/mergeObj.test.js
+++ b/gulpfile.js/tests/mergeObj.test.js
@@ -8,7 +8,7 @@ test('mergeObj - objects should merged as expected', function (t) {
 
   t.plan(4)
 
-  t.notEqual(typeof resultObj.parent, 'string', 'parent key value should be a string')
+  t.equal(typeof resultObj.parent, 'string', 'parent key value should be a string')
   t.equal(resultObj.parent, 'parent', 'parent key value should equal "parent"')
   t.equal(typeof resultObj.child, 'string', 'child value should be a string')
   t.equal(resultObj.child, 'child', 'child value should equal "child"')


### PR DESCRIPTION
## Problem

Failing gulp task tests aren't breaking builds on CI

### Example

From https://travis-ci.org/hmrc/assets-frontend/builds/206974831#L782:

![image](https://cloud.githubusercontent.com/assets/1752124/23508231/ff2bf90c-ff50-11e6-9b52-62d6cec63c1f.png)

## Solution

Add a bail flag to tape to make sure that the build fails on CI

### Example

From https://travis-ci.org/hmrc/assets-frontend/builds/206988745#L679

![image](https://cloud.githubusercontent.com/assets/1752124/23508479/32287212-ff52-11e6-892a-d0ddb45b3160.png)
