### PR TITLE
remove layout overrides to match GDS style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Changed a reference to an svg icon to a data uri
 - Updated .nvmrc file to use up to date node version for AF
 
+### Changed
+* Remove style overrides for layout and typography for the Design System [#851](https://github.com/hmrc/assets-frontend/pull/851)  
+
 ## [2.253.0] - 2017-10-26
 
 ### Added

--- a/assets/components/account-menu/_account-menu.scss
+++ b/assets/components/account-menu/_account-menu.scss
@@ -1,73 +1,3 @@
-.grid-row {
-  margin: 0 -15px;
-}
-
-.column-quarter,
-.column-one-quarter {
-  padding: 0 15px;
-  box-sizing: border-box;
-}
-
-@media (min-width: 641px) {
-  .column-quarter,
-  .column-one-quarter {
-    float: left;
-    width: 25%;
-  }
-}
-
-.column-half,
-.column-one-half {
-  padding: 0 15px;
-  box-sizing: border-box; 
-}
-
-@media (min-width: 641px) {
-  .column-half,
-  .column-one-half {
-    float: left;
-    width: 50%;
-  }
-}
-
-.column-third,
-.column-one-third {
-  padding: 0 15px;
-  box-sizing: border-box;
-}
-
-@media (min-width: 641px) {
-  .column-third,
-  .column-one-third {
-    float: left;
-    width: 33.33333%;
-  }
-}
-
-.column-two-thirds {
-  padding: 0 15px;
-  box-sizing: border-box;
-}
-
-@media (min-width: 641px) {
-  .column-two-thirds {
-    float: left;
-    width: 66.66667%;
-  }
-}
-
-.column-full {
-  padding: 0 15px;
-  box-sizing: border-box;
-}
-
-@media (min-width: 641px) {
-  .column-full {
-    float: left;
-    width: 100%;
-  }
-}
-
 .account-icon {
   background-repeat: no-repeat;
 }
@@ -149,12 +79,10 @@
 
 .account-menu__main {
   float: right;
-  margin: auto;
   margin: initial;
 
   li {
     @include inline-block;
-    margin: auto;
     margin: initial;
   }
 }

--- a/design-system.md
+++ b/design-system.md
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-<main id="design-system-content" class="technical-documentation markdown" data-module="anchored-headings">
+<main id="design-system-content" data-module="anchored-headings">
   <div class="grid-row">
     <div class="column-full">
       <section>

--- a/design-system.md
+++ b/design-system.md
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-<main id="design-system-content" data-module="anchored-headings">
+<main id="design-system-content" class="markdown" data-module="anchored-headings">
   <div class="grid-row">
     <div class="column-full">
       <section>


### PR DESCRIPTION
## Problem
Elements on the homepage (About) are misaligned due to the inherited `technical-documantion` wrapper.

### Example Screenshot
![image-2017-10-27-09-52-38-187](https://user-images.githubusercontent.com/18576086/32107351-3c754fac-bb26-11e7-95e8-9c1956d38ec2.png)

## Solution
Consolidate CSS and markup to avoid any inherited overrides.