### PR TITLE
Removed green background on button--link focus state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Build styles as a dependency of the test task [896](https://github.com/hmrc/assets-frontend/issues/896)
+- Link style button(button--link) focus background colour is green [900](https://github.com/hmrc/assets-frontend/issues/900)
 
 ## [3.1.0] and [4.1.0] - 2018-01-16
 ### Added

--- a/assets/scss/base/_buttons.scss
+++ b/assets/scss/base/_buttons.scss
@@ -87,6 +87,7 @@ button, .button {
   }
 
   &:hover, &:focus {
+    background-color: transparent;
     color: $link-hover-colour;
   }
 


### PR DESCRIPTION
When the focus state was instantiated the background of the button (button--link) was green and should be transparent.

<!-- Make sure your work follows to our CONTRIBUTING guidelines. -->
<!-- There's a link to them above. -->

## Problem
The background colour is wrong and confuses the user when focusing on this style of button.

### Example Screenshot
![screen shot 2018-01-19 at 09 42 40](https://user-images.githubusercontent.com/10154302/35145841-299fe03c-fd01-11e7-99fa-c62688ac1f56.png)


## Solution
Updated styles so background is transparent when focusing on button.

### Example Screenshot
![screen shot 2018-01-19 at 10 06 58](https://user-images.githubusercontent.com/10154302/35145874-42bc2116-fd01-11e7-8402-1879b322d013.png)

