### PR TITLE
Updated notification badge

### DIFF
--- a/assets/components/notification-badge/README.md
+++ b/assets/components/notification-badge/README.md
@@ -1,4 +1,4 @@
-# Notification Badge
+# Notification badge
 
 {{ wip(142) }}
 
@@ -38,4 +38,4 @@ Notification badges are common on many sites and services. It has been tested as
 - people understand what it is for
 - it does not distract people from their task
 
-More work is needed to make it accessible – [add your research on GitHub](https://github.com/hmrc/design-patterns/issues/142).
+{{ research(142) }}

--- a/assets/components/notification-badge/_notification_badge.scss
+++ b/assets/components/notification-badge/_notification_badge.scss
@@ -1,13 +1,9 @@
 .badge {
-  position: relative;
   display: inline-block;
-  top: -10px;
-  left: -6px;
-  min-width: 19px;
-  padding: 3px 6px 2px 6px;
+  min-width: 10px;
+  padding: 5px 8px 1px 8px;
   font-size: 14px;
   font-weight: 600;
-  line-height: 1;
   background: #B10E1E;
   color: #FFF;
   text-align: center;

--- a/assets/components/notification-badge/notification-badge.html
+++ b/assets/components/notification-badge/notification-badge.html
@@ -1,1 +1,1 @@
-<a href="#">Messages<span class="badge" aria-label="Number of x">36</span></a>
+<a href="#">Messages<span class="badge">36</span></a>


### PR DESCRIPTION
## Problem
Changed CSS, code and examples. The notification badge is now inline and the code does not contain any aria-label so it is more accessible and will work on all screen readers.