### PR TITLE
Rerun sass task in prod mode for CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Production styles not being generated on CI [#804](https://github.com/hmrc/assets-frontend/pull/804)
 
 ## [2.248.0] - 2017-08-23
 ### Added

--- a/gulpfile.js/tasks/build.js
+++ b/gulpfile.js/tasks/build.js
@@ -8,7 +8,7 @@ gulp.task('build', ['changelog', 'clean', 'test'], function () {
   global.location = undefined
 
   runSequence(
-    ['images', 'svg', 'error-pages'],
+    ['sass', 'images', 'svg', 'error-pages'],
     ['browserify', 'concatEncryption'],
     'modernizr',
     'version',


### PR DESCRIPTION
## Problem

After the refactoring of gulp tasks, the sass job doesn't build the production stylesheets during the [`build`](https://github.com/hmrc/assets-frontend/blob/b4ce7e2/gulpfile.js/tasks/build.js) job.

Because the sass task is being run as a dependency of the `test` task, the `global.runmode` is set as the default `dev`. Due to this, the sass task doesn't minify the styles or put them in the `assets/dist` directory ready to be zipped and deployed.

### Example Screenshot
![image](https://user-images.githubusercontent.com/1752124/29720316-7c6a9910-89b1-11e7-9b34-3e461c98836d.png)

## Solution

By explicitly calling the `sass` task as a step in the `build` task it picks up the `global.runmode = 'prod'` setting and builds the styles for production.

### Example Screenshot
![image](https://user-images.githubusercontent.com/1752124/29720411-d1f35f0c-89b1-11e7-9122-ea0e3e791e2a.png)

### Caveats

The `sass` task is being run twice as it's still a dependency of the `test` task. Ideally, the `sass` task would only be run once and then a separate minification step would be run for production. 

That hasn't been done for this change as we need to get a fix out for missing styles quickly and introducing a new minification library could produce different output to the original `sass` job.