### PR TITLE
whitelist README.md files from CHANGELOG check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Add header component to the new design system  
 * Use macros for example and markup rendering in README.md
 * Modify CHANGELOG.md change verification to stabilise Travis CI [#833](https://github.com/hmrc/assets-frontend/pull/833)
+* Allow README.md only changes to be merged without forcing CHANGELOG.md to be changed [#836](https://github.com/hmrc/assets-frontend/pull/836)
 
 ## [2.252.0] - 2017-10-16
 

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -4,6 +4,8 @@ const gulp = require('gulp')
 const exec = require('child_process').exec
 
 const MASTER_BRANCH = 'master'
+const CHANGELOG_MD = 'CHANGELOG.md'
+const README_MD = 'README.md'
 
 function runCommand (cmd) {
   return new Promise((resolve, reject) => {
@@ -35,12 +37,23 @@ function isWhitelistBranch (branch) {
   return (branch.trim() === MASTER_BRANCH)
 }
 
+function filterFiles(files) {
+  return files.filter(file => !file.includes(README_MD))
+}
+
 function verifyGitDiffs (diffs) {
+  diffs = diffs || ''
+
+  let files = diffs.trim().split('\n')
+  let filteredFiles = filterFiles(files)
+
   return new Promise((resolve, reject) => {
-    if (!diffs || !diffs.includes('CHANGELOG.md')) {
-      reject(new Error('CHANGELOG.md was not updated'))
-    } else {
+    if (filteredFiles.length === 0) {
       resolve(true)
+    } else if (filteredFiles.indexOf(CHANGELOG_MD) !== -1) {
+      resolve(true)
+    } else {
+      reject(new Error('CHANGELOG.md was not updated'))
     }
   })
 }
@@ -59,5 +72,6 @@ module.exports = {
   getCurrentBranch: getCurrentBranch,
   getGitDiffs: getGitDiffs,
   isWhitelistBranch: isWhitelistBranch,
+  filterFiles: filterFiles,
   verifyGitDiffs: verifyGitDiffs
 }

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -37,7 +37,7 @@ function isWhitelistBranch (branch) {
   return (branch.trim() === MASTER_BRANCH)
 }
 
-function filterFiles(files) {
+function filterFiles (files) {
   return files.filter(file => !file.includes(README_MD))
 }
 

--- a/gulpfile.js/tests/changelog.test.js
+++ b/gulpfile.js/tests/changelog.test.js
@@ -69,7 +69,6 @@ test('changelog - verifyGitDiffs', (t) => {
       t.ok(err.message.includes('CHANGELOG.md was not updated'), 'returns an error message')
     })
 
-
   t.ok(changelog.verifyGitDiffs('string').then(), 'returns a promise')
 
   changelog

--- a/gulpfile.js/tests/changelog.test.js
+++ b/gulpfile.js/tests/changelog.test.js
@@ -37,8 +37,16 @@ test('changelog - isWhitelistBranch', (t) => {
   t.ok(changelog.isWhitelistBranch('master'))
 })
 
+test('changelog - filterFiles', (t) => {
+  t.plan(3)
+
+  t.equal(changelog.filterFiles(['README.md', 'another.md']).length, 1, 'returns 1 as only README has filtered')
+  t.equal(changelog.filterFiles(['README.md', 'README.md', 'README.md', 'README.md', 'another.md']).length, 1, 'returns 1 as only README has filtered')
+  t.equal(changelog.filterFiles(['README.md', 'another.md'])[0], 'another.md', 'returns a string representing the only item')
+})
+
 test('changelog - verifyGitDiffs', (t) => {
-  t.plan(6)
+  t.plan(9)
 
   changelog
     .verifyGitDiffs()
@@ -54,11 +62,25 @@ test('changelog - verifyGitDiffs', (t) => {
       t.ok(err.message.includes('CHANGELOG.md was not updated'), 'returns an error message')
     })
 
+  changelog
+    .verifyGitDiffs('file1\nREADME.md\nfolder1/README.md')
+    .catch(function (err) {
+      t.ok(err instanceof Error, 'returns an Error if the command fails')
+      t.ok(err.message.includes('CHANGELOG.md was not updated'), 'returns an error message')
+    })
+
+
   t.ok(changelog.verifyGitDiffs('string').then(), 'returns a promise')
 
   changelog
     .verifyGitDiffs('file1\nCHANGELOG.md\nfile')
     .then((res) => {
       t.ok(res, 'returns true as CHANGELOG.md is in the list')
+    })
+
+  changelog
+    .verifyGitDiffs('README.md\nfolder1/README.md\nfolder2/README.md')
+    .then((res) => {
+      t.ok(res, 'returns true as CHANGELOG.md should not be changed')
     })
 })


### PR DESCRIPTION
## Problem
Even if only a README markdown has changed the build fails due to untouched CHANGELOG.md

## Solution
Whitelist README.md files so build won't fail