### PR TITLE
PLATY-62: Updated reportAProblem to reattach form validation after a successful submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Changed a reference to an svg icon to a data uri
 - Updated .nvmrc file to use up to date node version for AF
 - Adds a close link to the banner, with cookie [#859](https://github.com/hmrc/assets-frontend/pull/859)
-- Updated reportAProblem to reattach form validation after a successful submission, in case of server side validation failure resulting in the form reloaded [#863]
+- Updated reportAProblem to reattach form validation after a successful submission, in case of server side validation failure resulting in the form reloaded [#863](https://github.com/hmrc/assets-frontend/pull/863/files)
 
 ### Changed
 - Remove style overrides for layout and typography for the Design System [#851](https://github.com/hmrc/assets-frontend/pull/851)  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Changed a reference to an svg icon to a data uri
 - Updated .nvmrc file to use up to date node version for AF
 - Adds a close link to the banner, with cookie [#859](https://github.com/hmrc/assets-frontend/pull/859)
+- Updated reportAProblem to reattach form validation after a successful submission, in case of server side validation failure resulting in the form reloaded [#863]
 
 ### Changed
 - Remove style overrides for layout and typography for the Design System [#851](https://github.com/hmrc/assets-frontend/pull/851)  

--- a/assets/javascripts/modules/reportAProblem.js
+++ b/assets/javascripts/modules/reportAProblem.js
@@ -45,6 +45,7 @@ module.exports = function () {
 
       success: function (data) {
         showConfirmation(data)
+        setupFormValidation()
       },
 
       error: function (jqXHR, status) {


### PR DESCRIPTION
## Problem

If the reportAProblem form validation passes client-side but fails on the server, the result of the ajax call is another form which replaces the existing one. The submit event handler isn't attached to the replacement form though so when it's submitted, it redirects without the CSRF token.

## Solution

Call the function to attach the submit event handler after a successful ajax request in case it's a form.