### PR TITLE
Build successfully against node 4.8.4 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - 4.4.5
+  - 4.8.4
 before_install: git fetch origin master:master
 script: ./server.sh build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Tests pass when run against nodejs 4.8.4 [#784](https://github.com/hmrc/assets-frontend/pull/784)
 
 ## [2.246.0] - 2017-07-20
 ### Fixed

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -6,6 +6,10 @@ var proc = require('child_process')
 
 var runCommand = function (cmd) {
   return new Promise(function (resolve, reject) {
+    if (!cmd) {
+      reject(new Error('No command specified.'))
+    }
+
     proc.exec(cmd, function (err, stdout, stderr) {
       if (err) {
         reject(err)

--- a/gulpfile.js/tests/changelog.test.js
+++ b/gulpfile.js/tests/changelog.test.js
@@ -6,13 +6,15 @@ var changelog = require('../tasks/changelog')
 test('changelog - runCommand', function (t) {
   t.plan(3)
 
-  changelog.runCommand()
+  changelog
+    .runCommand()
     .catch(function (err) {
       t.ok(err instanceof Error, 'returns an Error if the command fails')
-      t.ok(err.message.includes('Command failed'), 'returns exec\'s error message')
+      t.ok(err.message.includes('No command specified'), 'returns exec\'s error message')
     })
 
-  changelog.runCommand('echo "test"')
+  changelog
+    .runCommand('echo "test"')
     .then(function (stdout) {
       t.equal(stdout, 'test\n', 'should return a Promise if given a command to run')
     })


### PR DESCRIPTION
## Problem

A test was failing when running on node 4.8.4

## Solution

Fix the changelog test to explicitly reject with an error when not given a command.
