### PR TITLE
Move header sass import from shared to all components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix style for logged in status logo [#872](https://github.com/hmrc/assets-frontend/pull/872)
+- Move header component stylesheet import to all-components [#875](https://github.com/hmrc/assets-frontend/pull/875)
 
 ## [3.0.1]
 - Remove the `.content__body p` selector as it is too specific and overriding other changes in V3

--- a/assets/components/_all-components.scss
+++ b/assets/components/_all-components.scss
@@ -3,3 +3,4 @@
 @import "character-counter/character-counter";
 @import "check-your-answers/check-your-answers";
 @import "page-heading/page-heading";
+@import "header/header";

--- a/assets/scss/_application-base.scss
+++ b/assets/scss/_application-base.scss
@@ -61,7 +61,6 @@
 @import "components/youtube-player";
 @import "components/auto-complete";
 @import "components/external-markup";
-@import "components/header/header";
 @import "components/add-remove";
 @import "components/toggle-button";
 @import "components/tabs";


### PR DESCRIPTION
## Problem
When v4 is complied the comp-lib scss files are not imported thus the header component does not have a style.

## Solution
Move header style import to the components folder to isolate the logic.