### PR TITLE
Fix broken and missing release links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,12 +248,14 @@ This entire version is covered by a single pull request. [#867](https://github.c
 - Changes to nginx error pages not being build and deployed [#734]
 
 [Unreleased]: https://github.com/hmrc/assets-frontend/compare/release/4.2.0...master
-[4.2.1]: https://github.com/hmrc/assets-frontend/compare/release/4.2.0...4.2.1
-[4.2.0]: https://github.com/hmrc/assets-frontend/compare/release/4.1.0...4.2.0
-[4.1.0]: https://github.com/hmrc/assets-frontend/compare/release/3.0.2...4.1.0
-[3.2.1]: https://github.com/hmrc/assets-frontend/compare/release/3.2.0...3.2.1
-[3.2.0]: https://github.com/hmrc/assets-frontend/compare/release/3.1.0...3.2.0
-[3.1.0]: https://github.com/hmrc/assets-frontend/compare/release/3.0.2...3.1.0
+[4.2.2]: https://github.com/hmrc/assets-frontend/compare/release/4.2.1...release/4.2.2
+[4.2.1]: https://github.com/hmrc/assets-frontend/compare/release/4.2.0...release/4.2.1
+[4.2.0]: https://github.com/hmrc/assets-frontend/compare/release/4.1.0...release/4.2.0
+[4.1.0]: https://github.com/hmrc/assets-frontend/compare/release/3.0.2...release/4.1.0
+[3.2.2]: https://github.com/hmrc/assets-frontend/compare/release/3.2.1...release/3.2.2
+[3.2.1]: https://github.com/hmrc/assets-frontend/compare/release/3.2.0...release/3.2.1
+[3.2.0]: https://github.com/hmrc/assets-frontend/compare/release/3.1.0...release/3.2.0
+[3.1.0]: https://github.com/hmrc/assets-frontend/compare/release/3.0.2...release/3.1.0
 [3.0.2]: https://github.com/hmrc/assets-frontend/compare/release/3.0.1...release/3.0.2
 [3.0.1]: https://github.com/hmrc/assets-frontend/compare/release/3.0.0...release/3.0.1
 [3.0.0]: https://github.com/hmrc/assets-frontend/compare/release/2.254.0...release/3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] 
+
+## [3.2.3] and [4.2.3] - 2018-03-15
+### Fixed
 - Preventing a user from being able to focus inside the subnav when it has not been opened
 
 ## [3.2.2] and [4.2.2] - 2018-02-16
@@ -248,10 +251,12 @@ This entire version is covered by a single pull request. [#867](https://github.c
 - Changes to nginx error pages not being build and deployed [#734]
 
 [Unreleased]: https://github.com/hmrc/assets-frontend/compare/release/4.2.0...master
+[4.2.3]: https://github.com/hmrc/assets-frontend/compare/release/4.2.2...release/4.2.3
 [4.2.2]: https://github.com/hmrc/assets-frontend/compare/release/4.2.1...release/4.2.2
 [4.2.1]: https://github.com/hmrc/assets-frontend/compare/release/4.2.0...release/4.2.1
 [4.2.0]: https://github.com/hmrc/assets-frontend/compare/release/4.1.0...release/4.2.0
 [4.1.0]: https://github.com/hmrc/assets-frontend/compare/release/3.0.2...release/4.1.0
+[3.2.3]: https://github.com/hmrc/assets-frontend/compare/release/3.2.2...release/3.2.3
 [3.2.2]: https://github.com/hmrc/assets-frontend/compare/release/3.2.1...release/3.2.2
 [3.2.1]: https://github.com/hmrc/assets-frontend/compare/release/3.2.0...release/3.2.1
 [3.2.0]: https://github.com/hmrc/assets-frontend/compare/release/3.1.0...release/3.2.0


### PR DESCRIPTION
Links to releases since 3.1.0 were broken resulting in 404s.