### PR TITLE
added styles to fix singleCheckbox error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Remove style overrides for layout and typography for the Design System [#851](https://github.com/hmrc/assets-frontend/pull/851)  
 - Add Styles tab with a reference for Component Library [#858](https://github.com/hmrc/assets-frontend/pull/858)
+- Add Styles to fix singleCheckbox error message placement [#864](https://github.com/hmrc/assets-frontend/pull/864)
 
 ## [2.253.0] - 2017-10-26
 

--- a/assets/scss/base/form/_errors.scss
+++ b/assets/scss/base/form/_errors.scss
@@ -207,14 +207,14 @@ Markup:
       &::before{
         top: 27px;
       }
-        &::after{
-          top: 37px;
-        }
+      &::after{
+        top: 37px;
       }
     }
-    .form-field-single{
-      .error-notification{
-        margin-left: -3.1em;
-      }
+  }
+  .form-field-single{
+    .error-notification{
+      margin-left: -3.1em;
     }
+  }
 }

--- a/assets/scss/base/form/_errors.scss
+++ b/assets/scss/base/form/_errors.scss
@@ -197,3 +197,24 @@ Markup:
 .js .email-form-errors .error-notification {
   display: none;
 }
+
+/*
+ Single checkbox errors
+*/
+.form-field--error{
+    .multiple-choice{
+        [type=checkbox]+label.form-field-single{
+            &::before{
+                top: 27px;
+            }
+            &::after{
+                top: 37px;
+            }
+        }
+    }
+    .form-field-single{
+        .error-notification{
+            margin-left: -3.1em;
+        }
+    }
+}

--- a/assets/scss/base/form/_errors.scss
+++ b/assets/scss/base/form/_errors.scss
@@ -202,19 +202,19 @@ Markup:
  Single checkbox errors
 */
 .form-field--error{
-    .multiple-choice{
-        [type=checkbox]+label.form-field-single{
-            &::before{
-                top: 27px;
-            }
-            &::after{
-                top: 37px;
-            }
+  .multiple-choice{
+    [type=checkbox]+label.form-field-single{
+      &::before{
+        top: 27px;
+      }
+        &::after{
+          top: 37px;
         }
+      }
     }
     .form-field-single{
-        .error-notification{
-            margin-left: -3.1em;
-        }
+      .error-notification{
+        margin-left: -3.1em;
+      }
     }
 }


### PR DESCRIPTION
## Problem
The placement of the error message sits above the label pushing it down

### Example Screenshot
![image](https://user-images.githubusercontent.com/3766696/33135728-1cfb2ec4-cf9b-11e7-809d-1b54734753d9.png)

## Solution
The added css will fix the placement of the error above the checkbox and label.
![image](https://user-images.githubusercontent.com/3766696/33135752-34e763b8-cf9b-11e7-8f2b-581a80d5efb2.png)
