### PR TITLE
Update visually hidden class to align with GDS Elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Updated visually hidden mixin to align with GDS [#814](https://github.com/hmrc/assets-frontend/pull/814)
 
 ## [2.250.0] - 2017-09-29
 ### Added

--- a/assets/scss/base/_helpers.scss
+++ b/assets/scss/base/_helpers.scss
@@ -318,14 +318,14 @@
  * breakpoint specific hidden elements.
  */
 @mixin accessibility {
-  border: 0 !important;
-  clip: rect(0 0 0 0) !important;
-  height: 1px !important;
-  margin: -1px !important;
-  overflow: hidden !important;
-  padding: 0 !important;
-  position: absolute !important;
-  width: 1px !important;
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
 }
 
 .accessibility,


### PR DESCRIPTION
Fixes issue #727

Removes important clauses which prevented VoiceOver from reading visually hidden copy inside links. Aligns code with GDS Elements.
