### PR TITLE
Fixed broken comments on shutter page examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- fixed comments on shutter page examples [#870](https://github.com/hmrc/assets-frontend/pull/870)
+
 ## [3.0.0] - 2017-11-24
 
 :rotating_light: **BREAKING CHANGE!!!** :rotating_light:

--- a/assets/patterns/shutter-pages/closed-amls.html
+++ b/assets/patterns/shutter-pages/closed-amls.html
@@ -1,4 +1,4 @@
-COOKIE MESSAGE -->
+<!-- COOKIE MESSAGE -->
 <div id="global-cookie-message" style="display: block;">
   <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
     cookies</a></p>
@@ -72,4 +72,4 @@ COOKIE MESSAGE -->
     </div>
   </div>
 </footer>
-<!-- END FOOTER
+<!-- END FOOTER -->

--- a/assets/patterns/shutter-pages/closed-tc.html
+++ b/assets/patterns/shutter-pages/closed-tc.html
@@ -1,4 +1,4 @@
-COOKIE MESSAGE -->
+<!-- COOKIE MESSAGE -->
 <div id="global-cookie-message" style="display: block;">
   <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
     cookies</a></p>
@@ -83,4 +83,4 @@ COOKIE MESSAGE -->
     </div>
   </div>
 </footer>
-<!-- END FOOTER
+<!-- END FOOTER -->

--- a/assets/patterns/shutter-pages/notyet-tc.html
+++ b/assets/patterns/shutter-pages/notyet-tc.html
@@ -1,4 +1,4 @@
-COOKIE MESSAGE -->
+<!-- COOKIE MESSAGE -->
 <div id="global-cookie-message" style="display: block;">
   <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
     cookies</a></p>
@@ -80,4 +80,4 @@ COOKIE MESSAGE -->
     </div>
   </div>
 </footer>
-<!-- END FOOTER
+<!-- END FOOTER -->

--- a/assets/patterns/shutter-pages/permanent-tc.html
+++ b/assets/patterns/shutter-pages/permanent-tc.html
@@ -1,4 +1,4 @@
-COOKIE MESSAGE -->
+<!-- COOKIE MESSAGE -->
 <div id="global-cookie-message" style="display: block;">
   <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
     cookies</a></p>
@@ -82,4 +82,4 @@ COOKIE MESSAGE -->
     </div>
   </div>
 </footer>
-<!-- END FOOTER
+<!-- END FOOTER -->


### PR DESCRIPTION
Comments were being displayed with the examples

## Problem
the preceding `<!--` and trailing `-->` had been left off some comments in pages causing the comments to be displayed alongside the examples

### Example Screenshot
<img width="947" alt="screenshot 2017-11-30 12 17 10" src="https://user-images.githubusercontent.com/868772/33430432-6ad5e5ac-d5c8-11e7-82b0-dd225ca96ef8.png">


## Solution
fix the comments

### Example Screenshot
<img width="746" alt="screenshot 2017-11-30 12 18 02" src="https://user-images.githubusercontent.com/868772/33430490-8ff9419e-d5c8-11e7-94c5-6253431753b3.png">

