### PR TITLE
Add build as a dependancy for test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Calls `.restore()` on spied functions after they've been used to prevent `already wrapped` errors from crashing the `watch` task [#882](https://github.com/hmrc/assets-frontend/pull/882)
 - Nunjucks config needed path to components - [892](https://github.com/hmrc/assets-frontend/issues/891)
+- Build styles as a dependency of the test task [896](https://github.com/hmrc/assets-frontend/issues/896)
 
 ### Changed
 - Updated badge README.md and added second markup example [#895](https://github.com/hmrc/assets-frontend/issues/895)

--- a/gulpfile.js/tasks/build.js
+++ b/gulpfile.js/tasks/build.js
@@ -29,7 +29,7 @@ gulp.task('build:v4', ['v4'], (done) => {
     ['lint', 'test:gulpTasks'],
     ['style:v4', 'images', 'svg', 'error-pages', 'concat:encryption', 'browserify:v4'],
     'modernizr',
-    // run jasmine tests
+    'test',
     done
   )
 })

--- a/gulpfile.js/tasks/test.js
+++ b/gulpfile.js/tasks/test.js
@@ -15,7 +15,7 @@ gulp.task('test:gulpTasks', ['lint:gulpTasks'], () => {
     }))
 })
 
-gulp.task('test', (done) => {
+gulp.task('test', ['lint', 'style'], (done) => {
   const server = new Server({
     configFile: fs.realpathSync(config.karmaConfig),
     singleRun: true


### PR DESCRIPTION
Running npm test on its own was failing due to missing stylesheets. Adding build as dependancy of test.