### PR TITLE
Remove old assets-frontend paragraph from styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Version build artefacts according to the [HMRC release candidate format](http://hmrc.github.io/coding-in-the-open-manual/#release-candidates) [#924](https://github.com/hmrc/assets-frontend/pull/924)
 - Tar build artefacts instead of zip and add a package file for publishing [#925](https://github.com/hmrc/assets-frontend/pull/925)
+- Updated Styles index page to remove redundant paragraph
 
 ### Fixed
 - Run tests in desktop viewport instead of phantom's default 400 [#927](https://github.com/hmrc/assets-frontend/pull/927)

--- a/assets/styles/README.md
+++ b/assets/styles/README.md
@@ -4,8 +4,6 @@ The core styles that will make your service look and feel like GOV.UK.
 
 Providing you are using the [GOV.UK Prototype Kit](https://github.com/alphagov/govuk_prototype_kit/) or have [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) included in your build, the code supplied in the design system should not need any additional styling.
 
-If you're using [HMRC Assets-Frontend](http://github.com/hmrc/assets-frontend) some of these styles will look different until Assets Frontend has been updated to the latest version of GOV.UK Frontend.
-
 Should you need to apply styles manually you should follow existing GOV.UK conventions. For example, don’t assign new meanings to colours, don’t change the styling of buttons or change the thickness of borders on form inputs.
 
 All of the links in this section will take you to the current version of [GOV.UK Elements](http://govuk-elements.herokuapp.com/).


### PR DESCRIPTION
### Problem
assets-frontend is now built from govuk-elements latest, so the warning about old styles being shown is out of date

### Solution
Removed the redundant paragraph
