### PR TITLE
MTA-2870 Resolve navigation snag list v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ This entire version is covered by a single pull request. [#867](https://github.c
 - Updated .nvmrc file to use up to date node version for AF [#848](https://github.com/hmrc/assets-frontend/pull/848)
 - Remove style overrides for layout and typography for the Design System [#851](https://github.com/hmrc/assets-frontend/pull/851)
 - Add Styles tab with a reference for Component Library [#858](https://github.com/hmrc/assets-frontend/pull/858)
+- Resolve navigation snag list for Frontend-template [#861](https://github.com/hmrc/assets-frontend/pull/861)
 - Add Styles to fix singleCheckbox error message placement [#864](https://github.com/hmrc/assets-frontend/pull/864)
 
 ## Fixed

--- a/assets/components/account-header/account-header-example.html
+++ b/assets/components/account-header/account-header-example.html
@@ -18,6 +18,16 @@
       <div class="content">
         <nav id="proposition-menu">
           <a href="#" id="proposition-name">Personal tax account</a>
+          <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
+          <ul id="proposition-links" class="header__menu__proposition-links">
+
+            <li>
+              <span class="faded-text--small"><strong>English |</strong></span>
+              <a id="switchToWelsh" lang="cy" href="/personal-account/lang/cyGb?redirectUrl&#61;%2Fpersonal-account" data-journey-click="link - click:lang-select:Cymraeg"><small><strong>Cymraeg</strong></small></a>
+            </li>
+
+
+          </ul>
         </nav>
       </div>
     </div>
@@ -27,76 +37,124 @@
 <!-- END GOV.UK HEADER -->
 <main id="content" role="main">
 <!-- ACCOUNT MENU -->
-<nav id="secondary-nav" class="account-menu" role="navigation">
-  <a href="#" class="account-menu__link account-menu__link--active account-menu__link--home "><span class="account-icon account-icon--home">Account home</span></a>
-  <a href="#" class="account-menu__link account-menu__link--menu js-hidden js-visible" aria-hidden="true" aria-expanded="false">Account menu</a>
+  <nav id="secondary-nav" class="account-menu js-enabled" role="navigation">
+    <a href="http://localhost:9232/personal-account" class="account-menu__link account-menu__link--home account-menu__link--active" data-journey-click="link - click:utility-nav:Account home">
+                        <span class="account-icon account-icon--home">
 
-  <ul class="account-menu__main">
-    <li class="account-menu__link--back hidden" aria-hidden="true"><a href="#" class="account-menu__link">Back</a></li>
 
-    <li><a href="messages" class="account-menu__link">Messages</a></li>
+                                Account home
 
-    <li><a href="track-your-forms" class="account-menu__link">Check progress</a></li>
+                        </span>
+    </a>
 
-    <li>
-      <a href="#subnav-1" id="account-menu__main-1" class="account-menu__link account-icon account-menu__link--more" aria-haspopup="true" aria-owns="subnav-1">Get help</a>
+    <a href="#" class="account-menu__link account-menu__link--menu js-hidden js-visible" aria-hidden="true" aria-expanded="false" data-journey-click="link - click:utility-nav:Account menu">
 
-      <div class="subnav js-hidden" id="subnav-1" role="navigation" aria-labelledby="account-menu__main-1" aria-label="Get help">
-        <div class="column-one-third subnav__section">
-          <p class="subnav__section__heading">Live chat</p>
-          <div><a href="#">Chat with us now</a></div>
-          <p>Live chat is available and the queue time is currently around 12 minutes</p>
+
+      Account menu
+
+    </a>
+
+    <ul class="account-menu__main">
+      <li class="account-menu__link--back hidden" aria-hidden="true">
+        <a href="#" class="account-menu__link" data-journey-click="link - click:utility-nav:Back">
+
+
+          Back
+
+        </a>
+      </li>
+
+      <li>
+        <a href="http://localhost:9232/personal-account/messages" class="account-menu__link" data-journey-click="link - click:utility-nav:Messages">
+
+
+          Messages
+
+        </a>
+      </li>
+
+      <li>
+        <a href="http://localhost:9100/track" class="account-menu__link" data-journey-click="link - click:utility-nav:Check progress">
+
+
+          Check progress
+
+        </a>
+      </li>
+
+      <li>
+        <a href="#subnav-your-account" id="account-menu__main-2" class="account-menu__link account-icon account-menu__link--more js-enabled" aria-haspopup="true" aria-owns="subnav-your-account" data-journey-click="accordion - click:utility-nav:Your account" aria-expanded="false">
+
+
+          Your account
+
+        </a>
+
+        <div class="subnav" id="subnav-your-account" role="navigation" aria-labelledby="account-menu__main-2" aria-label="Your account" aria-hidden="true" tabindex="-1">
+
+
+
+
+          <div class="
+                                 column-half
+
+                                 subnav__section">
+            <p class="subnav__section__heading">
+
+
+              Paperless settings
+
+            </p>
+            <div>
+              <a href="http://localhost:9232/personal-account/preferences" data-journey-click="link - click:utility-nav:Manage your paperless settings">
+
+
+                Manage your paperless settings
+
+              </a>
+            </div>
+          </div>
+          <div class="
+                                 column-half
+
+                                 subnav__section">
+            <p class="subnav__section__heading">
+
+
+              Personal details
+
+            </p>
+            <div>
+              <a href="http://localhost:9232/personal-account/personal-details" data-journey-click="link - click:utility-nav:Manage your personal details">
+
+
+                Manage your personal details
+
+              </a>
+            </div>
+          </div>
         </div>
-        <div class="column-one-third subnav__section">
-          <p class="subnav__section__heading">Phone</p>
-          <div>01234 567 890</div>
-          <p>Lines are currently closed and will reopen tomorrow at 8:00am</p>
-        </div>
-        <div class="column-one-third subnav__section">
-          <p class="subnav__section__heading">Technical problems</p>
-          <div><a href="#">Report a technical problem</a></div>
-          <p>We aim to reply within 72 hours</p>
-        </div>
-      </div>
-    </li>
+      </li>
 
-    <li>
-      <a href="#subnav-2" id="account-menu__main-2" class="account-menu__link account-icon account-menu__link--more" aria-haspopup="true" aria-owns="subnav-2">Your account</a>
+      <li>
+        <a href="/personal-account/signout?continueUrl=http%3A%2F%2Flocalhost%3A9514%2Ffeedback-survey%3Forigin%3DPERTAX" class="account-menu__link" data-journey-click="link - click:utility-nav:Sign out">
 
-      <div class="subnav js-hidden" id="subnav-2" role="navigation" aria-labelledby="account-menu__main-2" aria-label="Your account">
-        <div class="column-one-third subnav__section">
-          <p class="subnav__section__heading">Security settings</p>
-          <div><a href="#">Change your password</a></div>
-          <div><a href="#">Change your phone number</a></div>
-          <div><a href="account-two">Trusted helpers</a></div>
-        </div>
-        <div class="column-one-third subnav__section">
-          <p class="subnav__section__heading">Paperless settings</p>
-          <div><a href="contact-preferences">Go paperless</a></div>
-          <p>
-            You currently receive all correspondence by post
-          </p>
-        </div>
-        <div class="column-one-third subnav__section">
-          <p class="subnav__section__heading">Personal information</p>
-          <div><a href="personal-details">View your personal details</a></div>
-          <p>View or edit your address, phone number and National Insurance.</p>
-        </div>
-      </div>
-    </li>
 
-    <li><a href="#" class="account-menu__link">Sign out</a></li>
-  </ul>
-</nav>
+          Sign out
+
+        </a>
+      </li>
+    </ul>
+  </nav>
 <!-- END ACCOUNT MENU -->
 
   <!-- LANGUAGE TOGGLE -->
-  <div class="lang-select">
-    <ul>
-      <li>English</li>
-      <li>|</li>
-      <li><a href="#">Cymraeg</a></li>
-    </ul>
-  </div>
+  <!--<div class="lang-select">-->
+    <!--<ul>-->
+      <!--<li>English</li>-->
+      <!--<li>|</li>-->
+      <!--<li><a href="#">Cymraeg</a></li>-->
+    <!--</ul>-->
+  <!--</div>-->
   <!-- END LANGUAGE TOGGLE -->
 </main>

--- a/assets/components/account-menu/_account-menu.scss
+++ b/assets/components/account-menu/_account-menu.scss
@@ -4,68 +4,131 @@
 
 .account-icon--home {
   background-image: url(data:image/svg+xml;base64,PHN2ZyBkYXRhLW5hbWU9IkxheWVyIDEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHByZXNlcnZlQXNwZWN0UmF0aW89InhNaW5ZTWlkIj48dGl0bGU+aWNvbi1ob21lPC90aXRsZT48cGF0aCBkPSJNMTIgMkwxIDEyLjVoMy4xOXY5LjM4aDUuNDR2LTcuMTNoNC41djcuMTNoNS40NFYxMi41SDIzTDEyIDJ6Ii8+PC9zdmc+);
-  background-position: left -2px;
-  background-size: 24px;
-  padding-left: 28px;
+  background-position: left -1px;
+  background-size: 19px;
+  padding-left: 22px;
 
   @include ie-lte(9) {
     background-image: url("../images/icon-home.png");
   }
 }
 
-.account-menu {
-  @extend %contain-floats;
-  border-bottom: 1px solid $light-grey;
+#global-cookie-message {
   position: relative;
-
-  &.is-open {
-    margin-bottom: 5em;
-
-    &.is-smaller {
-      margin-bottom: 0;
-    }
-  }
-
+  z-index: 999;
 }
 
-.account-menu__link,
-.account-menu__link:visited {
-  font-size: 16px;
-  line-height: 1.25;
-  font-weight: 300;
-  text-transform: none;
+.service-info {
+  border-top: none;
+  display: block;
+  position: relative;
+  z-index: 997;
+}
+
+.account-menu {
+  @extend %contain-floats;
+  background-color: $white;
+  border-bottom: 1px solid $grey-8;
+  border-top: 10px solid $govuk-blue;
+  margin-bottom: 0;
+  position: relative;
+  transition: all .3s ease-in-out;
+
+  &.subnav-is-open {
+    margin-bottom: 5em;
+  }
+}
+
+.is-smaller.account-menu {
+  border-bottom: 1px solid $grey-8;
+  margin-bottom: 0;
+  transition: none;
+
+  &.main-nav-menu-is-open {
+    margin-bottom: 5em;
+  }
+
+  li:last-of-type {
+    a:last-of-type {
+      padding-right: 0;
+    }
+  }
+}
+
+.account-menu__link {
   border-bottom: 4px solid transparent;
   box-sizing: border-box;
-  color: $grey-1;
+  color: #4A4A4A;
   display: block;
+  font-size: 16px;
+  font-weight: 300;
+  line-height: 1.25;
+  padding: 12px 16px 8px;
+  text-transform: none;
   text-decoration: none;
-  padding: 12px 28px 8px;
+
+  &:visited {
+    color: #4A4A4A;
+  }
 
   &:hover,
   &:focus {
-    border-bottom: 4px solid $govuk-grey-3;
+    border-bottom-style: solid;
+    border-bottom-width: 4px;
+    color: $light-blue;
   }
 
   &:hover {
-    color: $light-blue;
+    border-bottom-color: $govuk-grey-3;
   }
 
   &:focus {
     background-color: transparent;
-    color: $black;
-    outline: 3px solid $focus-colour;
+    border-bottom-color: $focus-colour;
   }
 }
 
+.is-smaller .account-menu__link {
+  color: $black;
+  padding-left: 10px;
 
-.account-menu__link--home,
-.account-menu__link--home:visited {
+  &:hover {
+    color: $black;
+  }
+}
+
+.account-menu__link--home {
   float: left;
   padding: 12px 18px 8px 0;
 }
 
-.account-menu__link--menu,
-.account-menu__link--menu:visited {
+.is-smaller .account-menu__link--home,
+.is-smaller .account-menu__link--menu {
+  padding-left: 0;
+
+  &:hover {
+    border-bottom-color: transparent;
+  }
+
+  &:focus {
+    border-bottom-color: #ffbf47;
+    color: $light-blue;
+  }
+
+  &.account-menu__link--active {
+    &:hover {
+      border-bottom-color: $govuk-blue;
+      color: $black;
+    }
+
+    &:focus {
+      border-bottom-color: #ffbf47;
+      color: $light-blue;
+    }
+  }
+}
+
+.account-menu__link--menu {
   border-bottom: 4px solid transparent;
   float: right;
   padding: 12px 20px 8px 0;
@@ -73,17 +136,19 @@
 
 .account-menu__link--active,
 .account-menu__link--active:visited {
-  color: $black;
   border-bottom: 4px solid $govuk-blue;
+  color: $black;
 }
 
 .account-menu__main {
   float: right;
   margin: initial;
+  z-index: 995;
 
   li {
     @include inline-block;
     margin: initial;
+    margin-bottom: 0px;
   }
 }
 
@@ -93,8 +158,9 @@
     clear: both;
     float: none;
 
-    &.is-open {
-      border-top: 1px solid $light-grey;
+    &.main-nav-is-open,
+    &.subnav-is-open {
+      border-top: 1px solid $grey-8;
       position: relative;
 
       &:before,
@@ -123,11 +189,22 @@
     }
 
     li {
+      border-bottom: 1px solid $grey-8;
       display: block;
+      overflow: hidden;
+
+      &:last-child,
+      &.active-subnav-parent {
+        border-bottom: none;
+      }
     }
 
-    a {
-      width: 100%;
+    .account-menu__link {
+      border-bottom: none;
+
+      &:hover {
+        border-bottom: none;
+      }
     }
   }
 
@@ -145,6 +222,10 @@
 
     .account-menu__link {
       padding: 12px 8px 8px;
+
+      &:focus {
+        outline: none;
+      }
     }
   }
 }
@@ -153,41 +234,122 @@
   @include core-16;
   @extend %contain-floats;
   background-color: $shaded-bg-grey;
-  border-bottom: 1px solid $light-grey;
+  border-bottom: 1px solid $grey-8;
   left: 0;
+  outline: none;
   position: absolute;
-  top: 45px;
+  top: -61px;
+  transition: all .3s ease-in-out;
   width: 100%;
-  padding: 0.63158em 0;
+  z-index: -1;
 
   p {
     @include core-16;
   }
 
-  a:visited {
-    color: $light-blue;
+  a {
+    text-decoration: none;
+
+    &:visited {
+      color: $govuk-blue;
+    }
+
+    &:hover {
+      color: $light-blue;
+      text-decoration: underline;
+    }
+  }
+
+  &.subnav-reveal {
+    display: block;
+    top: 43px;
   }
 }
 
 .is-smaller .subnav {
-  margin: 0 28px;
+  border-bottom: none;
+  margin: 0 0 0 10px;
+  outline: none;
+  padding: 0;
   position: relative;
   top: inherit;
+  transition: none;
+  z-index: 1;
+
+  &.subnav-reveal {
+    display: block;
+  }
+}
+
+.subnav .subnav__section {
+  padding-bottom: 20px;
+  padding-top: 20px;
+  &:first-child {
+    > p,
+    > div a {
+      padding-left: 30px;
+      padding-right: 15px;
+    }
+  }
+
+  &:nth-child(2) {
+    > p,
+    > div a {
+      padding-left: 15px;
+      padding-right: 15px;
+    }
+  }
+
+  &:last-child {
+    > p,
+    > div a {
+      padding-right: 30px;
+    }
+  }
 }
 
 .is-smaller .subnav__section {
-  margin-bottom: 1em;
-  padding: 0;
+  border-bottom: 1px solid $grey-8;
+  margin: 0;
+  padding: 1em 0 1em 0;
+  width: 100%;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  a:hover {
+    color: $govuk-blue;
+  }
+
+  &:first-child,
+  &:nth-child(2),
+  &:last-child {
+    > p,
+    > div a {
+      padding-left: 0;
+      padding-right: 0;
+    }
+  }
 }
 
 p.subnav__section__heading {
-  @include bold-19;
+  @include bold-16;
+  font-weight: 400;
+  margin: 0;
+  padding-bottom: 5px;
+}
+
+.is-smaller p.subnav__section__heading {
+  @include bold-16;
+  font-weight: 600;
+  margin-bottom: 7px;
 }
 
 .js-enabled .account-menu__link--menu,
 .js-enabled .is-smaller .account-menu__link--more {
   background-image: url("../images/icon-chevron-right.svg");
-  background-position: right center;
+  background-position: right 4px center;
   background-repeat: no-repeat;
   background-size: 12px;
 
@@ -200,12 +362,61 @@ p.subnav__section__heading {
 .js-enabled .is-smaller .account-menu__link--more-expanded,
 .js-enabled .account-menu__link--more {
   background-image: url("../images/icon-chevron-down.svg");
-  background-position: right center;
+  background-position: right 4px center;
   background-size: 12px;
 
   @include ie-lte(9) {
     background-image: url("../images/icon-chevron-down.png");
   }
+}
+
+.js-enabled .account-menu__link--more {
+  background-image: url("../images/icon-chevron-down.svg");
+  background-position: right 14px center;
+  background-size: 12px;
+  border-bottom: none;
+  padding-right: 31px;
+  position: relative;
+  outline: none;
+
+  @include ie-lte(9) {
+    background-image: url("../images/icon-chevron-down.png");
+  }
+
+  &:before,
+  &:after {
+    content: none;
+  }
+
+  &.account-menu__link--more-expanded {
+    &:before,
+    &:after {
+      border: solid transparent;
+      bottom: -5px;
+      content: " ";
+      height: 0;
+      pointer-events: none;
+      position: absolute;
+      right: 14px;
+      width: 0;
+    }
+
+    &:before {
+      border-bottom-color: $light-grey;
+      border-width: 7px;
+      right: 13px;
+    }
+
+    &:after {
+      border-bottom-color: $shaded-bg-grey;
+      border-width: 6px;
+      margin-left: -6px;
+    }
+  }
+}
+
+.is-smaller .account-menu__link--more-expanded {
+  display: none;
 }
 
 .no-js {
@@ -224,19 +435,25 @@ p.subnav__section__heading {
   background-color: #005ea5;
   color: #fff;
   display: block;
+  position: relative;
+  z-index: 999;
 }
+
 .full-width-banner__container {
   padding: 20px .78947em;
   position: relative;
 }
+
 .full-width-banner a {
   color: #fff;
 }
+
 .full-width-banner__title {
   font-size: 18px;
   font-weight: 600;
   margin-bottom: 5px;
 }
+
 .full-width-banner__close {
   color: #fff;
   font-size: 14px;

--- a/assets/components/account-menu/account-menu.html
+++ b/assets/components/account-menu/account-menu.html
@@ -1,5 +1,5 @@
 <nav id="secondary-nav" class="account-menu" role="navigation">
-  <a href="#" class="account-menu__link account-menu__link--active account-menu__link--home "><span class="account-icon account-icon--home">Account home</span></a>
+  <a href="#" class="account-menu__link account-menu__link--active account-menu__link--home "><span class="account-icon account-icon--home">Account home</span><span class="account-icon account-icon--home hidden--tablet">Home</span></a>
   <a href="#" class="account-menu__link account-menu__link--menu js-hidden js-visible" aria-hidden="true" aria-expanded="false">Account menu</a>
 
   <ul class="account-menu__main">

--- a/assets/components/header/_header.scss
+++ b/assets/components/header/_header.scss
@@ -1,7 +1,12 @@
 /* For header styled see https://github.com/alphagov/govuk_template/blob/master/source/assets/stylesheets/_header.scss */
 
-#global-header .header-proposition #proposition-link {
-  float: right;
+#global-header {
+  position: relative;
+  z-index: 999;
+
+  .header-proposition #proposition-link {
+    float: right;
+  }
 }
 
 .hmrc-banner {

--- a/assets/scss/base/_helpers.scss
+++ b/assets/scss/base/_helpers.scss
@@ -340,6 +340,12 @@
 }
 
 // Base-level rules cannot contain the parent-selector-referencing character '&'.
+.hidden--mobile {
+  @include media(mobile) {
+    display: none !important;
+  }
+}
+
 .hidden--tablet {
   @include media(tablet) {
     display: none !important;


### PR DESCRIPTION
**Resolving utility navigation styling snags.** 

## Problem
The pull request resolves numerous styling issues that have been pointed out in first release for navigation bar on both mobile and desktop view. Also work has been done on the account_menu.js to correctly apply the appropriate classes to elements to show whether they are open/closed.
 
Fixed issue that no clicks would be registered on links on the homepage if the sub-navigation menu was open. Ticket has been deleted.

### Example Screenshot
![mobilenavstylingfixes](https://user-images.githubusercontent.com/29452017/33067990-c66f0d30-cea7-11e7-8b32-a44fea6e6090.png)
- Styling on mobile nav made to match prototype.

![mobilesubnav](https://user-images.githubusercontent.com/29452017/33068035-e8e25f0c-cea7-11e7-8668-e17620456f00.png)
- Designed to match prototype. Removed 'your account' link from subnav mobile menu just show back link.

![newnavstyling](https://user-images.githubusercontent.com/29452017/33068043-ef20ef28-cea7-11e7-9b78-5c23ee6419ce.png)
- Paddings on nav amended to match prototype.

![screenshot from 2017-11-21 10-37-34](https://user-images.githubusercontent.com/29452017/33068058-02126076-cea8-11e7-8d93-278680c82c4b.png)
-Transition has been added to the dropdown menu and also to the page to bring content down from behind drop down menu.


## Solution
- Styles have been added to the account_menu.scss to tidy up.
- Class 'subnav-reveal' added to account-menu.js 