### PR TITLE
Check that the current commit exits in remote master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Build styles as a dependency of the test task [896](https://github.com/hmrc/assets-frontend/issues/896)
 ### Added
 - Added in links to the contribution guidelines [#902](https://github.com/hmrc/assets-frontend/pull/902)
+- Change log checks that the current commit doesn't exist in the remote master [904](https://github.com/hmrc/assets-frontend/pull/904)
 
 ## [3.1.0] and [4.1.0] - 2018-01-16
 ### Added

--- a/gulpfile.js/tasks/changelog.js
+++ b/gulpfile.js/tasks/changelog.js
@@ -24,25 +24,13 @@ function runCommand (cmd) {
   })
 }
 
-function getMasterRevision () {
-  return runCommand('git rev-parse master')
-}
-
-function getCurrentBranchRevision () {
-  return runCommand('git rev-parse HEAD')
-}
-
 function getGitDiffs () {
   return runCommand(`git diff --name-only master...`)
 }
 
-function isMaster () {
-  return new Promise((resolve) => {
-    Promise.all([getCurrentBranchRevision(), getMasterRevision()])
-      .then(results => {
-        resolve(results[0].trim() === results[1].trim())
-      })
-  })
+function isMerged () {
+  return runCommand('git branch -a --contains HEAD')
+    .then((results) => results.includes('remotes/origin/master'))
 }
 
 function filterFiles (files) {
@@ -67,7 +55,7 @@ function verifyGitDiffs (diffs) {
 }
 
 gulp.task('changelog', () => {
-  return isMaster()
+  return isMerged()
     .then(isit => {
       return isit
         ? true
@@ -78,8 +66,7 @@ gulp.task('changelog', () => {
 module.exports = {
   runCommand: runCommand,
   getGitDiffs: getGitDiffs,
-  getCurrentBranchRevision: getCurrentBranchRevision,
-  getMasterRevision: getMasterRevision,
   filterFiles: filterFiles,
+  isMerged: isMerged,
   verifyGitDiffs: verifyGitDiffs
 }

--- a/gulpfile.js/tests/changelog.test.js
+++ b/gulpfile.js/tests/changelog.test.js
@@ -21,19 +21,14 @@ test('changelog - runCommand', (t) => {
     })
 })
 
-test('changelog - getCurrentBranchRevision', (t) => {
-  t.plan(1)
-  t.ok(changelog.getCurrentBranchRevision().then(), 'returns a promise')
-})
-
-test('changelog - getMasterRevision', (t) => {
-  t.plan(1)
-  t.ok(changelog.getMasterRevision().then(), 'returns a promise')
-})
-
 test('changelog - getGitDiffs', (t) => {
   t.plan(1)
   t.ok(changelog.getGitDiffs().then(), 'returns a promise')
+})
+
+test('changelog - isMerged', (t) => {
+  t.plan(1)
+  t.ok(changelog.isMerged().then(), 'returns a promise')
 })
 
 test('changelog - filterFiles', (t) => {


### PR DESCRIPTION
## Problem

The change log check compares `HEAD` to master and fails if they aren't the same. This is breaking builds of tags that are not the most recent commit on master.

## Solution

Check instead that the commit at `HEAD` is in the remote master branch. If it is, skip the change log check as it will have already been merged.