### PR TITLE
Made headers in transaction banners default to White

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Updated the README with the supported Node version [#775](https://github.com/hmrc/assets-frontend/pull/775)
+- Added explicit colour (white) to transaction banner headers to match the GDS example banner [#776](https://github.com/hmrc/assets-frontend/pull/776)
 
 ## [2.242.2] - 2017-04-21
 ## [2.242.1] - 2017-04-20
@@ -27,7 +28,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Simplified the contributing guidelines [#752](https://github.com/hmrc/assets-frontend/pull/752)
 - Added `bundle-collapser` plugin to convert bundle paths to IDs in bundled JavaScript [#763](https://github.com/hmrc/assets-frontend/pull/763)
 - The [Character counter](http://hmrc.github.io/assets-frontend/section-textarea-input.html#kssref-textarea-input-counter) has been refactored into our new clearer file structure [#767](https://github.com/hmrc/assets-frontend/pull/767)
-- Added explicit colour (white) to transaction banner headers to match the GDS example banner [#776](https://github.com/hmrc/assets-frontend/pull/776)
 
 ### Fixed
 - Continuous Integration builds weren't failing when JavaScript acceptance tests failed [#754](https://github.com/hmrc/assets-frontend/pull/754)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Simplified the contributing guidelines [#752](https://github.com/hmrc/assets-frontend/pull/752)
 - Added `bundle-collapser` plugin to convert bundle paths to IDs in bundled JavaScript [#763](https://github.com/hmrc/assets-frontend/pull/763)
 - The [Character counter](http://hmrc.github.io/assets-frontend/section-textarea-input.html#kssref-textarea-input-counter) has been refactored into our new clearer file structure [#767](https://github.com/hmrc/assets-frontend/pull/767)
+- Added explicit colour (white) to transaction banner headers to match the GDS example banner [#776](https://github.com/hmrc/assets-frontend/pull/776)
 
 ### Fixed
 - Continuous Integration builds weren't failing when JavaScript acceptance tests failed [#754](https://github.com/hmrc/assets-frontend/pull/754)

--- a/assets/scss/components/_header.scss
+++ b/assets/scss/components/_header.scss
@@ -92,6 +92,7 @@ Styleguide Header.Transaction
 
 .transaction-banner__heading {
   @include bold-36();
+  color: $white;
   margin: 15px 0;
 }
 


### PR DESCRIPTION
<!-- Provide a short summary of the issue in the Title above. -->

<!-- Make sure your work follows to our CONTRIBUTING guidelines. -->
<!-- There's a link to them above. -->

## Problem
Headings in Transaction Banners were supposed to be White but any "article h1" was being overridden to Black

### Example Screenshot
This: http://hmrc.github.io/assets-frontend/section-header.html should now be this: https://govuk-prototype-kit.herokuapp.com/docs/examples/confirmation-page

## Solution
I explicitly set the header class to be White

### Example Screenshot
Screenshot from running **npm run vrt:baseline** before
![assets-frontend-vrt_header_1_comp-lib-pattern-component__n1_0_desktop](https://cloud.githubusercontent.com/assets/18663420/25485552/3ca8a22c-2b56-11e7-98b3-c6e1b28b6d1f.png)

and after
![assets-frontend-vrt_header_1_comp-lib-pattern-component__n1_0_desktop](https://cloud.githubusercontent.com/assets/18663420/25485691/ac8705d4-2b56-11e7-9b13-fc3a45b4e89c.png)
