### PR TITLE
Add bundle-collapser to convert absolute paths to ids in bundled JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Simplified the contributing guidelines [#752](https://github.com/hmrc/assets-frontend/pull/752)
+- Added `bundle-collapser` plugin to convert bundle paths to IDs in bundled JavaScript [#763](https://github.com/hmrc/assets-frontend/pull/763)
 
 ### Fixed
 - Continuous Integration builds weren't failing when JavaScript acceptance tests failed [#754](https://github.com/hmrc/assets-frontend/pull/754)

--- a/gulpfile.js/tasks/browserify.js
+++ b/gulpfile.js/tasks/browserify.js
@@ -7,8 +7,8 @@
    different sources, and to use Watchify when run from the default task.
    See browserify.bundleConfigs in gulp/config.js
 */
-
 var browserify = require('browserify')
+var collapse = require('bundle-collapser/plugin')
 var watchify = require('watchify')
 var bundleLogger = require('../util/bundleLogger')
 var gulp = require('gulp')
@@ -37,6 +37,9 @@ var browserifyTask = function (callback, devMode) {
       // `gulp browserify` directly will properly require and externalize.
       bundleConfig = _.omit(bundleConfig, ['external', 'require'])
     }
+
+    // stop absolute urls appearing in prod browserify'd bundles
+    _.extend(bundleConfig, {plugin: collapse})
 
     var b = browserify(bundleConfig)
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "browser-sync": "^2.4.0",
     "browserify-istanbul": "^0.1.3",
     "browserify-shim": "^3.8.2",
+    "bundle-collapser": "^1.2.1",
     "datatables": "1.10.11",
     "del": "^1.1.1",
     "fingerprintjs": "^0.5.3",


### PR DESCRIPTION
## Problem
Our `application.min.js` has some absolute paths we wish to convert to id's in production.

## Solution
On production builds only use [bundle-collapser](https://github.com/substack/bundle-collapser) a plugin for browserify that has been built for this job.  
> convert bundle paths to IDs to save bytes in browserify bundles

Also make `{fullPaths: false}` in `browserify`:
<blockquote>
 --full-paths
 
    Turn off converting module ids into numerical indexes. This is useful for
    preserving the original paths that a bundle was generated with.
</blockquote>

### Of Note
VRT tests pass

<img width="834" alt="screen shot 2017-03-11 at 09 28 06" src="https://cloud.githubusercontent.com/assets/2305016/23822097/2af8a7ae-063d-11e7-875c-6aee4c38698c.png">


### Screenshot of master/PR application.js Diff
<img width="1269" alt="diff" src="https://cloud.githubusercontent.com/assets/2305016/23803374/344d53f2-05ae-11e7-95f7-ca13f5e3ffd2.png">

> NOTE: this is shown in none minified mode for illustrative purposes only
