### PR TITLE
Removed an unnecessary heading

### DIFF
--- a/assets/patterns/500-pages/README.md
+++ b/assets/patterns/500-pages/README.md
@@ -4,8 +4,6 @@
 
 500 pages are used to tell users that we [HMRC] have a problem that was not their fault.
 
-### Standard 500 Page example
-
 {{ example('500-page.html', true) }}
 
 ## When to use a 500 page 


### PR DESCRIPTION
There was an H3 introducing the first example that is not needed.