### PR TITLE
Fix changelog check with jenkins env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Continuous Integration builds weren't failing when JavaScript acceptance tests failed [#754](https://github.com/hmrc/assets-frontend/pull/754)
 - The Youtube-player Visual regression test was always failing [#761](https://github.com/hmrc/assets-frontend/pull/761)
 - Changelog test class, lint errors [#764](https://github.com/hmrc/assets-frontend/pull/764)
+- Fixed jenkins builds failing changelog check [#769](https://github.com/hmrc/assets-frontend/pull/769)
 
 ## [2.241.0] - 2017-01-20
 ### Fixed

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -34,7 +34,9 @@ var getChangedFiles = function (commit) {
     throw new Error('No commit given')
   }
 
-  var cmd = 'git diff --name-only master ' + commit
+  var ref = process.env.GIT_PREVIOUS_SUCCESSFUL_COMMIT || 'master'
+
+  var cmd = 'git diff --name-only ' + ref + ' ' + commit
   return runCommand(cmd)
 }
 
@@ -47,7 +49,11 @@ var checkForChangelog = function (files) {
 }
 
 gulp.task('changelog', function (done) {
-  getCurrentCommit(process.env.TRAVIS_COMMIT)
+  var commit = process.env.TRAVIS
+    ? process.env.TRAVIS_COMMIT
+    : process.env.GIT_COMMIT
+
+  getCurrentCommit(commit)
     .then(getChangedFiles)
     .then(checkForChangelog)
     .then(function () {


### PR DESCRIPTION
## Problem

The `CHANGELOG.md` check in the build tasks was failing on Jenkins due to missing master as a refspec.

## Solution

Use Jenkins' environment variables to make sure references to commits exist.