### PR TITLE
Remove email from APICollaboratorResponse url 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Gulpfile JavaScript tests (using [tape](https://www.npmjs.com/package/tape)) [#756](https://github.com/hmrc/assets-frontend/pull/756)
 
 ### Changed
+- Removed email address from apiCollaboratorResponse ajax form action url [#768](https://github.com/hmrc/assets-frontend/pull/768)
 - Simplified the contributing guidelines [#752](https://github.com/hmrc/assets-frontend/pull/752)
 - Added `bundle-collapser` plugin to convert bundle paths to IDs in bundled JavaScript [#763](https://github.com/hmrc/assets-frontend/pull/763)
 

--- a/assets/javascripts/modules/ajaxCallbacks.js
+++ b/assets/javascripts/modules/ajaxCallbacks.js
@@ -121,15 +121,18 @@ var ajaxCallbacks = {
         var $action = $('<td></td>').addClass('text--right hard--right')
 
         var $form = $('<form></form>')
-          .attr('action', $list.data('collaborator-remove-url') + email)
+          .attr('action', $list.data('collaborator-remove-url'))
           .attr('data-ajax-submit', true)
           .attr('data-callback-args', '')
           .attr('data-callback-name', 'apiCollaboratorRemoveResponse.callbacks')
-          .addClass('form')
+          .attr('data-container', '.js-remove-collaborator-data')
+          .addClass('form js-remove-collaborator-data')
 
         var $span = $('<span></span>')
             .text('Server error, please try again')
             .addClass('error-notification js-remove-error')
+
+        var $emailField = '<input name="email" type="hidden" value="' + email + '" />'
 
         var $button = $('<button type="submit"></button>')
             .text('Remove')
@@ -152,7 +155,7 @@ var ajaxCallbacks = {
         }
 
         // add to the list
-        $form.append($span, $button)
+        $form.append($span, $emailField, $button)
         $action.append($form)
         $tr.append($name, $permission, $action)
         $list.append($tr)

--- a/assets/test/specs/ajaxCallbacks.spec.js
+++ b/assets/test/specs/ajaxCallbacks.spec.js
@@ -600,7 +600,7 @@ describe('AjaxCallbacks', function () {
           expect($message[0].innerText).toContain('inviting them to register with the Application Title.')
         })
 
-        it('includes a hidden email field and removal button', function() {
+        it('includes a hidden email field and removal button', function () {
           var $form = $(
             '<form>' +
               '<input name="email" value="user2@example.com"/>' +
@@ -618,13 +618,10 @@ describe('AjaxCallbacks', function () {
 
           expect($removeButton[0].innerText).toBe('Remove')
           expect($($removeHiddenField[0]).val()).toBe('user2@example.com')
-
         })
-
       })
     })
   })
-
 
   describe('.apiCollaboratorRemoveResponse', function () {
     describe('.callbacks', function () {
@@ -659,29 +656,16 @@ describe('AjaxCallbacks', function () {
           $container.empty()
         })
 
-        it('can remove a collaborator from the table', function() {
-
+        it('can remove a collaborator from the table', function () {
           // Add row to the table to setup test
           $container.append($row)
-
           var $form = $row.find('form')
-
           var data = $form.serialize()
-
           underTest(response, $row, data, helpers, targets, null, null)
-
           var $td = $container.find('td')
-
           expect($td[0]).toBeUndefined()
-
         })
-
       })
     })
   })
-
-
-
-
-
 })

--- a/assets/test/specs/ajaxCallbacks.spec.js
+++ b/assets/test/specs/ajaxCallbacks.spec.js
@@ -599,7 +599,89 @@ describe('AjaxCallbacks', function () {
           var $message = $form.find('p')
           expect($message[0].innerText).toContain('inviting them to register with the Application Title.')
         })
+
+        it('includes a hidden email field and removal button', function() {
+          var $form = $(
+            '<form>' +
+              '<input name="email" value="user2@example.com"/>' +
+              '<input type="radio" name="role" value="ADMINISTRATOR"/>' +
+              '<input type="radio" checked name="role" value="DEVELOPER"/>' +
+            '</form>'
+          )
+          var data = $form.serialize()
+          underTest(response, $form, data, helpers, targets, null, null)
+          var $td = $container.find('td')
+
+          var $removeCell = $($td[2])
+          var $removeButton = $($removeCell[0]).find('button')
+          var $removeHiddenField = $($removeCell[0]).find('input[name="email"]')
+
+          expect($removeButton[0].innerText).toBe('Remove')
+          expect($($removeHiddenField[0]).val()).toBe('user2@example.com')
+
+        })
+
       })
     })
   })
+
+
+  describe('.apiCollaboratorRemoveResponse', function () {
+    describe('.callbacks', function () {
+      describe('.success', function () {
+        var $container
+        var underTest = ajaxCallbacks.apiCollaboratorRemoveResponse.callbacks.success
+        var targets = {
+          success: null
+        }
+        var response = {
+          registeredUser: false
+        }
+
+        var $row = $('<tr data-collaborator-row="user2@example.com">' +
+                  '<td class="table--large">user2@example.com</td>' +
+                  '<td class="table--large text--right hard--right">' +
+                  '<span class="faded-text">Developer</span>' +
+                  '</td><td class="text--right hard--right">' +
+                  '<form method="POST" class="form" data-ajax-submit="true" data-callback-name="apiCollaboratorRemoveResponse.callbacks" data-callback-args="" data-container="js-remove-collaborator-data">' +
+                  '<span class="error-notification js-remove-error">Server error, please try again</span>' +
+                  '<input name="email" type="hidden" value="user2@example.com" />' +
+                  '<button data-remove-collaborator-link="user2@example.com" class="button button--link button--small flush hard--right" type="submit">Remove</button>' +
+                  '</form>' +
+                  '</td>' +
+                  '</tr>')
+
+        beforeEach(function () {
+          $container = setFixtures('<tbody data-collaborator-list></tbody>')
+        })
+
+        afterEach(function () {
+          $container.empty()
+        })
+
+        it('can remove a collaborator from the table', function() {
+
+          // Add row to the table to setup test
+          $container.append($row)
+
+          var $form = $row.find('form')
+
+          var data = $form.serialize()
+
+          underTest(response, $row, data, helpers, targets, null, null)
+
+          var $td = $container.find('td')
+
+          expect($td[0]).toBeUndefined()
+
+        })
+
+      })
+    })
+  })
+
+
+
+
+
 })


### PR DESCRIPTION
# Problem
The ajax form on the collaborators screen of the Developer Hub currently passes an email address in the action url.  

# Solution
We are cleaning this up to ensure emails are only passed in the request body.  The change updates the form in the ajax response to use a hidden input in a data-container instead.