### PR TITLE
TAI-3083 : Introduce styling for check-your-answers summary content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ component-library/*
 !gulpfile.js/util/component-library/
 vrt-output/
 backstop.json
+.project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Updating `.notice-banner__content` styles so that they're actually visible [#820](https://github.com/hmrc/assets-frontend/pull/820)
 
+### Added
+- Introduced new summary page styling, derived from GOV.UK design pattern. New sass partial `_check-your-answers.scss` [#823](https://github.com/hmrc/assets-frontend/pull/823)
+
 ## [2.251.1] - 2017-10-05
 ### Changed
 - Updating .form-control styles missed in 2.251.0 [#816](https://github.com/hmrc/assets-frontend/pull/816)

--- a/assets/components/check-your-answers/README.md
+++ b/assets/components/check-your-answers/README.md
@@ -1,4 +1,4 @@
-# Check your answers
+# Check your answers 
 
 A definition list based layout for use in confirmation pages.
 

--- a/assets/components/check-your-answers/README.md
+++ b/assets/components/check-your-answers/README.md
@@ -1,0 +1,5 @@
+# Check your answers
+
+A definition list based layout for use in confirmation pages.
+
+Based upon the GOV.UK service manual [design pattern](https://www.gov.uk/service-manual/design/check-your-answers-pages)

--- a/assets/components/check-your-answers/README.md
+++ b/assets/components/check-your-answers/README.md
@@ -2,4 +2,4 @@
 
 A definition list based layout for use in confirmation pages.
 
-Based upon the GOV.UK service manual [design pattern](https://www.gov.uk/service-manual/design/check-your-answers-pages)
+Based upon the GOV.UK service manual [design pattern](https://www.gov.uk/service-manual/design/check-your-answers-pages).

--- a/assets/components/check-your-answers/_check-your-answers.scss
+++ b/assets/components/check-your-answers/_check-your-answers.scss
@@ -1,0 +1,81 @@
+.govuk-check-your-answers {
+
+  @include media(desktop) {
+    display: table;
+  }
+
+  > * {
+    position: relative;
+    border-bottom: 1px solid $border-colour;
+
+    @include media(desktop) {
+      display: table-row;
+      border-bottom-width: 0;
+    }
+
+    > * {
+      display: block;
+
+      @include media(desktop) {
+        display: table-cell;
+        border-bottom: 1px solid $border-colour;
+        padding: em(12, 19) em(20, 19) em(9, 19) 0; // copied from Elements' td padding
+        margin: 0;
+      }
+    }
+
+    @include media(desktop) {
+      &:first-child > * {
+        padding-top: 0;
+      }
+    }
+  }
+
+  .cya-question {
+    font-weight: bold;
+    margin: em(12, 19) 4em em(4,19) 0;
+    // top: from Elements' td
+    // right: due to length of "change" link (adjust if you change the link to be much longer)
+    // bottom: by eye
+    // using margin instead of padding because of easier absolutely positioning of .change
+  }
+
+  > *:first-child .cya-question {
+    margin-top: 0;
+  }
+
+  @include media(desktop) {
+    // to make group of q&a line up horizontally (unless there is just one group)
+    &.cya-questions-short,
+    &.cya-questions-long {
+      width: 100%;
+    }
+
+    // recommended for mostly short questions
+    &.cya-questions-short .cya-question {
+      width: 30%;
+    }
+
+    // recommended for mostly long questions
+    &.cya-questions-long .cya-question {
+      width: 50%;
+    }
+  }
+
+  .cya-answer {
+    padding-bottom: em(9, 19); // from Elements' td
+  }
+
+  .cya-change {
+    text-align: right;
+    position: absolute;
+    top: 0;
+    right: 0;
+
+    @include media(desktop) {
+      position: static;
+      padding-right: 0;
+    }
+  }
+
+}

--- a/assets/components/check-your-answers/check-your-answers.html
+++ b/assets/components/check-your-answers/check-your-answers.html
@@ -1,0 +1,62 @@
+<h2 class="heading-medium">An example confirmation page</h2>
+
+<dl class="govuk-check-your-answers cya-questions-short">
+  <div>
+    <dt class="cya-question">
+      Name
+    </dt>
+    <dd class="cya-answer">
+      Sarah Philips
+    </dd>
+    <dd class="cya-change">
+      <a href="#">
+        Change<span class="visually-hidden"> name</span>
+      </a>
+    </dd>
+  </div>
+
+  <div>
+    <dt class="cya-question">
+      Date of birth
+    </dt>
+    <dd class="cya-answer">
+      5 January 1978
+    </dd>
+    <dd class="cya-change">
+      <a href="#">
+        Change<span class="visually-hidden"> date of birth</span>
+      </a>
+    </dd>
+  </div>
+
+  <div>
+    <dt class="cya-question">
+      Home address
+    </dt>
+    <dd class="cya-answer">
+      72 Guild Street<br>
+      London<br>
+      SE23 6FH
+    </dd>
+    <dd class="cya-change">
+      <a href="#">
+        Change<span class="visually-hidden"> home address</span>
+      </a>
+    </dd>
+  </div>
+
+  <div>
+    <dt class="cya-question">
+      Contact details
+    </dt>
+    <dd class="cya-answer">
+      07700 900457<br>
+      sarah.phillips@example.com
+    </dd>
+    <dd class="cya-change">
+      <a href="#">
+        Change<span class="visually-hidden"> contact details</span>
+      </a>
+    </dd>
+  </div>
+</dl>

--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -96,6 +96,7 @@ $path: "../images/icons/";
 @import "components/flag";
 @import "components/indent";
 @import "components/page-heading/page-heading";
+@import "components/check-your-answers/check-your-answers";
 
 // Page Specific Styles
 @import "pages/messages";


### PR DESCRIPTION
Introduction of new styling, derived from the GOV.UK design pattern [here](https://www.gov.uk/service-manual/design/check-your-answers-pages)

## Problem
A number of services have the same requirement when developing linear journeys, for an accessible and responsive confirmation page. Rather than define the relevant styling locally to services, we're adding to the assets-frontend library for consistent use across services.

## Solution
The new sass partial we've introduced is taken directly from the GOV.UK service design manual example. No changes have been made.

### Example Screenshot
The screenshot below is taken directly from the GOV.UK service design manual, and an illustration is now included in the generated component library.
![image](https://user-images.githubusercontent.com/5548514/31505444-cf8a3eee-af6c-11e7-9fc4-7835e3075b48.png)
