### PR TITLE
Implement wip macro and replace the code duplications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - 404 page pattern [#835](https://github.com/hmrc/assets-frontend/pull/835)
 - Shutter Page pattern [#838](https://github.com/hmrc/assets-frontend/pull/838)
 - Added the image `icon-print.svg` [#841](https://github.com/hmrc/assets-frontend/pull/841)
+- Add WIP macro [#843](https://github.com/hmrc/assets-frontend/pull/843)
 
 ### Changed
 * Replace the component library with a new design pattern library [#822](https://github.com/hmrc/assets-frontend/pull/822) 

--- a/assets/components/account-menu/README.md
+++ b/assets/components/account-menu/README.md
@@ -1,11 +1,6 @@
 # Account Menu
 
-<div class="alert alert--info">
-
-<p class="alert__message">This pattern is work in progress.</p>
-<p class="alert__message">View the todo list for this pattern on [GitHub](https://github.com/hmrc/design-patterns/issues/128).</p>
-
-</div>
+{{ wip('https://github.com/hmrc/design-patterns/issues/128') }}
 
 An account menu for services with accounts.
 

--- a/assets/components/account-menu/README.md
+++ b/assets/components/account-menu/README.md
@@ -1,6 +1,6 @@
 # Account Menu
 
-{{ wip('https://github.com/hmrc/design-patterns/issues/128') }}
+{{ wip(128) }}
 
 An account menu for services with accounts.
 

--- a/assets/components/header/README.md
+++ b/assets/components/header/README.md
@@ -1,6 +1,6 @@
 # Header
 
-{{ wip('https://github.com/hmrc/design-patterns/issues/4') }}
+{{ wip(4) }}
 
 The HMRC header is the same as the [GOV.UK header](https://www.gov.uk/service-manual/design/add-the-govuk-header-and-footer) but includes the HMRC logo. All elements that are imported from the GOV.UK header must not be changed.
 

--- a/assets/components/header/README.md
+++ b/assets/components/header/README.md
@@ -1,9 +1,6 @@
 # Header
 
-<div class="alert alert--info">
-  <p class="alert__message">This is a work in progress.</p>
-  <p class="alert__message">You can use it in your service but you should [contribute research](https://github.com/hmrc/design-patterns/issues/4).</p>
-</div>
+{{ wip('https://github.com/hmrc/design-patterns/issues/4') }}
 
 The HMRC header is the same as the [GOV.UK header](https://www.gov.uk/service-manual/design/add-the-govuk-header-and-footer) but includes the HMRC logo. All elements that are imported from the GOV.UK header must not be changed.
 

--- a/assets/patterns/404-page/README.md
+++ b/assets/patterns/404-page/README.md
@@ -1,6 +1,6 @@
 # 404 page
 
-{{ wip('https://github.com/hmrc/design-patterns/issues/104') }}
+{{ wip(104) }}
 
 404 pages (usually described as a 'page not found') tell users that the page they were trying to access is not there.
 

--- a/assets/patterns/404-page/README.md
+++ b/assets/patterns/404-page/README.md
@@ -1,11 +1,6 @@
 # 404 page
 
-<div class="alert alert--info">
-
-<p class="alert__message">This pattern is work in progress.</p>
-<p class="alert__message">View the todo list for this pattern on [GitHub](https://github.com/hmrc/design-patterns/issues/104).</p>
-
-</div>
+{{ wip('https://github.com/hmrc/design-patterns/issues/104') }}
 
 404 pages (usually described as a 'page not found') tell users that the page they were trying to access is not there.
 

--- a/assets/patterns/shutter-pages/README.md
+++ b/assets/patterns/shutter-pages/README.md
@@ -1,6 +1,6 @@
 # Shutter pages
 
-{{ wip('https://github.com/hmrc/design-patterns/issues/103') }}
+{{ wip(103) }}
 
 A shutter page is a page that is shown when a service has been switched off on purpose. These are different to [page not found](/pages/404-pages/index) and [technical difficulties](/pages/500-pages/index) pages.
 

--- a/assets/patterns/shutter-pages/README.md
+++ b/assets/patterns/shutter-pages/README.md
@@ -1,11 +1,6 @@
 # Shutter pages
 
-<div class="alert alert--info">
-
-<p class="alert__message">This pattern is work in progress.</p>
-<p class="alert__message">View the todo list for this pattern on [GitHub](https://github.com/hmrc/design-patterns/issues/103).</p>
-
-</div>
+{{ wip('https://github.com/hmrc/design-patterns/issues/103') }}
 
 A shutter page is a page that is shown when a service has been switched off on purpose. These are different to [page not found](/pages/404-pages/index) and [technical difficulties](/pages/500-pages/index) pages.
 

--- a/gulpfile.js/util/pattern-library/lib/parseDocumentation.js
+++ b/gulpfile.js/util/pattern-library/lib/parseDocumentation.js
@@ -12,6 +12,7 @@ var parseDocumentation = function (files) {
     var fileContents = [
       `{% from 'example.html' import example %}`,
       `{% from 'markup.html' import markup %}`,
+      `{% from 'wip.html' import wip %}`,
       file.contents.toString()
     ].join('\n')
 

--- a/gulpfile.js/util/pattern-library/macros/wip.html
+++ b/gulpfile.js/util/pattern-library/macros/wip.html
@@ -1,13 +1,11 @@
 {% macro wip(issue) %}
-<div class="wip">
-  <div class="alert alert--info">
-    <p class="alert__message">This component is work in progress.</p>
-    <p class="alert__message">
+  <div class="panel panel-border-narrow">
+    <p class="heading-small">This component is work in progress.</p>
+    <p>
       View the todo list for this pattern on
       <a href="https://github.com/hmrc/design-patterns/issues/{{ issue }}" target="_blank">
         GitHub (opens in a new window or tab)
       </a>
     </p>
   </div>
-</div>
 {% endmacro %}

--- a/gulpfile.js/util/pattern-library/macros/wip.html
+++ b/gulpfile.js/util/pattern-library/macros/wip.html
@@ -3,7 +3,9 @@
   <p class="alert__message">This component is work in progress.</p>
   <p class="alert__message">
     View the todo list for this pattern on
-    <a href="https://github.com/hmrc/design-patterns/issues/{{ issue }}" target="_blank">GitHub</a>
+    <a href="https://github.com/hmrc/design-patterns/issues/{{ issue }}" target="_blank">
+      GitHub (opens in a new window or tab)
+    </a>
   </p>
 </div>
 {% endmacro %}

--- a/gulpfile.js/util/pattern-library/macros/wip.html
+++ b/gulpfile.js/util/pattern-library/macros/wip.html
@@ -1,11 +1,13 @@
 {% macro wip(issue) %}
-<div class="alert alert--info">
-  <p class="alert__message">This component is work in progress.</p>
-  <p class="alert__message">
-    View the todo list for this pattern on
-    <a href="https://github.com/hmrc/design-patterns/issues/{{ issue }}" target="_blank">
-      GitHub (opens in a new window or tab)
-    </a>
-  </p>
+<div class="wip">
+  <div class="alert alert--info">
+    <p class="alert__message">This component is work in progress.</p>
+    <p class="alert__message">
+      View the todo list for this pattern on
+      <a href="https://github.com/hmrc/design-patterns/issues/{{ issue }}" target="_blank">
+        GitHub (opens in a new window or tab)
+      </a>
+    </p>
+  </div>
 </div>
 {% endmacro %}

--- a/gulpfile.js/util/pattern-library/macros/wip.html
+++ b/gulpfile.js/util/pattern-library/macros/wip.html
@@ -1,8 +1,9 @@
-{% macro wip(url) %}
+{% macro wip(issue) %}
 <div class="alert alert--info">
   <p class="alert__message">This component is work in progress.</p>
   <p class="alert__message">
-    You can use it in your service but you should <a href="{{ url }}">contribute research</a>.
+    View the todo list for this pattern on
+    <a href="https://github.com/hmrc/design-patterns/issues/{{ issue }}" target="_blank">GitHub</a>
   </p>
 </div>
 {% endmacro %}

--- a/gulpfile.js/util/pattern-library/macros/wip.html
+++ b/gulpfile.js/util/pattern-library/macros/wip.html
@@ -1,0 +1,8 @@
+{% macro wip(url) %}
+<div class="alert alert--info">
+  <p class="alert__message">This component is work in progress.</p>
+  <p class="alert__message">
+    You can use it in your service but you should <a href="{{ url }}">contribute research</a>.
+  </p>
+</div>
+{% endmacro %}


### PR DESCRIPTION
## Problem
WIP banner code is duplicated across markdowns.

### Example Screenshot
<img width="1120" alt="screen shot 2017-10-24 at 13 02 01" src="https://user-images.githubusercontent.com/18576086/31987746-af40109e-b964-11e7-83a6-9cd279e719be.png">

## Solution
Introduce a macro to centralise the markup and to provide a reusable component.

### Example Screenshot
<img width="768" alt="screen shot 2017-10-25 at 14 17 42" src="https://user-images.githubusercontent.com/18576086/32040784-ce7bbdf8-ba29-11e7-80ef-6b28d389251f.png">
