### PR TITLE
Issue with Stageprompt not recognising JQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Issue with Stageprompt not recognising JQuery [909](https://github.com/hmrc/assets-frontend/pull/909)
 
 ## [3.2.0] and [4.2.0] - 2018-01-25
 ### Fixed

--- a/assets/application.js
+++ b/assets/application.js
@@ -1,3 +1,4 @@
+require('jquery')
 
 require('govuk-template')
 

--- a/assets/javascripts/index.js
+++ b/assets/javascripts/index.js
@@ -1,10 +1,8 @@
 /* eslint-env jquery */
 
-require('jquery')
 require('details')
 require('validate')
 require('basicpunc')
-require('govuk-template')
 require('stageprompt')
 
 window._gaq = window._gaq || []


### PR DESCRIPTION
Stage prompt module has errors due to jQuery being loaded too late

## Problem
As Stage prompt loads first it errors as it has a dependancy on jQuery. As a result of the error javascript functionality will be compromised.

## Solution
For the Stage prompt module to work it depends on jQuery so I have shifted this to the top of the page as a require in the application.js. jQuery now loads first which fixes the error.
