### PR TITLE
Corrected a Typo in the Open links in a new window or tab page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Updated
-- Fixed a typo in open links in a new window or tab page
+- Fixed a typo in open links in a new window or tab page [#935](https://github.com/hmrc/assets-frontend/pull/935)
 - Fixed a typo in technical problem page [#933](https://github.com/hmrc/assets-frontend/pull/933)
 - Added documentation for page title [#928](https://github.com/hmrc/assets-frontend/pull/928)
 - Added documentation for open links in a new window or tab component [#926](https://github.com/hmrc/assets-frontend/pull/926)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Updated
+- Fixed a typeo in open links in a new window or tab page
 - Fixed a typo in technical problem page [#933](https://github.com/hmrc/assets-frontend/pull/933)
 - Added documentation for page title [#928](https://github.com/hmrc/assets-frontend/pull/928)
 - Added documentation for open links in a new window or tab component [#926](https://github.com/hmrc/assets-frontend/pull/926)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Updated
-- Fixed a typeo in open links in a new window or tab page
+- Fixed a typo in open links in a new window or tab page
 - Fixed a typo in technical problem page [#933](https://github.com/hmrc/assets-frontend/pull/933)
 - Added documentation for page title [#928](https://github.com/hmrc/assets-frontend/pull/928)
 - Added documentation for open links in a new window or tab component [#926](https://github.com/hmrc/assets-frontend/pull/926)

--- a/assets/components/open-links-in-a-new-window-or-tab/README.md
+++ b/assets/components/open-links-in-a-new-window-or-tab/README.md
@@ -20,7 +20,7 @@ Use this component if your testing shows you need to open a link in a new window
 If opening a link in a new window or tab:
 
 - does not meet a user need
-- leads to multiples windows or tabs for the same service
+- leads to multiple windows or tabs for the same service
 - stops people completing their task
 
 Do not use any icons in place of the words. See ‘[Removing the external link icon from GOV.UK](https://designnotes.blog.gov.uk/2016/11/28/removing-the-external-link-icon-from-gov-uk/)'.


### PR DESCRIPTION
## Problem
The Open links in a new window or tab page contained a typo, which I've corrected.

## Solution
Replaced *multiples windows* with *multiple windows*
