### PR TITLE
Add pathPrefix for template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Replace the component library with the design pattern library [#822](https://github.com/hmrc/assets-frontend/pull/822) 
+* Replace the component library with the design pattern library [#822](https://github.com/hmrc/assets-frontend/pull/822)
 
 ## [2.252.0] - 2017-10-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Replace the component library with the design pattern library [#822](https://github.com/hmrc/assets-frontend/pull/822)
+- Replace the component library with the design pattern library [#822](https://github.com/hmrc/assets-frontend/pull/822) 
 
 ## [2.252.0] - 2017-10-16
 

--- a/gulpfile.js/util/pattern-library/lib/renderPagesFromTemplate.js
+++ b/gulpfile.js/util/pattern-library/lib/renderPagesFromTemplate.js
@@ -7,6 +7,7 @@ var relativeUrl = function (basedir, filePath) {
 var renderPagesFromTemplate = function (files, compiledTemplate, baseDirectory) {
   var data = {}
   var homepage = 'about'
+  var pathPrefix = (global.runmode === 'prod') ? '/assets-frontend' : ''
 
   baseDirectory = baseDirectory || ''
 
@@ -37,6 +38,7 @@ var renderPagesFromTemplate = function (files, compiledTemplate, baseDirectory) 
 
       data.documentation = file.contents.toString()
       data.homepage = currentSection === homepage
+      data.pathPrefix = pathPrefix
 
       file.contents = Buffer.from(compiledTemplate(data))
 


### PR DESCRIPTION
## Problem

The github pages domain is a subdirectory (i.e. http://hmrc.github.io/assets-frontend/) but the template's asset paths in the template are root absolute.

## Solution

Add a `pathPrefix` that gets passed into the template when the gulp task is built in `prod` mode (i.e. on CI).
