### PR TITLE
Changed Transaction Banner font size to match GOV Elements banner due…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Updated existing link colour variables to match gov.uk [#795](https://github.com/hmrc/assets-frontend/pull/795)
+- Increased font size in transaction banner headers to match the GDS example banner to fix an accessibility issue [#781](https://github.com/hmrc/assets-frontend/pull/781)
 
 ## [2.248.1] - 2017-09-04
 ### Fixed
@@ -40,7 +41,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Added the correct class to the Tab component to enable targetting an open tab via the url with a fragment [#778](https://github.com/hmrc/assets-frontend/issues/778)
-- Increased font size in transaction banner headers to match the GDS example banner to fix an accessibility issue [#781](https://github.com/hmrc/assets-frontend/pull/781)
 
 ## [2.245.0] - 2017-05-09
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Added the correct class to the Tab component to enable targetting an open tab via the url with a fragment [#778](https://github.com/hmrc/assets-frontend/issues/778)
+- Increased font size in transaction banner headers to match the GDS example banner to fix an accessibility issue [#781](https://github.com/hmrc/assets-frontend/pull/781)
 
 ## [2.245.0] - 2017-05-09
 ### Fixed

--- a/assets/govuk_elements/public/sass/elements/_components.scss
+++ b/assets/govuk_elements/public/sass/elements/_components.scss
@@ -1,0 +1,44 @@
+// Box with turquoise background and white text
+// Used for transaction end pages, and Bank Holidays
+.govuk-box-highlight {
+  margin: 1em 0;
+  padding: 2em 1em;
+  color: $white;
+  background: $turquoise;
+  text-align: center;
+}
+
+// overwrite article h1 colour set in the file below
+// https://github.com/hmrc/assets-frontend/blob/3610585baeb96bb4ad9d73d20cfb73864e095b50/assets/govuk_frontend_static/_template-text.scss#L58-L63
+.govuk-box-highlight h1 {
+	color: $white;
+}
+
+// overwrite content__body p font size set in file below
+// https://github.com/hmrc/assets-frontend/blob/3610585baeb96bb4ad9d73d20cfb73864e095b50/assets/scss/layouts/_page.scss#L48-L51
+.govuk-box-highlight p.font-large {
+	@include core-36;
+}
+
+/*
+
+Use of .govuk-box-highlight
+
+For reference see:
+https://govuk-prototype-kit.herokuapp.com/docs/examples/confirmation-page
+and
+http://govuk-elements.herokuapp.com/colour/#examples
+
+
+The above styles and overwrites means you can simplify the markup to the following:
+
+<div class="govuk-box-highlight">
+  <h1 class="heading-xlarge">Application complete</h1>
+  <p class="font-large">
+    Your reference number is
+    <br>
+    <strong class="bold">HDJ2123F</strong>
+  </p>
+</div>
+
+*/

--- a/assets/govuk_elements/public/sass/main.scss
+++ b/assets/govuk_elements/public/sass/main.scss
@@ -50,3 +50,5 @@
 // Icons
 @import "elements/icons";
 
+// Confirmation page header
+@import "elements/components";

--- a/assets/scss/components/_header.scss
+++ b/assets/scss/components/_header.scss
@@ -88,10 +88,16 @@ Styleguide Header.Transaction
     text-align: left;
     padding: 0;
   }
+
+  p {
+    @include core-36();
+    color: $white;
+    text-decoration: none;
+  }
 }
 
 .transaction-banner__heading {
-  @include bold-36();
+  @include bold-48();
   color: $white;
   margin: 15px 0;
 }

--- a/assets/scss/components/_header.scss
+++ b/assets/scss/components/_header.scss
@@ -90,14 +90,13 @@ Styleguide Header.Transaction
   }
 
   p {
-    @include core-36();
-    color: $white;
+    @include core-36;
     text-decoration: none;
   }
 }
 
 .transaction-banner__heading {
-  @include bold-48();
+  @include bold-48;
   color: $white;
   margin: 15px 0;
 }


### PR DESCRIPTION
… to a colour contrast accessibility issue

DAC reports showed that the current transaction banner failed WCAG AAA colour contrast standards.

## Problem
The font size of the `<p> text </p>` was too small for the colour contrast to pass accessibility standards.

### Example Screenshot
LEFT: Assets frontend    RIGHT: GOV Elements
![image](https://user-images.githubusercontent.com/18663420/27223536-c75964c0-5288-11e7-89b5-00b28f184778.png)

## Solution
Increased the font sizes to match those used in the GOV Elements kit
