### PR TITLE
Fix builds dying silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Generate component library files from components in new file structure without kss-node [#791](https://github.com/hmrc/assets-frontend/pull/791)
+- Fix builds silently failing [#794](https://github.com/hmrc/assets-frontend/pull/794)
 
 ### Changed
 - Updated the README.md as node version has been bumped up

--- a/gulpfile.js/tasks/comp-lib.js
+++ b/gulpfile.js/tasks/comp-lib.js
@@ -42,4 +42,6 @@ gulp.task('component-library', ['kss-node'], function (cb) {
         library: path.join(compLibConfig.destination)
       }))
       .pipe(gulp.dest(compLibConfig.destination))
+
+  cb()
 })


### PR DESCRIPTION
## Problem
Running `gulp` causes a silent failure.

## Solution
Run the `cb` argument, which runs the server.