### PR TITLE
MTA-3081: Fix issue with blue border not displaying on pages without the PTA account menu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Content of work in progress macro and added new research macro [#888](https://github.com/hmrc/assets-frontend/pull/888)
 - Include language selector as a partial in other components [#887](https://github.com/hmrc/assets-frontend/pull/887)
 - Removed check your answers from component navigation [#885](https://github.com/hmrc/assets-frontend/pull/885)
+- Fix issue with blue border not displaying on pages without the PTA account menu [#903](https://github.com/hmrc/assets-frontend/pull/903)
 
 ## [3.0.2] - 2017-12-19
 ### Deprecated

--- a/assets/components/account-menu/_account-menu.scss
+++ b/assets/components/account-menu/_account-menu.scss
@@ -19,17 +19,16 @@
 }
 
 .service-info {
-  border-top: none;
   display: block;
   position: relative;
   z-index: 997;
+  overflow: hidden;
 }
 
 .account-menu {
   @extend %contain-floats;
   background-color: $white;
   border-bottom: 1px solid $grey-2;
-  border-top: 10px solid $govuk-blue;
   margin-bottom: 0;
   position: relative;
   transition: all .3s ease-in-out;


### PR DESCRIPTION
<!-- Provide a short summary of the issue in the Title above. -->

When the account-menu component was introduced some styling was changed for the display of the blue border on the service-info element. This was to get the account-menu sub-menu to display properly. Unfortunately this introduced a bug that prevented the blue border-top to display on pages that didn't use the account-menu. 

<!-- Make sure your work follows to our CONTRIBUTING guidelines. -->
<!-- There's a link to them above. -->

## Problem
<!-- What problem does the pull request solve? Why is this change required? -->
<!-- If it fixes an open issue, please link to the issue or add: Fixes #<issue_number> -->

### Example Screenshot
<!-- Add an image or gif to help illustrate the point. -->

## Solution
<!-- Describe your changes -->
Remove the blue border-top from the account-menu and revert back to it being displayed as part of the service-info element. Change the styling so the account-menu sub-nav still displays properly.

### Example Screenshot
<!-- If possible, add an image or gif of what's changed. -->
