### PR TITLE
Add discovery and live colour variables and update semantic colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Added in colour new variables for discovery and live badges and banners
-- updated link colour variables to match gov.uk [#795](https://github.com/hmrc/assets-frontend/pull/795)
+- Updated link colour variables to match gov.uk [#795](https://github.com/hmrc/assets-frontend/pull/795)
 
 ## [2.248.1] - 2017-09-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Added in colour new variables for discovery and live badges and banners
-- Updated link colour variables to match gov.uk [#795](https://github.com/hmrc/assets-frontend/pull/795)
+- Updated existing link colour variables to match gov.uk [#795](https://github.com/hmrc/assets-frontend/pull/795)
 
 ## [2.248.1] - 2017-09-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
-- Added in colour new variables for discovery and live badges and banners
 - Updated existing link colour variables to match gov.uk [#795](https://github.com/hmrc/assets-frontend/pull/795)
 
 ## [2.248.1] - 2017-09-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Added in colour new variables for discovery and live badges and banners
+- updated link colour variables to match gov.uk [#795](https://github.com/hmrc/assets-frontend/pull/795)
 
 ## [2.248.1] - 2017-09-04
 ### Fixed

--- a/assets/govuk_elements/govuk/public/sass/_colours.scss
+++ b/assets/govuk_elements/govuk/public/sass/_colours.scss
@@ -103,10 +103,8 @@ $panel-colour: $grey-3;           // Related links panel, page footer etc.
 $canvas-colour: $grey-4;          // Page background
 $highlight-colour: $grey-4;       // Table stripes etc.
 $page-colour: $white;             // The page
-$discovery-colour: $govuk-blue;   // Discovery badges and banners
 $alpha-colour: $govuk-blue;       // Alpha badges and banners
 $beta-colour: $govuk-blue;        // Beta badges and banners
-$live-colour: $grass-green;       // Live badges and banners
 $banner-text-colour: #000;        // Text colour for Alpha & Beta banners
 $error-colour: $red;              // Error text and border colour
 $error-background: #fef7f7;       // Error background colour

--- a/assets/govuk_elements/govuk/public/sass/_colours.scss
+++ b/assets/govuk_elements/govuk/public/sass/_colours.scss
@@ -91,10 +91,11 @@ $white: #fff;
 
 // Semantic colour names
 $link-colour: $govuk-blue;
-$link-active-colour: #2e8aca;
-$link-hover-colour: #2e8aca;
-$link-visited-colour: #2e8aca;
+$link-active-colour: $light-blue;
+$link-hover-colour: $light-blue;
+$link-visited-colour: #4c2c92;
 $button-colour: #00823b;
+$focus-colour: $yellow;
 $text-colour: $black;             // Standard text colour
 $secondary-text-colour: $grey-1;  // Section headers, help text etc.
 $border-colour: $grey-2;          // Borders, seperators, rules, keylines etc.
@@ -102,8 +103,10 @@ $panel-colour: $grey-3;           // Related links panel, page footer etc.
 $canvas-colour: $grey-4;          // Page background
 $highlight-colour: $grey-4;       // Table stripes etc.
 $page-colour: $white;             // The page
-$alpha-colour: $pink;             // Alpha badges and banners
-$beta-colour: $orange;            // Beta badges and banners
+$discovery-colour: $govuk-blue;   // Discovery badges and banners
+$alpha-colour: $govuk-blue;       // Alpha badges and banners
+$beta-colour: $govuk-blue;        // Beta badges and banners
+$live-colour: $grass-green;       // Live badges and banners
 $banner-text-colour: #000;        // Text colour for Alpha & Beta banners
-$error-colour: $mellow-red;       // Error text and border colour
+$error-colour: $red;              // Error text and border colour
 $error-background: #fef7f7;       // Error background colour

--- a/assets/govuk_elements/govuk/public/sass/_colours.scss
+++ b/assets/govuk_elements/govuk/public/sass/_colours.scss
@@ -103,8 +103,10 @@ $panel-colour: $grey-3;           // Related links panel, page footer etc.
 $canvas-colour: $grey-4;          // Page background
 $highlight-colour: $grey-4;       // Table stripes etc.
 $page-colour: $white;             // The page
+$discovery-colour: $govuk-blue;   // Discovery badges and banners
 $alpha-colour: $govuk-blue;       // Alpha badges and banners
 $beta-colour: $govuk-blue;        // Beta badges and banners
+$live-colour: $grass-green;       // Live badges and banners
 $banner-text-colour: #000;        // Text colour for Alpha & Beta banners
 $error-colour: $red;              // Error text and border colour
 $error-background: #fef7f7;       // Error background colour

--- a/assets/govuk_frontend_toolkit/stylesheets/_colours.scss
+++ b/assets/govuk_frontend_toolkit/stylesheets/_colours.scss
@@ -91,8 +91,8 @@ $white: #fff;
 
 // Semantic colour names
 $link-colour: $govuk-blue;
-$link-active-colour: #2e8aca;
-$link-hover-colour: #2e8aca;
+$link-active-colour: $light-blue;
+$link-hover-colour: $light-blue;
 $link-visited-colour: #4c2c92;
 $button-colour: #00823b;
 $focus-colour: $yellow;
@@ -103,8 +103,10 @@ $panel-colour: $grey-3;           // Related links panel, page footer etc.
 $canvas-colour: $grey-4;          // Page background
 $highlight-colour: $grey-4;       // Table stripes etc.
 $page-colour: $white;             // The page
-$alpha-colour: $pink;             // Alpha badges and banners
-$beta-colour: $orange;            // Beta badges and banners
+$discovery-colour: $govuk-blue;   // Discovery badges and banners
+$alpha-colour: $govuk-blue;       // Alpha badges and banners
+$beta-colour: $govuk-blue;        // Beta badges and banners
+$live-colour: $grass-green;       // Live badges and banners
 $banner-text-colour: #000;        // Text colour for Alpha & Beta banners
-$error-colour: $mellow-red;       // Error text and border colour
+$error-colour: $red;              // Error text and border colour
 $error-background: #fef7f7;       // Error background colour

--- a/assets/govuk_frontend_toolkit/stylesheets/_colours.scss
+++ b/assets/govuk_frontend_toolkit/stylesheets/_colours.scss
@@ -103,10 +103,8 @@ $panel-colour: $grey-3;           // Related links panel, page footer etc.
 $canvas-colour: $grey-4;          // Page background
 $highlight-colour: $grey-4;       // Table stripes etc.
 $page-colour: $white;             // The page
-$discovery-colour: $govuk-blue;   // Discovery badges and banners
 $alpha-colour: $govuk-blue;       // Alpha badges and banners
 $beta-colour: $govuk-blue;        // Beta badges and banners
-$live-colour: $grass-green;       // Live badges and banners
 $banner-text-colour: #000;        // Text colour for Alpha & Beta banners
 $error-colour: $red;              // Error text and border colour
 $error-background: #fef7f7;       // Error background colour

--- a/assets/scss/base/_colours.scss
+++ b/assets/scss/base/_colours.scss
@@ -6,8 +6,6 @@ $input-bg-colour: #f9f9f9;
 $login-green: #00692f;
 $primary-green: #00823B;
 
-$beta-colour: #f47738;
-
 $info-bg-color: #ddeeff;
 $info-border-color: #005EA4;
 


### PR DESCRIPTION
This pull request includes:
• adding $discovery-colour and $live-colour variables
• updating semantic colour variables to match gov.uk - only affects alpha and beta banners, link :hover and active states and error colour

The purpose of this is to bring assets up to date and inline with gov.uk so that all services use the latest colours to reduce inconsistencies.
This won't break anything, but will update colours that bump to latest version of AF

## Problem
Inconsistencies in colours

## Colour variable updates captured in image
![colours-update](https://user-images.githubusercontent.com/1692222/29073852-1a19c02a-7c45-11e7-843c-34418c822eeb.jpg)

## GOV.UK code and style references
Link to colours in GOV.UK frontend toolkit
https://github.com/alphagov/govuk_frontend_toolkit/tree/master/stylesheets/colours
https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/colours/_palette.scss

Alpha and Beta banners on GOV.UK
http://govuk-elements.herokuapp.com/alpha-beta-banners/

