### PR TITLE
Fix the language toggle example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 * Replace the component library with a new design pattern library [#822](https://github.com/hmrc/assets-frontend/pull/822) 
-* Add header component to the new design system
+* Add header component to the new design system 
 * Use macros for example and markup rendering in README.md
 
 ## [2.252.0] - 2017-10-16

--- a/assets/components/header/header--signed-in.html
+++ b/assets/components/header/header--signed-in.html
@@ -53,7 +53,8 @@
   <!-- LANGUAGE TOGGLE -->
   <div class="lang-select">
     <ul>
-      <li><a href="#">English</a></li>
+      <li>English</li>
+      <li>|</li>
       <li><a href="#">Cymraeg</a></li>
     </ul>
   </div>

--- a/assets/components/header/header.html
+++ b/assets/components/header/header.html
@@ -47,7 +47,8 @@
   <!-- LANGUAGE TOGGLE -->
   <div class="lang-select">
     <ul>
-      <li><a href="#">English</a></li>
+      <li>English</li>
+      <li>|</li>
       <li><a href="#">Cymraeg</a></li>
     </ul>
   </div>


### PR DESCRIPTION
## Problem

The language select is missing a pipe (`|`) between the words "English Cymraeg" and the word "English" is a link.

### Screenshot before
![image](https://user-images.githubusercontent.com/868772/31729251-620cdea8-b426-11e7-8c15-dca5063b9352.png)


## Solution
Added a pipe and removed the link from the word "English"

### Screenshot after 
![image](https://user-images.githubusercontent.com/868772/31729228-57f60d72-b426-11e7-9185-026b5f3984eb.png)



