### PR TITLE
Modify header styles for logged in status message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+
 ## [Unreleased]
+
+### Fixed
+- Fix style for logged in status logo [#872](https://github.com/hmrc/assets-frontend/pull/872)
 
 ## [3.0.1]
 - Remove the `.content__body p` selector as it is too specific and overriding other changes in V3

--- a/assets/components/header/_header.scss
+++ b/assets/components/header/_header.scss
@@ -6,6 +6,7 @@
 
 .hmrc-banner {
   @include phase-banner();
+  position: relative;
 }
 
 .organisation-logo {
@@ -34,7 +35,9 @@
 }
 
 .logged-in-status {
-  float: right;
+  position: absolute;
+  top: 10px;
+  right: 0;
 
   @include media(tablet) {
     padding: 4px 0;


### PR DESCRIPTION
## Problem
The logged in status message breaks the header layout.

### Example Screenshot
<img width="728" alt="screen shot 2017-12-01 at 09 11 03" src="https://user-images.githubusercontent.com/18576086/33478737-3f0c2886-d682-11e7-83c3-1db99e469b52.png">

## Solution
Modify the style applied to the status message.

### Example Screenshot
<img width="717" alt="screen shot 2017-12-01 at 10 20 17" src="https://user-images.githubusercontent.com/18576086/33478757-4e1d7244-d682-11e7-9024-c3d6b04a7615.png">
