### PR TITLE
Use NODE_ENV for building pattern library on CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Changed
-
 * Replace the component library with the design pattern library [#822](https://github.com/hmrc/assets-frontend/pull/822)
 
 ## [2.252.0] - 2017-10-16
 
 ### Changed
-
 - Minor updates to input type="number" and fix for Firefox [#821](https://github.com/hmrc/assets-frontend/pull/821)
 - Updating `.notice-banner__content` styles so that they're actually visible [#820](https://github.com/hmrc/assets-frontend/pull/820)
 
 ### Fixed
-
 - Updated validatorFocus javascript to navigate to the input field in IE8 when there is a valudation error. [#805](https://github.com/hmrc/assets-frontend/pull/805)
 
 ### Added
-
 - Styling for new full width banner on frontend-template-provider [#824](https://github.com/hmrc/assets-frontend/pull/824)
 - Introduced new summary page styling, derived from GOV.UK design pattern. New sass partial `_check-your-answers.scss` [#823](https://github.com/hmrc/assets-frontend/pull/823)
 

--- a/gulpfile.js/util/pattern-library/lib/renderPagesFromTemplate.js
+++ b/gulpfile.js/util/pattern-library/lib/renderPagesFromTemplate.js
@@ -7,7 +7,7 @@ var relativeUrl = function (basedir, filePath) {
 var renderPagesFromTemplate = function (files, compiledTemplate, baseDirectory) {
   var data = {}
   var homepage = 'about'
-  var pathPrefix = (global.runmode === 'prod') ? '/assets-frontend' : ''
+  var pathPrefix = (process.env.NODE_ENV === 'prod') ? '/assets-frontend' : ''
 
   baseDirectory = baseDirectory || ''
 


### PR DESCRIPTION
# Problem

The pattern library is run as a separate job on our jenkins so `global.runmode` doesn't get set to `prod`.

# Solution

Use `NODE_ENV` instead and run the pattern library on CI with that instead:

`NODE_ENV='prod' npm run pattern-library`