### PR TITLE
Adds a close link to the banner, with cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/). 
+and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 - Changed a reference to an svg icon to a data uri
 - Updated .nvmrc file to use up to date node version for AF
+- Adds a close link to the banner, with cookie
 
 ### Changed
-* Remove style overrides for layout and typography for the Design System [#851](https://github.com/hmrc/assets-frontend/pull/851)  
+* Remove style overrides for layout and typography for the Design System [#851](https://github.com/hmrc/assets-frontend/pull/851)
 
 ## [2.253.0] - 2017-10-26
 
@@ -22,10 +23,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add WIP macro [#843](https://github.com/hmrc/assets-frontend/pull/843)
 
 ### Changed
-* Replace the component library with a new design pattern library [#822](https://github.com/hmrc/assets-frontend/pull/822) 
+* Replace the component library with a new design pattern library [#822](https://github.com/hmrc/assets-frontend/pull/822)
 * Add header component to the new design system  [#829](https://github.com/hmrc/assets-frontend/pull/829)
 * Use macros for example and markup rendering in README.md [#828](https://github.com/hmrc/assets-frontend/pull/828)
-* Modify CHANGELOG.md change verification to stabilise Travis CI [#833](https://github.com/hmrc/assets-frontend/pull/833) 
+* Modify CHANGELOG.md change verification to stabilise Travis CI [#833](https://github.com/hmrc/assets-frontend/pull/833)
 * Allow README.md only changes to be merged without forcing CHANGELOG.md to be changed [#836](https://github.com/hmrc/assets-frontend/pull/836)
 * Replaced [_panels.scss](https://github.com/hmrc/assets-frontend/pull/835/commits/31e4c36c1a94e151448b23b34670fff7232d7823) with content from GOV.UK [#835](https://github.com/hmrc/assets-frontend/pull/835)
 * Updated the homepage with a description of patterns [#846](https://github.com/hmrc/assets-frontend/pull/846)

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -50,6 +50,7 @@ var addRemove = require('./modules/addRemove.js')
 var modalDialog = require('./modules/modalDialog.js')
 var dynamicGaTags = require('./modules/dynamicGaTags.js')
 var listCollapse = require('./modules/listCollapse.js')
+var noticeBanner = require('./modules/noticeBanner.js')
 
 // initialise mdtpf
 fingerprint()
@@ -177,4 +178,5 @@ $(function () {
   modalDialog()
   dynamicGaTags()
   listCollapse()
+  noticeBanner()
 })

--- a/assets/javascripts/modules/noticeBanner.js
+++ b/assets/javascripts/modules/noticeBanner.js
@@ -1,0 +1,27 @@
+/* eslint-env jquery */
+
+require('jquery')
+
+var govuk = require('./GOVUK_helpers.js')
+
+module.exports = function () {
+// =====================================================
+// Handle the UR banner dismiss link functionality
+// =====================================================
+  var cookieName = 'mdtpurr'
+  var noticeBanner = $('#notice-banner')
+  var cookieData = govuk.getCookie(cookieName)
+  var noticeBannerShow = 'notice-banner--show'
+  var expiryDate = new Date()
+
+  if (cookieData == null) {
+    noticeBanner.addClass(noticeBannerShow).removeClass('js-hidden')
+  }
+
+  $('.notice-banner__close').on('click', function (e) {
+    e.preventDefault()
+    var oneMonthInFuture = expiryDate.setMonth(expiryDate.getMonth() + 1)
+    govuk.setCookie(cookieName, 'suppress_for_all_services', oneMonthInFuture)
+    noticeBanner.removeClass(noticeBannerShow).addClass('js-hidden')
+  })
+}

--- a/assets/scss/components/_notice-banner.scss
+++ b/assets/scss/components/_notice-banner.scss
@@ -2,10 +2,15 @@
 Notification banner
 
 Markup:
-<div class="notice-banner">
-  <div class="notice-banner__wrapper">
-    <h3 class="notice-banner__content">Please help us improve our service</h3>
-    <a class="notice-banner__content" href="#">Enter our survey</a>
+<div class="js-hidden notice-banner" id="notice-banner">
+  <div class="notice-banner__wrapper grid-layout">
+    <div class="grid-layout__column--2-3">
+      <h3 class="notice-banner__content">Please help us improve our service</h3>
+      <a class="notice-banner__content" href="#">Enter our survey</a>
+    </div>
+    <div class="grid-layout__column--1-3 text--right">
+      <a class="notice-banner__close notice-banner__content" href="#">No thanks</a>
+    </div>
   </div>
 </div>
 
@@ -20,7 +25,7 @@ Styleguide Notification banner
 }
 
 .notice-banner__wrapper {
-  max-width: 960px;
+  @include box-sizing(border-box);
   margin: 0 auto;
   padding: 15px;
   @include media(tablet) {

--- a/assets/test/specs/fixtures/notice-banner-fixture.html
+++ b/assets/test/specs/fixtures/notice-banner-fixture.html
@@ -1,0 +1,11 @@
+<div class="js-hidden notice-banner" id="notice-banner">
+  <div class="notice-banner__wrapper grid-layout">
+    <div class="grid-layout__column--2-3">
+      <h3 class="notice-banner__content">Please help us improve our service</h3>
+      <a class="notice-banner__content" href="#">Enter our survey</a>
+    </div>
+    <div class="grid-layout__column--1-3 text--right">
+      <a class="notice-banner__close notice-banner__content" href="#">No thanks</a>
+    </div>
+  </div>
+</div>

--- a/assets/test/specs/noticeBanner.spec.js
+++ b/assets/test/specs/noticeBanner.spec.js
@@ -1,0 +1,82 @@
+/* eslint-env jasmine, jquery */
+/* global loadFixtures */
+
+require('jquery')
+
+var govuk = require('../../javascripts/modules/GOVUK_helpers.js')
+
+describe('Given I have a notice banner on the page', function () {
+  var $jsHiddenClass = 'js-hidden'
+  var fixtureFile = 'notice-banner-fixture.html'
+  var cookieDataValue = 'suppress_for_all_services'
+  var cookieName = 'mdtpurr'
+  var noticeBannerJavascript
+  var $cookieData
+  var $noticeBanner
+  var $closeBannerLink
+
+  beforeEach(function () {
+    jasmine.getFixtures().fixturesPath = 'base/test/specs/fixtures/'
+    loadFixtures(fixtureFile)
+
+    noticeBannerJavascript = require('../../javascripts/modules/noticeBanner.js')
+  })
+
+  afterEach(function () {
+    $cookieData = govuk.setCookie(cookieName, '', -1)
+  })
+
+  describe('loading the page with cookie set and not clicking the close link', function () {
+    beforeEach(function () {
+      loadFixtures(fixtureFile)
+      $noticeBanner = $('#notice-banner')
+      govuk.setCookie(cookieName, cookieDataValue, 999)
+      $cookieData = govuk.getCookie(cookieName)
+      noticeBannerJavascript()
+    })
+
+    it('the cookie should have a value', function () {
+      expect($cookieData).toBe(cookieDataValue)
+    })
+
+    it('the banner should not be visible', function () {
+      expect($noticeBanner).toHaveClass($jsHiddenClass)
+    })
+  })
+
+  describe('loading the page without the cookie set and not clicking the close link', function () {
+    beforeEach(function () {
+      loadFixtures(fixtureFile)
+      noticeBannerJavascript()
+      $noticeBanner = $('#notice-banner')
+    })
+
+    it('the cookie should be null', function () {
+      $cookieData = govuk.getCookie(cookieName)
+      expect($cookieData).toBe(null)
+    })
+
+    it('the banner should be visible', function () {
+      expect($noticeBanner).not.toHaveClass($jsHiddenClass)
+    })
+  })
+
+  describe('loading the page without a cookie and clicking the close link', function () {
+    beforeEach(function () {
+      loadFixtures(fixtureFile)
+      noticeBannerJavascript()
+      $closeBannerLink = $('.notice-banner__close')
+      $closeBannerLink.click()
+      $noticeBanner = $('#notice-banner')
+    })
+
+    it('the cookie data should have the value surpress_for_all_services', function () {
+      $cookieData = govuk.getCookie(cookieName)
+      expect($cookieData).toBe(cookieDataValue)
+    })
+
+    it('the banner should not be visible', function () {
+      expect($noticeBanner).toHaveClass($jsHiddenClass)
+    })
+  })
+})


### PR DESCRIPTION
## Problem
The original banner didn't have a link to close it and set a cookie to keep it closed. This led to lots of teams adding their own, which meant lots of versions of the same thing and a whole lot of different cookie names. 

### Example Screenshot
<img width="754" alt="notification-banner-before" src="https://user-images.githubusercontent.com/272769/32772175-ff7a82d4-c91c-11e7-8f73-06ff63b31cdc.png">

## Solution
This adds the missing link, which closes the banner and keeps it closed with a cookie that has _the correct name_. 

### Example Screenshot
<img width="752" alt="notification-banner-after" src="https://user-images.githubusercontent.com/272769/32772183-0b154818-c91d-11e7-964f-72dca7a16d91.png">

