### PR TITLE
SDT-702: Adds missing style pages that correspond to gov.uk element pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- All style sections now link to the corresponding GOV.UK Elements style section [#883](https://github.com/hmrc/assets-frontend/pull/883)
+
 ## [3.0.2] - 2017-12-19
 - Depricated the HMRC character counter in favour of the GDS version [#897](https://github.com/hmrc/assets-frontend/pull/879)
 

--- a/assets/styles/alpha-and-beta-banners/README.md
+++ b/assets/styles/alpha-and-beta-banners/README.md
@@ -1,0 +1,5 @@
+# Alpha and beta banners
+
+You have to use an alpha banner if your thing is in alpha, and a beta banner if it’s in beta.
+
+[See alpha and beta banners in Elements](http://govuk-elements.herokuapp.com/alpha-beta-banners/).

--- a/assets/styles/buttons/README.md
+++ b/assets/styles/buttons/README.md
@@ -1,5 +1,5 @@
 # Buttons
 
-Use buttons to move though a transaction, aim to use only one button per page.
+Use buttons to move through a transaction, aim to use only one button on a page.
 
 [See buttons in Elements](http://govuk-elements.herokuapp.com/buttons/).

--- a/assets/styles/buttons/README.md
+++ b/assets/styles/buttons/README.md
@@ -1,0 +1,5 @@
+# Buttons
+
+Use buttons to move though a transaction, aim to use only one button per page.
+
+[See buttons in Elements](http://govuk-elements.herokuapp.com/buttons/).

--- a/assets/styles/data/README.md
+++ b/assets/styles/data/README.md
@@ -1,0 +1,5 @@
+# Data
+
+Consider putting content into tables to make it easier to scan.
+
+[See data in Elements](http://govuk-elements.herokuapp.com/data/).

--- a/assets/styles/errors-and-validation/README.md
+++ b/assets/styles/errors-and-validation/README.md
@@ -1,0 +1,5 @@
+# Errors and validation
+
+Minimise the number of errors on a page.
+
+[See errors and validation in Elements](http://govuk-elements.herokuapp.com/errors-and-validation/).

--- a/assets/styles/errors-and-validation/README.md
+++ b/assets/styles/errors-and-validation/README.md
@@ -1,5 +1,5 @@
 # Errors and validation
 
-Minimise the number of errors on a page.
+Reduce the number of errors on a page.
 
 [See errors and validation in Elements](http://govuk-elements.herokuapp.com/errors-and-validation/).

--- a/assets/styles/form-elements/README.md
+++ b/assets/styles/form-elements/README.md
@@ -1,0 +1,5 @@
+# Form elements
+
+Keep forms as simple as possible – only ask what’s needed to run your service.
+
+[See form elements in Elements](http://govuk-elements.herokuapp.com/form-elements/).


### PR DESCRIPTION
## Problem
Not all Gov.Uk Elements style sections were linked to from the design system
## Solution
Add missing folders and READMEs for each missing section