### PR TITLE
Remove default button margin/padding from button link helper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+### Changed
+- Remove default button styling from button link helper class [#876](https://github.com/hmrc/assets-frontend/pull/876)
+
 ### Fixed
 - Fix header logo reference in header and account-header components [#874](https://github.com/hmrc/assets-frontend/pull/874)
 

--- a/assets/scss/base/_buttons.scss
+++ b/assets/scss/base/_buttons.scss
@@ -74,6 +74,8 @@ button, .button {
   text-decoration: underline;
   color: $link-colour;
   border: none;
+  margin: 0;
+  padding: 0;
 
   &.button--link-table {
     color: $black;


### PR DESCRIPTION
## Problem
The button-link helper class removes the default button styling, to make the button appear as a standard link, but does not remove margin or padding, so buttons are still indented/offset from the main content.

### Example Screenshot
<img width="1636" alt="screen shot 2017-12-12 at 12 47 59" src="https://user-images.githubusercontent.com/5601214/33894359-b12718e6-df55-11e7-9aef-bbc32fab7c0c.png">

## Solution
I have removed margin and padding on all sides of the button--link helper class.
