### PR TITLE
Deprecated character counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Depricated the HMRC character counter in favour of the GDS version [#897](https://github.com/hmrc/assets-frontend/pull/879)
+
 ### Fixed
 - Fix header logo reference in header and account-header components [#874](https://github.com/hmrc/assets-frontend/pull/874)
 

--- a/assets/components/character-counter/README.md
+++ b/assets/components/character-counter/README.md
@@ -1,6 +1,6 @@
 # Character Counter
 
-{{ deprecated(https://github.com/alphagov/ds-character-count, GDS Character counter) }}
+{{ deprecated('https://github.com/alphagov/ds-character-count', 'GDS Character counter') }}
 
 A character counter for textareas.
 

--- a/assets/components/character-counter/README.md
+++ b/assets/components/character-counter/README.md
@@ -1,6 +1,6 @@
 # Character Counter
 
-{{ wip(140) }}
+{{ deprecated(https://github.com/alphagov/ds-character-count, GDS Character counter) }}
 
 A character counter for textareas.
 

--- a/gulpfile.js/util/pattern-library/lib/parseDocumentation.js
+++ b/gulpfile.js/util/pattern-library/lib/parseDocumentation.js
@@ -13,6 +13,7 @@ var parseDocumentation = function (files) {
       `{% from 'example.html' import example %}`,
       `{% from 'markup.html' import markup %}`,
       `{% from 'wip.html' import wip %}`,
+      `{% from 'deprecated.html' import deprecated %}`,
       file.contents.toString()
     ].join('\n')
 

--- a/gulpfile.js/util/pattern-library/macros/deprecated.html
+++ b/gulpfile.js/util/pattern-library/macros/deprecated.html
@@ -1,0 +1,11 @@
+{% macro deprecated(new_component_link, component_name) %}
+  <div class="panel panel-border-wide">
+    <p class="heading-small">This component has been deprecated.</p>
+    <p>
+      You should remove this component and replace it with 
+      <a href="{{ new_component_link }}" target="_blank">
+        {{ component_name }}
+      </a>
+    </p>
+  </div>
+{% endmacro %}


### PR DESCRIPTION
## Problem
GDS have a better version of the character counter. The @hmrc/design-system-working-group decided on Friday to deprecate the HMRC version and use the GDS version.
We need to communicate this to users who are looking for a character counter in the HMRC design system.


## Solution
This PR adds a deprecated banner to the top of the component in the HMRC design system and points at the GDS version.
