### PR TITLE
Changing the inset text to match GOV.UK elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+and this project adheres to [Semantic Versioning](http://semver.org/). 
 
 ## [Unreleased]
 - Changed a reference to an svg icon to a data uri

--- a/gulpfile.js/util/pattern-library/macros/wip.html
+++ b/gulpfile.js/util/pattern-library/macros/wip.html
@@ -1,5 +1,5 @@
 {% macro wip(issue) %}
-  <div class="panel panel-border-narrow">
+  <div class="panel panel-border-wide">
     <p class="heading-small">This component is work in progress.</p>
     <p>
       View the todo list for this pattern on


### PR DESCRIPTION
## Problem
GOV.UK elements uses a wider version which has more impact on the page. I think we should be encouraging people to use.

### Example Screenshot
![screenshot 2017-10-31 15 49 42](https://user-images.githubusercontent.com/868772/32233825-3b233f58-be53-11e7-8197-00954d1d4cd5.png)


## Solution
Changes the modifier on the class from `panel-border-narrow` to `panel-border-wide`

### Example Screenshot
![screenshot 2017-10-31 15 49 59](https://user-images.githubusercontent.com/868772/32233863-5c28f8f0-be53-11e7-906c-a6225a3fca06.png)

