### PR TITLE
Refactor unit tests to allow builds on node 4.8.4 and 6.11.1 simultaneously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Updated most build-related dependencies to latest versions & refactor gulp tasks to be more efficient [#787](https://github.com/hmrc/assets-frontend/pull/787)
 
+### Fixed
+- Tests pass when run against nodejs 4.8.4 and 6.11.1 [#788](https://github.com/hmrc/assets-frontend/pull/788)
+
 ## [2.247.0] - 2017-08-01
 ### Added
 - Add latest GOV.UK radio buttons and checkboxes [#789](https://github.com/hmrc/assets-frontend/pull/789)

--- a/gulpfile.js/tests/BuildScenarios.test.js
+++ b/gulpfile.js/tests/BuildScenarios.test.js
@@ -64,13 +64,8 @@ test('buildScenarios - JSON parse error caught as expected', function (t) {
     .pipe(buildScenarios)
     .on('error', function (err) {
       t.equal(
-        err.message, 'Unexpected end of input',
-        'error message should be "Unexpected end of input"')
-      t.true(
-        err instanceof SyntaxError,
-        'error message should be of type "SyntaxError"'
-      )
-
+        err, 'Malformed JSON error',
+        'error message should be "Malformed JSON error"')
       t.end()
     })
 })

--- a/gulpfile.js/tests/configGenerator.test.js
+++ b/gulpfile.js/tests/configGenerator.test.js
@@ -105,9 +105,8 @@ test('configGenerator - bad template data should throw', function (t) {
       return configGenerator(brokenConfig)
     })
     .catch(function (err) {
-      t.true(err instanceof Error, 'Error type should of been thrown')
       t.equal(
-        err.message, 'Unexpected token N',
+        err, 'Bad data in template config',
         'bad data in template config should throw error'
       )
       t.end()

--- a/gulpfile.js/util/backstop/BuildScenarios.js
+++ b/gulpfile.js/util/backstop/BuildScenarios.js
@@ -34,7 +34,7 @@ BuildScenarios.prototype._flush = function (done) {
     jsonData.scenarios = jsonData.scenarios.concat(this.createScenarios())
     dataAsString = JSON.stringify(jsonData, null, 2)
   } catch (err) {
-    this.emit('error', err)
+    this.emit('error', 'Malformed JSON error')
   }
 
   this.push(dataAsString || this.data)

--- a/gulpfile.js/util/backstop/configGenerator.js
+++ b/gulpfile.js/util/backstop/configGenerator.js
@@ -21,9 +21,13 @@ module.exports = function (config) {
     readConfig.setEncoding('utf8')
     readConfig
       .pipe(buildScenarios)
-      .on('error', reject)
+      .on('error', function () {
+        reject('Bad data in template config')
+      })
       .pipe(writeConfig)
-      .on('error', reject)
+      .on('error', function () {
+        reject('Bad data in template config')
+      })
       .on('finish', function () {
         resolve('backstop.json created')
       })


### PR DESCRIPTION
## Problem
When running a build on the current LTS version of node, the build fails due to various errors. Primarily, failing tests due to a change in error strings being returned.

## Solution
Refactor out code to return our own error messaging, and test for those strings instead.