### PR TITLE
Fixed the youtube failing visual regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `standard` formatting for JavaScript [#736]
 - Interaction for visual regression tests [#748]
 
+### Fixed
+- Fixed the youtube failing visual regression test [#761]
+
 ## [2.241.0] - 2017-01-20
 ### Fixed
 - URLs for `govuk_template` assets in nginx error pages [#735]

--- a/gulpfile.js/util/backstop/onReady.js
+++ b/gulpfile.js/util/backstop/onReady.js
@@ -26,4 +26,23 @@ module.exports = function (casper, scenario, vp) {
   if (scenarioLabel === 'form') {
     casper.click('#continue')
   }
+
+  if (scenarioLabel === 'youtube-player') {
+    casper.evaluate(function () {
+      var youTubePlayerContainerElement = document.querySelector('.youtube-player-container')
+      var maskingDivElement = document.createElement('div')
+
+      maskingDivElement.style.cssText = [
+        'position: absolute;',
+        'top: 0;',
+        'left: 0;',
+        'width: 100%;',
+        'height: 100%;',
+        'background-color: #000;',
+        'z-index: 1000;'
+      ].join('')
+
+      youTubePlayerContainerElement.insertBefore(maskingDivElement, youTubePlayerContainerElement.firstElementChild)
+    })
+  }
 }


### PR DESCRIPTION
When running visual regression tests the [Youtube video player](http://hmrc.github.io/assets-frontend/section-youtube-player.html) was failing due to differences on the static between `npm run vrt:baseline` and `npm run vrt:compare`. 

## Problem
Allows the youtube video player visual regression tests to pass.

### Example Screenshot
<!-- Add an image or gif to help illustrate the point. -->
![screen shot 2017-03-07 at 10 00 22](https://cloud.githubusercontent.com/assets/10154302/23651464/81924d18-031d-11e7-8345-a209c72fad72.png)

## Solution
<!-- Describe your changes -->
We now apply a div in the Youtube container which is then styled to cover the player with a large black rectangle so the test always passes.

### Example Screenshot
<!-- If possible, add an image or gif of what's changed. -->
![screen shot 2017-03-06 at 12 27 38](https://cloud.githubusercontent.com/assets/10154302/23631148/756bf63c-02b5-11e7-9710-dc1e8a7219a5.png)
