### PR TITLE
Prevents spies from trying to wrap functions that are already wrapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Calls `.restore()` on spied functions after they've been used to prevent `already wrapped` errors from crashing the `watch` task
+
 ## [3.0.2] - 2017-12-19
 - Depricated the HMRC character counter in favour of the GDS version [#897](https://github.com/hmrc/assets-frontend/pull/879)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
-- Calls `.restore()` on spied functions after they've been used to prevent `already wrapped` errors from crashing the `watch` task
+- Calls `.restore()` on spied functions after they've been used to prevent `already wrapped` errors from crashing the `watch` task [#882](https://github.com/hmrc/assets-frontend/pull/882)
 
 ## [3.0.2] - 2017-12-19
 - Depricated the HMRC character counter in favour of the GDS version [#897](https://github.com/hmrc/assets-frontend/pull/879)

--- a/gulpfile.js/tests/compileTemplate.test.js
+++ b/gulpfile.js/tests/compileTemplate.test.js
@@ -39,5 +39,6 @@ test('compileTemplate - compiles a template at a given path', (t) => {
         handlebarsSpy.calledOnce,
         'returns the compiled template as a Promisified function'
       )
+      handlebarsSpy.restore()
     })
 })

--- a/gulpfile.js/tests/registerHandlebarsHelpers.test.js
+++ b/gulpfile.js/tests/registerHandlebarsHelpers.test.js
@@ -38,4 +38,5 @@ test('registerHandlebarsHelpers - accepts an optional hendlebars helpers directo
 
   registerHandlebarsHelpers([existentHelpersDirectory])
   t.equal(handlebarsSpy.callCount, 1, 'accepts helpers paths as an array')
+  handlebarsSpy.restore()
 })


### PR DESCRIPTION
## Problem
Editing a gulpfile test while the `watch` task was running resulted in the following errors, crashing the `watch` task
`TypeError: Attempted to wrap compile which is already wrapped`
`TypeError: Attempted to wrap registerHelper which is already wrapped`

## Solution
Call `.restore()` on the spied function after use, so that it can be successfully wrapped again when the test runs again