### PR TITLE
Check that the change log has been updated as part of a PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ sudo: false
 language: node_js
 node_js:
   - 4.4.5
-before_install: npm i -g npm@2.4.1
+before_install: git fetch origin master:master
 script: ./server.sh build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- `standard` formatting for JavaScript [#736]
-- Interaction for visual regression tests [#748]
+- [standardjs](http://standardjs.com) formatting for JavaScript [#736](https://github.com/hmrc/assets-frontend/pull/736)
+- Interaction for visual regression tests [#748](https://github.com/hmrc/assets-frontend/pull/748)
+- Check for a `CHANGELOG.md` update during the build [#759](https://github.com/hmrc/assets-frontend/pull/759)
 
 ## [2.241.0] - 2017-01-20
 ### Fixed

--- a/gulpfile.js/tasks/build.js
+++ b/gulpfile.js/tasks/build.js
@@ -8,6 +8,7 @@ gulp.task('build', ['clean', 'test'], function () {
   global.location = undefined
 
   runSequence(
+    'changelog',
     ['sass', 'images', 'svg', 'error-pages'],
     ['browserify', 'concatEncryption'],
     'modernizr',

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -34,7 +34,7 @@ var getCurrentCommit = function (commit) {
 
 var getChangedFiles = function (commit) {
   if (!commit) {
-    return new Error(gutil.log(gutil.colors.red('ERROR: No commit given')))
+    return Promise.reject(new Error('No commit given'))
   }
 
   var cmd = 'git diff --name-only master ' + commit
@@ -43,7 +43,7 @@ var getChangedFiles = function (commit) {
 
 var checkForChangelog = function (files) {
   if (!files.includes('CHANGELOG.md')) {
-    throw new Error(gutil.log(gutil.colors.red('ERROR: No CHANGELOG.md update')))
+    return Promise.reject(new Error('No CHANGELOG.md update'))
   }
 
   return Promise.resolve(true)
@@ -57,6 +57,7 @@ gulp.task('changelog', function (done) {
       done()
     })
     .catch(function (err) {
+      gutil.log(gutil.colors.red(err))
       done(err)
     })
 })

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -30,17 +30,17 @@ var getCurrentCommit = function (commit) {
 }
 
 var getChangedFiles = function (commit) {
-  if (commit) {
-    var cmd = 'git diff --name-only master ' + commit
-    return runCommand(cmd)
+  if (!commit) {
+    throw new Error('No commit given')
   }
 
-  return Promise.reject(new Error('No commit given'))
+  var cmd = 'git diff --name-only master ' + commit
+  return runCommand(cmd)
 }
 
 var checkForChangelog = function (files) {
   if (!files.includes('CHANGELOG.md')) {
-    return Promise.reject(new Error('No CHANGELOG.md update'))
+    throw new Error('No CHANGELOG.md update')
   }
 
   return true

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -20,7 +20,7 @@ var runCommand = function (cmd) {
 
 var getCurrentBranch = function (travisBranch) {
   if (travisBranch) {
-    return travisBranch
+    return Promise.resolve(travisBranch)
   }
 
   var cmd = 'git symbolic-ref HEAD | sed \'s!refs/heads/!!\''
@@ -45,7 +45,7 @@ var checkForChangelog = function (files) {
 }
 
 gulp.task('changelog', function (done) {
-  getCurrentBranch(process.env.TRAVIS_PULL_REQUEST_BRANCH)
+  getCurrentBranch(process.env.TRAVIS_BRANCH)
     .then(getChangedFiles)
     .then(checkForChangelog)
     .catch(done)

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -24,21 +24,18 @@ var getCurrentCommit = function (commit) {
       resolve(commit)
     } else {
       var cmd = 'git rev-parse HEAD'
-      runCommand(cmd)
-        .then(function (commit) {
-          resolve(commit)
-        })
+      runCommand(cmd).then(resolve)
     }
   })
 }
 
 var getChangedFiles = function (commit) {
-  if (!commit) {
-    return Promise.reject(new Error('No commit given'))
+  if (commit) {
+    var cmd = 'git diff --name-only master ' + commit
+    return runCommand(cmd)
   }
 
-  var cmd = 'git diff --name-only master ' + commit
-  return runCommand(cmd)
+  return Promise.reject(new Error('No commit given'))
 }
 
 var checkForChangelog = function (files) {
@@ -46,7 +43,7 @@ var checkForChangelog = function (files) {
     return Promise.reject(new Error('No CHANGELOG.md update'))
   }
 
-  return Promise.resolve(true)
+  return true
 }
 
 gulp.task('changelog', function (done) {

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -1,0 +1,59 @@
+'use strict'
+
+var gulp = require('gulp')
+var gutil = require('gulp-util')
+var proc = require('child_process')
+
+var runCommand = function (cmd) {
+  return new Promise(function (resolve, reject) {
+    proc.exec(cmd, function (err, stdout, stderr) {
+      if (err) {
+        reject(err)
+      } else if (stderr) {
+        reject(stderr)
+      } else {
+        resolve(stdout)
+      }
+    })
+  })
+}
+
+var getCurrentBranch = function (travisBranch) {
+  if (travisBranch) {
+    return travisBranch
+  }
+
+  var cmd = 'git symbolic-ref HEAD | sed \'s!refs/heads/!!\''
+  return runCommand(cmd)
+}
+
+var getChangedFiles = function (branch) {
+  if (!branch) {
+    return new Error(gutil.log(gutil.colors.red('ERROR: No branch given')))
+  }
+
+  var cmd = 'git diff --name-only master ' + branch
+  return runCommand(cmd)
+}
+
+var checkForChangelog = function (files) {
+  if (!files.includes('CHANGELOG.md')) {
+    throw new Error(gutil.log(gutil.colors.red('ERROR: No CHANGELOG.md update')))
+  }
+
+  return true
+}
+
+gulp.task('changelog', function (done) {
+  getCurrentBranch(process.env.TRAVIS_PULL_REQUEST_BRANCH)
+    .then(getChangedFiles)
+    .then(checkForChangelog)
+    .catch(done)
+})
+
+module.exports = {
+  runCommand: runCommand,
+  getCurrentBranch: getCurrentBranch,
+  getChangedFiles: getChangedFiles,
+  checkForChangelog: checkForChangelog
+}

--- a/gulpfile.js/tests/changelog.test.js
+++ b/gulpfile.js/tests/changelog.test.js
@@ -18,24 +18,25 @@ test('changelog - runCommand', function (t) {
     })
 })
 
-test('changelog - getCurrentBranch', function (t) {
+test('changelog - getCurrentCommit', function (t) {
   t.plan(5)
 
-  var execStub = sinon.stub(proc, 'exec').callsArgWith(1, null, 'test', null)
+  var sha = 'abcd123'
+  var execStub = sinon.stub(proc, 'exec').callsArgWith(1, null, sha, null)
 
-  var givenBranch = changelog.getCurrentBranch('master')
-  var currentBranch = changelog.getCurrentBranch()
+  var givenCommit = changelog.getCurrentCommit(sha)
+  var currentCommit = changelog.getCurrentCommit()
 
-  t.ok(givenBranch.then(), 'returns a Promise when given a branch name')
-  t.ok(currentBranch.then(), 'returns a Promise when not given a branch name')
-  t.ok(execStub.calledOnce, 'only calls git when not given a branch')
+  t.ok(givenCommit.then(), 'returns a Promise when given a commit sha')
+  t.ok(currentCommit.then(), 'returns a Promise when not given a commit sha')
+  t.ok(execStub.calledOnce, 'only calls git when not given a commit sha')
 
-  givenBranch.then(function (branch) {
-    t.equal(branch, 'master', 'returns the branch name exactly when given a branch')
+  givenCommit.then(function (branch) {
+    t.equal(branch, sha, 'returns the result of git exactly when given a sha')
   })
 
-  currentBranch.then(function (branch) {
-    t.equal(branch, 'test', 'returns the result of git exactly when not given a branch')
+  currentCommit.then(function (branch) {
+    t.equal(branch, sha, 'returns the result of git exactly when not given a sha')
   })
 
   proc.exec.restore()
@@ -51,8 +52,8 @@ test('changelog - getChangedFiles', function (t) {
   sinon.stub(gutil, 'log')
   sinon.stub(proc, 'exec').callsArgWith(1, null, files, null)
 
-  var noBranch = changelog.getChangedFiles(null)
-  var changedFiles = changelog.getChangedFiles('branch')
+  var noBranch = changelog.getChangedFiles()
+  var changedFiles = changelog.getChangedFiles('master...test')
 
   t.throws(function () {
     noBranch.then()

--- a/gulpfile.js/tests/changelog.test.js
+++ b/gulpfile.js/tests/changelog.test.js
@@ -53,11 +53,11 @@ test('changelog - getChangedFiles', function (t) {
   sinon.stub(proc, 'exec').callsArgWith(1, null, files, null)
 
   var noBranch = changelog.getChangedFiles()
-  var changedFiles = changelog.getChangedFiles('master...test')
+  var changedFiles = changelog.getChangedFiles('test')
 
-  t.throws(function () {
-    noBranch.then()
-  }, TypeError, 'throws an error when not given a branch')
+  noBranch.catch(function (err) {
+    t.ok(err instanceof Error, 'throws an error when not given a branch')
+  })
 
   t.ok(changedFiles.then(), 'returns a Promise when given a branch')
 
@@ -72,16 +72,21 @@ test('changelog - getChangedFiles', function (t) {
 test('changelog - checkForChangelog', function (t) {
   t.plan(2)
 
+  var files = 'file-one.html\n' +
+    'CHANGELOG.md\n' +
+    'file-three'
+
   sinon.stub(gutil, 'log')
 
   t.true(
-    changelog.checkForChangelog('CHANGELOG.md'),
+    changelog.checkForChangelog(files),
     'returns true when CHANGELOG.md is found'
   )
 
-  t.throws(function () {
-    changelog.checkForChangelog('CHANGELOG')
-  }, Error, 'throws an Error when CHANGELOG.md cannot be found')
+  changelog.checkForChangelog('CHANGELOG')
+    .catch(function (err) {
+      t.ok(err instanceof Error, 'returns an Error when CHANGELOG.md cannot be found')
+    })
 
   gutil.log.restore()
 })

--- a/gulpfile.js/tests/changelog.test.js
+++ b/gulpfile.js/tests/changelog.test.js
@@ -44,7 +44,7 @@ test('changelog - getCurrentCommit', function (t) {
 })
 
 test('changelog - getChangedFiles', function (t) {
-  t.plan(4)
+  t.plan(3)
 
   var files = 'file-one.html\n' +
     'file-two.js\n' +
@@ -52,13 +52,12 @@ test('changelog - getChangedFiles', function (t) {
 
   sinon.stub(proc, 'exec').callsArgWith(1, null, files, null)
 
-  var noBranch = changelog.getChangedFiles()
+  // var noCommit = changelog.getChangedFiles()
   var changedFiles = changelog.getChangedFiles('test')
 
-  noBranch.catch(function (err) {
-    t.ok(err instanceof Error, 'returns an error when not given a branch')
-    t.ok(err.message.includes('No commit given'), 'returns an approptiate error message')
-  })
+  t.throws(function() {
+    changelog.getChangedFiles()
+  }, /No commit given/, 'throws an error when not given a branch')
 
   t.ok(changedFiles.then(), 'returns a Promise when given a branch')
 
@@ -70,20 +69,22 @@ test('changelog - getChangedFiles', function (t) {
 })
 
 test('changelog - checkForChangelog', function (t) {
-  t.plan(3)
+  t.plan(2)
 
-  var files = 'file-one.html\n' +
+  var files1 = 'file-one.html\n' +
     'CHANGELOG.md\n' +
-    'file-three'
+    'file-two.js'
+
+  var files2 = 'file-one.html\n' +
+    'file-two.js\n' +
+    'file-three.css'
 
   t.true(
-    changelog.checkForChangelog(files),
+    changelog.checkForChangelog(files1),
     'returns true when CHANGELOG.md is found'
   )
 
-  changelog.checkForChangelog('CHANGELOG')
-    .catch(function (err) {
-      t.ok(err instanceof Error, 'returns an Error when CHANGELOG.md cannot be found')
-      t.equal(err.message, 'No CHANGELOG.md update', 'returns an approptiate error message')
-    })
+  t.throws(function () {
+    changelog.checkForChangelog(files2)
+  }, /No CHANGELOG\.md update/, 'returns an Error when CHANGELOG.md cannot be found')
 })

--- a/gulpfile.js/tests/changelog.test.js
+++ b/gulpfile.js/tests/changelog.test.js
@@ -1,0 +1,87 @@
+var test = require('tape')
+var sinon = require('sinon')
+var gutil = require('gulp-util')
+var proc = require('child_process')
+var changelog = require('../tasks/changelog')
+
+test('changelog - runCommand', function (t) {
+  t.plan(2)
+
+  changelog.runCommand()
+    .catch(function (data) {
+      t.ok(data instanceof Error, 'returns an Error if the command fails')
+    })
+
+  changelog.runCommand('echo "test"')
+    .then(function (command) {
+      t.equal(command, 'test\n', 'should return a Promise if given a command to run')
+    })
+})
+
+test('changelog - getCurrentBranch', function (t) {
+  t.plan(4)
+
+  var execStub = sinon.stub(proc, 'exec').callsArgWith(1, null, 'test', null)
+
+  var givenBranch = changelog.getCurrentBranch('master')
+  var currentBranch = changelog.getCurrentBranch()
+
+  t.throws(function () {
+    givenBranch.then()
+  }, TypeError, 'does not return a Promise when given a branch name')
+
+  t.equal(givenBranch, 'master', 'returns the branch when given one')
+
+  t.ok(currentBranch.then(), 'returns a Promise when not given a branch name')
+
+  currentBranch.then(function (branch) {
+    t.equal(branch, 'test', 'returns the Promise value exactly')
+  })
+
+  proc.exec.restore()
+})
+
+test('changelog - getChangedFiles', function (t) {
+  t.plan(3)
+
+  sinon.stub(gutil, 'log')
+
+  var files = 'file-one.html\n' +
+    'file-two.js\n' +
+    'file-three'
+
+  var execStub = sinon.stub(proc, 'exec').callsArgWith(1, null, files, null)
+
+  var noBranch = changelog.getChangedFiles(null)
+  var changedFiles = changelog.getChangedFiles('branch')
+
+  t.throws(function () {
+    noBranch.then()
+  }, TypeError, 'throws an error when not given a branch')
+
+  t.ok(changedFiles.then(), 'returns a Promise when given a branch')
+
+  changedFiles.then(function (value) {
+    t.equal(value, files, 'returns the Promise value exactly')
+  })
+
+  gutil.log.restore()
+  proc.exec.restore()
+})
+
+test('changelog - checkForChangelog', function (t) {
+  t.plan(2)
+
+  sinon.stub(gutil, 'log')
+
+  t.true(
+    changelog.checkForChangelog('CHANGELOG.md'),
+    'returns true when CHANGELOG.md is found'
+  )
+
+  t.throws(function () {
+    changelog.checkForChangelog('CHANGELOG')
+  }, Error, 'throws an Error when CHANGELOG.md cannot be found')
+
+  gutil.log.restore()
+})

--- a/gulpfile.js/tests/changelog.test.js
+++ b/gulpfile.js/tests/changelog.test.js
@@ -19,23 +19,23 @@ test('changelog - runCommand', function (t) {
 })
 
 test('changelog - getCurrentBranch', function (t) {
-  t.plan(4)
+  t.plan(5)
 
   var execStub = sinon.stub(proc, 'exec').callsArgWith(1, null, 'test', null)
 
   var givenBranch = changelog.getCurrentBranch('master')
   var currentBranch = changelog.getCurrentBranch()
 
-  t.throws(function () {
-    givenBranch.then()
-  }, TypeError, 'does not return a Promise when given a branch name')
-
-  t.equal(givenBranch, 'master', 'returns the branch when given one')
-
+  t.ok(givenBranch.then(), 'returns a Promise when given a branch name')
   t.ok(currentBranch.then(), 'returns a Promise when not given a branch name')
+  t.ok(execStub.calledOnce, 'only calls git when not given a branch')
+
+  givenBranch.then(function (branch) {
+    t.equal(branch, 'master', 'returns the branch name exactly when given a branch')
+  })
 
   currentBranch.then(function (branch) {
-    t.equal(branch, 'test', 'returns the Promise value exactly')
+    t.equal(branch, 'test', 'returns the result of git exactly when not given a branch')
   })
 
   proc.exec.restore()
@@ -44,13 +44,12 @@ test('changelog - getCurrentBranch', function (t) {
 test('changelog - getChangedFiles', function (t) {
   t.plan(3)
 
-  sinon.stub(gutil, 'log')
-
   var files = 'file-one.html\n' +
     'file-two.js\n' +
     'file-three'
 
-  var execStub = sinon.stub(proc, 'exec').callsArgWith(1, null, files, null)
+  sinon.stub(gutil, 'log')
+  sinon.stub(proc, 'exec').callsArgWith(1, null, files, null)
 
   var noBranch = changelog.getChangedFiles(null)
   var changedFiles = changelog.getChangedFiles('branch')

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
   "devDependencies": {
     "gulp-standard": "^8.0.3",
     "gulp-tape": "0.0.9",
+    "sinon": "^1.17.7",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.3"
   }


### PR DESCRIPTION
## Problem

Having added a `CHANGELOG.md` we need a way to remind contributors to update it when they make a pull request.

## Solution

Add a gulp task that breaks the build if `CHANGELOG.md` hasn't been updated as part of the pull request.

- Get the commit being built
- Diff the commit against master for the names of the files that have changed
- Check to see if `CHANGELOG.md` appears in that list and throw an error if it does

**Failing**: https://travis-ci.org/hmrc/assets-frontend/builds/207461966#L1140:

![image](https://cloud.githubusercontent.com/assets/1752124/23564279/24c3865e-004a-11e7-89c0-4998976fc91d.png)

**Passing**: https://travis-ci.org/hmrc/assets-frontend/builds/207466855#L1141

![image](https://cloud.githubusercontent.com/assets/1752124/23564762/8d8d2e8c-004b-11e7-8b60-f0d2b8c6aaf3.png)

