### PR TITLE
Updated the ‘pattern-library’ task so macro refs and component refs a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Calls `.restore()` on spied functions after they've been used to prevent `already wrapped` errors from crashing the `watch` task [#882](https://github.com/hmrc/assets-frontend/pull/882)
 
 ### Changed
+- Updated the ‘pattern-library’ task so macro refs are dynamic in the gulp task [#890](https://github.com/hmrc/assets-frontend/pull/890)
 - Content of work in progress macro and added new research macro [#888](https://github.com/hmrc/assets-frontend/pull/888)
 
 - Removed check your answers from component navigation [#885](https://github.com/hmrc/assets-frontend/pull/885)

--- a/gulpfile.js/config.js
+++ b/gulpfile.js/config.js
@@ -223,7 +223,8 @@ module.exports = {
     dest: 'design-pattern-library',
     template: './node_modules/hmrc-component-library-template/design-system.html',
     homepage: 'design-system.md',
-    helpers: './node_modules/hmrc-component-library-template/helpers'
+    helpers: './node_modules/hmrc-component-library-template/helpers',
+    macrosPath: './gulpfile.js/util/pattern-library/macros'
   },
 
   vrt: {

--- a/gulpfile.js/util/pattern-library/lib/parseDocumentation.js
+++ b/gulpfile.js/util/pattern-library/lib/parseDocumentation.js
@@ -1,23 +1,21 @@
+var fs = require('fs')
 var path = require('path')
 var marked = require('marked')
 var nunjucks = require('nunjucks')
+var config = require('../../../config')
 
 var parseDocumentation = function (files) {
+  var macros = fs.readdirSync(config.patternLibrary.macrosPath)
+    .map(fileName => `{% from '${fileName}' import '${path.parse(fileName).name}' %}`)
+    .join('')
+
   files.forEach(function (file) {
     nunjucks.configure([
-      path.join(__dirname, '..', 'macros'),
+      config.patternLibrary.macrosPath,
       path.parse(file.path).dir
     ])
 
-    var fileContents = [
-      `{% from 'example.html' import example %}`,
-      `{% from 'markup.html' import markup %}`,
-      `{% from 'wip.html' import wip %}`,
-      `{% from 'research.html' import research %}`,
-      `{% from 'deprecated.html' import deprecated %}`,
-      file.contents.toString()
-    ].join('\n')
-
+    var fileContents = macros + file.contents.toString()
     var markdown = nunjucks.renderString(fileContents)
     var html = marked(markdown)
 


### PR DESCRIPTION
## Problem
Currently we have to manually add references in the gulp tasks 'parseDocumentation.js' file to each macro added in the macro directory.

## Solution
By reading the macro directory we can grab the name of each macro by filename and dynamically build this in the 'parseDocumentation.js' task as a string to be rendered alongside the markdown.
