### PR TITLE
Fix date year specificity display bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Continuous Integration builds weren't failing when JavaScript acceptance tests failed [#754](https://github.com/hmrc/assets-frontend/pull/754)
 - The Youtube-player Visual regression test was always failing [#761](https://github.com/hmrc/assets-frontend/pull/761)
 - Changelog test class, lint errors [#764](https://github.com/hmrc/assets-frontend/pull/764)
+- Date year text box width specificity bug [#766](https://github.com/hmrc/assets-frontend/pull/766) 
 
 ## [2.241.0] - 2017-01-20
 ### Fixed

--- a/assets/scss/base/form/_form.scss
+++ b/assets/scss/base/form/_form.scss
@@ -310,16 +310,16 @@ Styleguide Form.date
   }
 }
 
-.form-date .form-group-year {
-  width: 70px;
-}
-
 .form-date .form-group {
   width: 56px;
   float: left;
   margin-right: 20px;
   margin-bottom: 0;
   clear: none;
+}
+
+.form-date .form-group-year {
+  width: 70px;
 }
 
 /*


### PR DESCRIPTION
This PR fixes a specificity issue preventing a date year field from being displayed at the correct width. 

https://github.com/hmrc/assets-frontend/issues/765