### PR TITLE
Fixing issues where users can focus elements inside the dropdown without selecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [Unreleased] 
+- Preventing a user from being able to focus inside the subnav when it has not been opened
 
 ## [3.2.2] and [4.2.2] - 2018-02-16
 ### Fixed

--- a/assets/components/account-menu/_account-menu.scss
+++ b/assets/components/account-menu/_account-menu.scss
@@ -234,6 +234,7 @@
   @extend %contain-floats;
   background-color: $canvas-colour;
   border-bottom: 1px solid $grey-2;
+  display: none;
   left: 0;
   outline: none;
   position: absolute;


### PR DESCRIPTION
## Problem
Using the keyboard a user is able to tab into the dropdown without it being active

## Solution
Adding `display: none` to the subnav means a user will not be able to navigate inside of it until your account has been selected.