### PR TITLE
Use origin/master as the base refspec so that Jenkins can run the changelog comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Continuous Integration builds weren't failing when JavaScript acceptance tests failed [#754](https://github.com/hmrc/assets-frontend/pull/754)
 - The Youtube-player Visual regression test was always failing [#761](https://github.com/hmrc/assets-frontend/pull/761)
 - Changelog test class, lint errors [#764](https://github.com/hmrc/assets-frontend/pull/764)
+- Fixed jenkins builds failing changelog check [#769](https://github.com/hmrc/assets-frontend/pull/769)
 
 ## [2.241.0] - 2017-01-20
 ### Fixed

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -34,7 +34,9 @@ var getChangedFiles = function (commit) {
     throw new Error('No commit given')
   }
 
-  var cmd = 'git diff --name-only master ' + commit
+  var ref = process.env.GIT_PREVIOUS_SUCCESSFUL_COMMIT || 'master'
+
+  var cmd = 'git diff --name-only ' + ref + ' ' + commit
   return runCommand(cmd)
 }
 
@@ -47,7 +49,11 @@ var checkForChangelog = function (files) {
 }
 
 gulp.task('changelog', function (done) {
-  getCurrentCommit(process.env.TRAVIS_COMMIT)
+  var commit = process.env.TRAVIS
+    ? process.env.TRAVIS_COMMIT
+    : process.env.GIT_COMMIT
+
+  getCurrentCommit(commit)
     .then(getChangedFiles)
     .then(checkForChangelog)
     .then(function () {

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -34,7 +34,7 @@ var getChangedFiles = function (commit) {
     throw new Error('No commit given')
   }
 
-  var ref = process.env.GIT_PREVIOUS_SUCCESSFUL_COMMIT || 'master'
+  var ref = process.env.GIT_PREVIOUS_SUCCESSFUL_COMMIT || 'origin/master'
 
   var cmd = 'git diff --name-only ' + ref + ' ' + commit
   return runCommand(cmd)


### PR DESCRIPTION
## Problem
Jenkins dosn't do a  `git clone` when checking out a git repo, so it doesn't have a local tracking branch called `master`.

It's therefore necessary to do a diff pointing at `origin/master` to check for changes to the CHANGELOG when running the diff on Jenkins.

### Error Thrown

This is the error thrown when Jenkins tries to do the diff
```bash
Run Diff
fatal: ambiguous argument 'master': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```


## Solution
Modify the changelog.js task to specify the `origin/master` refspec rather than master