### PR TITLE
Pass the change log check when no files have been changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
-- Change log check passes if no files have been changed (mostly for CI) [#771](https://github.com/hmrc/assets-frontend/pull/771)
+- Pass the change log check if no files have been changed (mostly for CI) [#771](https://github.com/hmrc/assets-frontend/pull/771)
 
 ## [2.242.0] - 2017-04-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Change log check passes if no files have been changed (mostly for CI) [#771](https://github.com/hmrc/assets-frontend/pull/771)
+
+## [2.242.0] - 2017-04-13
 ### Added
 - This change log! :boom: [#753](https://github.com/hmrc/assets-frontend/pull/753)
 - ...and a check that it's been update as part of a pull request [#759](https://github.com/hmrc/assets-frontend/pull/759)
@@ -33,7 +37,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Changes to nginx error pages not being build and deployed [#734]
 
-[Unreleased]: https://github.com/hmrc/assets-frontend/compare/release/2.241.0...master
+[Unreleased]: https://github.com/hmrc/assets-frontend/compare/release/2.242.0...master
+[2.242.0]: https://github.com/hmrc/assets-frontend/compare/release/2.241.0...release/2.242.0
 [2.241.0]: https://github.com/hmrc/assets-frontend/compare/release/2.240.0...release/2.241.0
 [2.240.0]: https://github.com/hmrc/assets-frontend/compare/release/2.239.0...release/2.240.0
 [2.239.0]: https://github.com/hmrc/assets-frontend/compare/release/2.238.0...release/2.239.0

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -41,7 +41,7 @@ var getChangedFiles = function (commit) {
 }
 
 var checkForChangelog = function (files) {
-  if (!files.includes('CHANGELOG.md')) {
+  if (files.length && !files.includes('CHANGELOG.md')) {
     throw new Error('No CHANGELOG.md update')
   }
 

--- a/gulpfile.js/tests/changelog.test.js
+++ b/gulpfile.js/tests/changelog.test.js
@@ -68,7 +68,7 @@ test('changelog - getChangedFiles', function (t) {
 })
 
 test('changelog - checkForChangelog', function (t) {
-  t.plan(2)
+  t.plan(3)
 
   var files1 = 'file-one.html\n' +
     'CHANGELOG.md\n' +
@@ -77,6 +77,11 @@ test('changelog - checkForChangelog', function (t) {
   var files2 = 'file-one.html\n' +
     'file-two.js\n' +
     'file-three.css'
+
+  t.true(
+    changelog.checkForChangelog(''),
+    'returns true when CHANGELOG.md is empty'
+  )
 
   t.true(
     changelog.checkForChangelog(files1),


### PR DESCRIPTION
## Problem

The `CHANGELOG.md` check fails even if no files have been changed. This fails the build when run on non-PRs in CI.

## Solution

Pass the `CHANGELOG.md` check if there are no files changed since the last commit.