### PR TITLE
Simples fixes to align js to linter rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Continuous Integration builds weren't failing when JavaScript acceptance tests failed [#754](https://github.com/hmrc/assets-frontend/pull/754)
 - The Youtube-player Visual regression test was always failing [#761](https://github.com/hmrc/assets-frontend/pull/761)
+- Changelog test class, lint errors [#764](https://github.com/hmrc/assets-frontend/pull/764)
 
 ## [2.241.0] - 2017-01-20
 ### Fixed

--- a/gulpfile.js/tests/changelog.test.js
+++ b/gulpfile.js/tests/changelog.test.js
@@ -1,6 +1,5 @@
 var test = require('tape')
 var sinon = require('sinon')
-var gutil = require('gulp-util')
 var proc = require('child_process')
 var changelog = require('../tasks/changelog')
 
@@ -55,7 +54,7 @@ test('changelog - getChangedFiles', function (t) {
   // var noCommit = changelog.getChangedFiles()
   var changedFiles = changelog.getChangedFiles('test')
 
-  t.throws(function() {
+  t.throws(function () {
     changelog.getChangedFiles()
   }, /No commit given/, 'throws an error when not given a branch')
 


### PR DESCRIPTION
2 lines of JS were not adhering to the lining rules for the project.

## Problem
Within the test for the js file used to inspect the changelog, there were lint rule issue (gulpfile.js/tests/changelog.test.js):
* A dependency was unused.
* Syntactic style wasn't correct for parentheses spacing

## Solution
I removed the import of the unused dependency & added the whitespace need to allow the anonymous function to pass.