### PR TITLE
Specify correct node version in the README.md file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
-- Updated the README with the supported Node version
+- Updated the README with the supported Node version [#775](https://github.com/hmrc/assets-frontend/pull/775)
 
 ## [2.242.2] - 2017-04-21
 ## [2.242.1] - 2017-04-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Updated the README with the supported Node version
 
 ## [2.242.2] - 2017-04-21
 ## [2.242.1] - 2017-04-20

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ sm --start ASSETS_FRONTEND
 
 ### Requirements
 
-* [Node.js](https://nodejs.org/en/) `>= 0.12.7`
+* [Node.js](https://nodejs.org/en/) `== 4.4.5`
 * [npm](https://www.npmjs.com/) `>= 2.11.3`
 
 #### [Node.js](https://nodejs.org/en/) & [npm](https://www.npmjs.com/)


### PR DESCRIPTION
## Problem
The documentation specifies a minimum version of Node to be used when working on assets-frontend, however there is also a maximum version and a single supported version. 

The supported version is the version used on the build servers. Node v4.4.5

## Solution
Updating the README.md to specify Node v4.4.5 (and update the CHANGELOG.md) fixes #774  
