### PR TITLE
Fixed broken link on "errors and validation" page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Run tests in desktop viewport instead of phantom's default 400 [#927](https://github.com/hmrc/assets-frontend/pull/927)
+- Fixed broken link [#937](https://github.com/hmrc/assets-frontend/pull/937)
 
 ## [3.2.3] and [4.2.3] - 2018-03-15
 ### Fixed

--- a/assets/styles/errors-and-validation/README.md
+++ b/assets/styles/errors-and-validation/README.md
@@ -2,4 +2,4 @@
 
 Reduce the number of errors on a page.
 
-[See errors and validation in Elements](http://govuk-elements.herokuapp.com/errors-and-validation/).
+[See errors and validation in Elements](http://govuk-elements.herokuapp.com/errors).


### PR DESCRIPTION
## Problem
The link on the errors and validation page is broken

## Solution
Fix link to point to correct page on Gov.uk Elements