### PR TITLE
Enabled targeting of a tab component via URL fragment in the component library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Added the correct class to the Tab component to enable targetting an open tab via the url with a fragment [#778](https://github.com/hmrc/assets-frontend/issues/778)
+
+## [2.245.0] - 2017-05-09
 ### Fixed
 - Updated the README with the supported Node version [#775](https://github.com/hmrc/assets-frontend/pull/775)
 - Added explicit colour (white) to transaction banner headers to match the GDS example banner [#776](https://github.com/hmrc/assets-frontend/pull/776)

--- a/assets/scss/components/_tabs.scss
+++ b/assets/scss/components/_tabs.scss
@@ -4,7 +4,7 @@ Tabs
 Tabs are useful for displaying navigational links.
 
 Markup:
-<div data-tabs>
+<div data-tabs class="js-hash-selected-tab">
   <ul class="tabs-nav" role="tablist">
     <li id="tab1" role="tab"
                   data-tab-link="tab1"


### PR DESCRIPTION
Fixes #778 

## Problem/Feature
The component library implementation of tabs doesn't enable the behaviour which allows deep-linking to a tab other than the initial tab.

Designers and developers are  therefore unaware that this behaviour is possible with the assets frontend tabs control.

## Expected behaviour
Navigating to the assets frontend with a fragment that references a tab should open that tab on page load e.g.

http://hmrc.github.io/assets-frontend/section-tabs.html#tab3

Should open with Tab 3 open

## Proposed solution
add the `js-hash-selected-tab` class to the div with the `data-tabs` attribute eg

```<div data-tabs class="js-hash-selected-tab">```
