### PR TITLE
Updated tabular data component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Added the correct class to the Tab component to enable targetting an open tab via the url with a fragment [#778](https://github.com/hmrc/assets-frontend/issues/778)
+- Fixed alignment issues in Tabular Data component at page widths in-between the full desktop and mobile sizes
 
 ## [2.245.0] - 2017-05-09
 ### Fixed

--- a/assets/scss/components/_tabular-data.scss
+++ b/assets/scss/components/_tabular-data.scss
@@ -38,6 +38,7 @@ Styleguide Tabular Data
   width: 100%;
   position: relative;
   padding: em(15) 0;
+  table-layout: fixed;
 }
 
 .tabular-data__entry--grouped:first-child {
@@ -109,7 +110,7 @@ Styleguide Tabular Data
   margin: em(10) 0;
   @include media(tablet) {
     display: table-cell;
-    width: 50%;
+    width: 44%;
   }
   li {
     margin: 0;
@@ -129,9 +130,10 @@ Styleguide Tabular Data
 .tabular-data__data-2 {
   display: block;
   margin: em(10) 0;
+  white-space: nowrap;
   @include media(tablet) {
     display: table-cell;
-    width: 10%;
+    width: 16%;
     text-align: right;
     padding-right: em(10);
   }


### PR DESCRIPTION
Amended the tabular data component to ensure that the columns remain aligned at lower page widths, and that column 3 remains wide enough to cater for a 'Change' link.

## Problem

When the component doesn't have a full desktop width available, two visual problems would occur:

* Rows with a 'change' link would fall out of alignment with those without one.
* Rows with a 'details' component would break the 'change' link onto two lines.

![screen shot 2017-05-24 at 11 07 31](https://cloud.githubusercontent.com/assets/238270/26398792/871b2de4-4072-11e7-8f35-6940232e9a59.png)

## Solution

1. The rows have had `table-layout: fixed;` applied to them so that their width is pre-determined and not affected by the content of the cells.
1. Column 3 has increased in width from 10% to 16% to ensure there is enough room to fit the text at smaller screen sizes.
1. Column 2 on a 3 column layout has decreased in width by 6% to support (2).

![screen shot 2017-05-24 at 11 17 38](https://cloud.githubusercontent.com/assets/238270/26398816/9ece0b3c-4072-11e7-90c2-abc2a9db55d9.png)