### PR TITLE
MTA-2832 - Add styling for frontend-template-provider full-width banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Styling for new full width banner on frontend-template-provider [#824](https://github.com/hmrc/assets-frontend/pull/824)
+
 ## [2.251.1] - 2017-10-05
 ### Changed
 - Updating .form-control styles missed in 2.251.0 [#816](https://github.com/hmrc/assets-frontend/pull/816)

--- a/assets/components/account-menu/_account-menu.scss
+++ b/assets/components/account-menu/_account-menu.scss
@@ -291,3 +291,37 @@ p.subnav__section__heading {
     position: static;
   }
 }
+
+.full-width-banner {
+  background-color: #005ea5;
+  color: #fff;
+  display: block;
+}
+.full-width-banner__container {
+  padding: 20px .78947em;
+  position: relative;
+}
+.full-width-banner a {
+  color: #fff;
+}
+.full-width-banner__title {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 5px;
+}
+.full-width-banner__close {
+  color: #fff;
+  font-size: 14px;
+  position: absolute;
+  right: 15px;
+  top: 20px;
+}
+
+@media (min-width: 641px) {
+  .full-width-banner__close {
+    right: 35px;
+  }
+  .full-width-banner__container {
+    padding: 20px 30px 10px;
+  }
+}


### PR DESCRIPTION
Problem
A number of services have use of a full width banner found in the new template.

Solution

Add styling to the banner added into frontend-template-provider

Screenshot
<img width="1076" alt="screen shot 2017-10-16 at 11 54 57" src="https://user-images.githubusercontent.com/29451372/31608686-13a9b04c-b269-11e7-9e6c-f2aca20ae957.png">

