### PR TITLE
Remove the link 'Old component library' in the components navigation

### DIFF
--- a/assets/components/README.md
+++ b/assets/components/README.md
@@ -6,6 +6,4 @@ On the most part, if you are using the [GOV.UK Prototype Kit](https://github.com
 
 ## HMRC component library 
 
-The HMRC component library has been depricated. You should not use patterns from the component library in your service.
-
-However you can refer to the [component library](https://hmrc-component-library.herokuapp.com) to maintain your exsisting service.
+Do not use the [component library](https://hmrc-component-library.herokuapp.com) to build new services. Use it to maintain a service that uses assets frontend version 1, 2 or 3.

--- a/assets/components/README.md
+++ b/assets/components/README.md
@@ -3,3 +3,9 @@
 Components are re-usable parts of the user interface. They are named chunks of code that have been made to support a variety of applications. They are often associated with specific patterns when used in a particular context.
 
 On the most part, if you are using the [GOV.UK Prototype Kit](https://github.com/alphagov/govuk_prototype_kit/), the coded examples provided should render exactly as they do inside the design system.
+
+## HMRC component library 
+
+The HMRC component library has been depricated. You should not use patterns from the component library in your service.
+
+However you can refer to the [component library](https://hmrc-component-library.herokuapp.com) to maintain your exsisting service.

--- a/assets/components/old-component-library/README.md
+++ b/assets/components/old-component-library/README.md
@@ -1,5 +1,0 @@
-# HMRC component library
-
-The HMRC component library has been depricated. You should not use patterns from the component library in your service.
-
-However you can refer to the [component library](https://hmrc-component-library.herokuapp.com) to maintain your exsisting service.


### PR DESCRIPTION
## Problem
The reference to the old component library is in the components navigation

![screen shot 2018-03-06 at 14 38 02](https://user-images.githubusercontent.com/10154302/37038194-0f421358-214c-11e8-8bf3-3ab5a8f23a95.png)


## Solution
Remove this link and then add the contents of the page to the components landing page


