### PR TITLE
Update button mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Updated padding for button mixin and included outline css [#813](https://github.com/hmrc/assets-frontend/pull/813)
 
 ## [2.250.0] - 2017-09-29
 ### Added

--- a/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss
+++ b/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss
@@ -27,9 +27,11 @@
   // Size and shape
   position: relative;
   @include inline-block;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+  padding: .526315em .789473em .263157em; // 10px 15px 5px
   border: none;
   @include border-radius(0);
+  outline: 1px solid transparent; // keep some button appearance when changing colour settings in browsers
+  outline-offset: -1px; // fixes bug in Safari that outline width on focus is not overwritten, is reset to 0 on focus in govuk_template
   -webkit-appearance: none;
 
   // Bottom edge effect


### PR DESCRIPTION
To update button mixin padding and adding outline css. The padding updates increases padding and matches GOV.UK styles. The addition of outline: introduces a Safari focus issue, as mentioned in GOV.UK frontend toolkit - https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/design-patterns/_buttons.scss#L33-L34

## Problem
Buttons sizing out of sync with GOV.UK styles

## Solution
Update padding and add in outline css

### Before
![screen shot 2017-10-03 at 16 31 40](https://user-images.githubusercontent.com/1692222/31133873-8e74e44c-a858-11e7-9474-1c7a01a2bf4d.png)

### After
![screen shot 2017-10-03 at 16 31 12](https://user-images.githubusercontent.com/1692222/31133882-95f3975e-a858-11e7-93d5-9ae67eed30b1.png)

