### PR TITLE
Minor input type="number" updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## [Unreleased]
+### Changed
+- Minor updates to input type="number" and fix for Firefox [#821](https://github.com/hmrc/assets-frontend/pull/821)
+- Updating `.notice-banner__content` styles so that they're actually visible [#820](https://github.com/hmrc/assets-frontend/pull/820)
 
 ###Fixed
 - Updated validatorFocus javascript to navigate to the input field in IE8 when there is a valudation error.
-
-### Changed
-- Updating `.notice-banner__content` styles so that they're actually visible [#820](https://github.com/hmrc/assets-frontend/pull/820)
 
 ### Added
 - Styling for new full width banner on frontend-template-provider [#824](https://github.com/hmrc/assets-frontend/pull/824)

--- a/assets/scss/base/form/_form.scss
+++ b/assets/scss/base/form/_form.scss
@@ -301,6 +301,10 @@ Markup:
 Styleguide Form.date
 */
 
+input[type=number] {
+  appearance: textfield; // removes default value adjusters in Firefox
+}
+
 .form-date {
   @extend %contain-floats;
   display: inline-block;
@@ -310,16 +314,16 @@ Styleguide Form.date
   }
 }
 
-.form-date .form-group-year {
-  width: 70px;
-}
-
 .form-date .form-group {
-  width: 56px;
+  width: 50px;
   float: left;
   margin-right: 20px;
   margin-bottom: 0;
   clear: none;
+}
+
+.form-date .form-group-year {
+  width: 70px;
 }
 
 /*


### PR DESCRIPTION
## Problem
Currently all 3 date inputs are the same width, despite the 3rd input with class .form-group-year having a set width of 70px. This is because of incorrect hierarchy, so I have move this style below so that the width is assigned correctly.
As default Firefox displays a value adjustment arrows for input type="number" which allow the user to adjust the value within the input.

## Solution
- Moved .form-group-year down, so the larger width is assigned correctly
- Added in appearence: textfield to remove value adjusters in Firefox
- Update value of input width from 56px to 50px inline with GOV.UK

### Before (in Firefox)
<img width="224" alt="screen shot 2017-10-12 at 15 01 17" src="https://user-images.githubusercontent.com/1692222/31500361-188d3bea-af5f-11e7-80cf-edcecfc11d64.png">


### After (in Firefox)
<img width="237" alt="screen shot 2017-10-12 at 15 02 17" src="https://user-images.githubusercontent.com/1692222/31500367-1ef4f2c0-af5f-11e7-966a-10b5d16bc5f4.png">

