### PR TITLE
SDT-306 - Optional quiet logging for VRT baseline runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Generate component library files from components in new file structure without kss-node [#791](https://github.com/hmrc/assets-frontend/pull/791)
 - Fixes builds silently failing [#798](https://github.com/hmrc/assets-frontend/pull/798)
+- Optional quiet logging for VRT tests using --quiet flag
 
 ### Changed
 - Updated the README.md as node version has been bumped up

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Generate component library files from components in new file structure without kss-node [#791](https://github.com/hmrc/assets-frontend/pull/791)
 - Fixes builds silently failing [#798](https://github.com/hmrc/assets-frontend/pull/798)
-- Optional quiet logging for VRT tests using --quiet flag
+- Optional quiet logging for VRT tests using --quiet flag [#798](https://github.com/hmrc/assets-frontend/pull/800)
 
 ### Changed
 - Updated the README.md as node version has been bumped up

--- a/gulpfile.js/tasks/vrt.js
+++ b/gulpfile.js/tasks/vrt.js
@@ -7,6 +7,7 @@ var st = require('st')
 var http = require('http')
 var config = require('../config')
 var backstopConfigGenerator = require('./../util/backstop/configGenerator')
+var argv = require('yargs').argv
 var compLibServer
 
 gulp.task('build-vrt-config', function () {
@@ -14,30 +15,33 @@ gulp.task('build-vrt-config', function () {
 })
 
 gulp.task('vrt-baseline', function () {
+  var quiet = !!argv.quiet
+
   runSequence(
     'component-library',
     'vrt-server',
     'build-vrt-config',
     function () {
-      backstop('reference')
-        .then(function () {
-          compLibServer.close()
-        })
-        .catch(function (err) {
-          console.log(err)
-          compLibServer.close()
-        })
+      backstop('reference', {}, quiet).then(function () {
+        compLibServer.close()
+      })
+      .catch(function (err) {
+        console.log(err)
+        compLibServer.close()
+      })
     }
   )
 })
 
 gulp.task('vrt-compare', function () {
+  var quiet = !!argv.quiet
+
   runSequence(
     'component-library',
     'vrt-server',
     'build-vrt-config',
     function () {
-      backstop('test')
+      backstop('test', {}, quiet)
         .then(function () {
           compLibServer.close()
         })

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "HMRC",
   "license": "Apache-2.0",
   "dependencies": {
-    "backstopjs": "^2.3.3",
+    "backstopjs": "hmrc/BackstopJS",
     "browser-sync": "^2.4.0",
     "browserify": "^14.4.0",
     "browserify-shim": "^3.8.14",
@@ -83,7 +83,9 @@
     "sticky-header": "^0.2.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
-    "vinyl-transform": "^1.0.0"
+    "vinyl-transform": "^1.0.0",
+    "watchify": "^3.9.0",
+    "yargs": "^8.0.2"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
## Problem
VRTs currently offer no logging levels, and the output can be confusing.

## Solution
Allow a `--quiet` option to be passed in when running VRTs which reduces logging verbosity and makes things clearer.