### PR TITLE
Added in link to Contribution Guidelines on index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Build styles as a dependency of the test task [896](https://github.com/hmrc/assets-frontend/issues/896)
+### Added
+- Added in links to the contribution guidelines [#902](https://github.com/hmrc/assets-frontend/pull/902)
 
 ## [3.1.0] and [4.1.0] - 2018-01-16
 ### Added

--- a/design-system.md
+++ b/design-system.md
@@ -44,6 +44,8 @@
   <section>
     <div class="grid-row">
       <div class="column-full column-constrained">
+      <h2 class="heading-large">Contribute</h2>
+      <p>If the component or pattern you need does not already exist, you can <a href="https://github.com/hmrc/design-patterns/blob/master/CONTRIBUTING.md">contribute a new one</a> to the HMRC Design System.</p>
         <h2 class="heading-large">Get in touch</h2>
         <p>If you’ve got a question, idea or suggestion share it in <a href="https://hmrcdigital.slack.com/messages/C39V3PH38">#team-sdt</a> on HMRC Slack (<a href="slack://channel?team=T04RY81HB&amp;id=C39V3PH38">open in app</a>) or <a href="hmrc-service-design-tools-g@digital.hmrc.gov.uk">email the Service Design Tools team</a></p>
       </div>


### PR DESCRIPTION
## Problem
There was no link to the contribution guidelines within the design system. 

## Solution
This is a strategic fix to link to contribution guidelines in the github wiki, prior to including this documentation within the design system itself. 


