### PR TITLE
Run tests in desktop viewport instead of phantom's default 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Version build artefacts according to the [HMRC release candidate format](http://hmrc.github.io/coding-in-the-open-manual/#release-candidates) [#924](https://github.com/hmrc/assets-frontend/pull/924)
 - Tar build artefacts instead of zip and add a package file for publishing [#925](https://github.com/hmrc/assets-frontend/pull/925)
 
+### Fixed
+- Run tests in desktop viewport instead of phantom's default 400 [#927](https://github.com/hmrc/assets-frontend/pull/927)
+
 ## [3.2.3] and [4.2.3] - 2018-03-15
 ### Fixed
 - Preventing a user from being able to focus inside the subnav when it has not been opened [#920](https://github.com/hmrc/assets-frontend/pull/920)

--- a/assets/test/config/karma.conf.js
+++ b/assets/test/config/karma.conf.js
@@ -57,7 +57,19 @@ module.exports = function (karmaConfig) {
     // - Safari (only Mac; has to be installed with `npm install karma-safari-launcher`)
     // - PhantomJS
     // - IE (only Windows; has to be installed with `npm install karma-ie-launcher`)
-    browsers: ['PhantomJS'],
+    browsers: ['PhantomJS_desktop'],
+
+    customLaunchers: {
+      'PhantomJS_desktop': {
+        base: 'PhantomJS',
+        options: {
+          viewportSize: {
+            width: 1024,
+            height: 800
+          }
+        }
+      }
+    },
 
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 60000,


### PR DESCRIPTION
## Problem

PhantomJS has a default viewport width of 400. This means all our tests are effectively running in our mobile media-query breakpoint.

## Solution

Set the default viewport size to larger than the [GOV.UK "desktop" breakpoint](https://github.com/alphagov/govuk_frontend_toolkit/blob/2011e77436fccd31f32a0a975a2bf4cc3b961495/stylesheets/_conditionals.scss#L29) of `min-width: 769px`
