### PR TITLE
Added page title documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Updated
+- Added documentation for page title [#928](https://github.com/hmrc/assets-frontend/pull/928)
 - Added documentation for open links in a new window or tab component [#926](https://github.com/hmrc/assets-frontend/pull/926)
 - Updated documentation headings and page not found pattern [#922](https://github.com/hmrc/assets-frontend/pull/922)
 - Updated documentation and examples for page heading [#923](https://github.com/hmrc/assets-frontend/pull/923)

--- a/assets/components/page-title/README.md
+++ b/assets/components/page-title/README.md
@@ -1,0 +1,40 @@
+# Page title
+
+What information to include in the page title. This is the `<title>` not the main heading or `<h1>`.
+
+{{ example("page-title.html") }}
+
+## When to use this component
+
+Use a unique page title on every page.
+
+### When not to use this component
+
+If there is personally identifiable information in the `<h1>` replace it so is not recorded in Google Analytics.
+
+For example, ‘What is Gordon's date of birth?’ could be ‘What is their date of birth?’ or ‘What is the child’s date of birth?’
+
+## How it works
+
+The page title can have 3 or 4 items separated by dashes.
+
+1. The same `<h1>` as the page with any personally identifiable information replaced.
+2. Section name. This should only be used with long services and those with multiple sections.
+3. Service name.
+4. GOV.UK
+
+{{ example("page-title.html") }}
+
+{{ markup("page-title-markup.html") }}
+
+## Research on this component
+
+This component is based on the format recommended by the Web Content Accessibility Guidelines in [Providing descriptive titles for Web pages](https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/G88).
+
+It is more accessible and is consistent with GOV.UK guidance pages.
+
+All users will be able to use the title to know:
+
+- what page they are on
+- where that page is inside a service
+- they are still on GOV.UK

--- a/assets/components/page-title/page-title-markup.html
+++ b/assets/components/page-title/page-title-markup.html
@@ -1,0 +1,1 @@
+<title>Do you live in the UK? – Your details – Manage your tax credits – GOV.UK</title>

--- a/assets/components/page-title/page-title.html
+++ b/assets/components/page-title/page-title.html
@@ -1,0 +1,1 @@
+Do you live in the UK? – Your details – Manage your tax credits – GOV.UK


### PR DESCRIPTION
# Problem

Different services use different page titles in different formats. This is to make it consistent and accessible.