### PR TITLE
Notification banner styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Updating `.notice-banner__content` styles so that they're actually visible [#820](https://github.com/hmrc/assets-frontend/pull/820)
 
 ## [2.251.1] - 2017-10-05
 ### Changed

--- a/assets/scss/components/_notice-banner.scss
+++ b/assets/scss/components/_notice-banner.scss
@@ -33,6 +33,7 @@ Styleguide Notification banner
   margin-top: 0;
 }
 
+// needs to be a qualified selector in this instance
 a.notice-banner__content {
   color: $white;
 

--- a/assets/scss/components/_notice-banner.scss
+++ b/assets/scss/components/_notice-banner.scss
@@ -31,7 +31,22 @@ Styleguide Notification banner
 .notice-banner__content {
   color: $white;
   margin-top: 0;
-  a {
+}
+
+a.notice-banner__content {
+  color: $white;
+
+  &:link,
+  &:visited {
+    color: $grey-9;
+  }
+
+  &:focus {
+    color: $black;
+  }
+
+  &:hover,
+  &:active {
     color: $white;
   }
 }


### PR DESCRIPTION
## Problem
The existing styles for the notification banner don't account for pseudo classes on the anchor. 
That means the default styles make the anchor melt into the banner. 

### Example Screenshot
<img width="749" alt="notification-banner-before" src="https://user-images.githubusercontent.com/272769/31448404-472099e8-ae9c-11e7-95af-24149ad5bb91.png">

## Solution
This commit adds styles for those pseudo classes.

### Example Screenshot
<img width="751" alt="notification-banner-after" src="https://user-images.githubusercontent.com/272769/31448425-54e70594-ae9c-11e7-910d-6900b35dfeef.png">
<img width="752" alt="notification-banner-after-focus" src="https://user-images.githubusercontent.com/272769/31448428-583d31f0-ae9c-11e7-8291-ce3bcef0adcf.png">
