### PR TITLE
Fix form-control in high contrast mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Run tests in desktop viewport instead of phantom's default 400 [#927](https://github.com/hmrc/assets-frontend/pull/927)
 - Fixed broken link [#937](https://github.com/hmrc/assets-frontend/pull/937)
+- The text in form inputs wasn't visible in high contrast mode [#939](https://github.com/hmrc/assets-frontend/pull/939)
 
 ## [3.2.3] and [4.2.3] - 2018-03-15
 ### Fixed

--- a/assets/scss/base/form/_form.scss
+++ b/assets/scss/base/form/_form.scss
@@ -411,7 +411,6 @@ Styleguide Form.control
   width: 100%;
 
   padding: 5px 4px 4px;
-  background-color: $white;
   border: 2px solid $text-colour;
 
   // Disable appearance and remove rounded corners


### PR DESCRIPTION
## Problem

In high contrast mode the input text isn't visible.

### Example Screenshot

The highlighted text shows there is text in the input and it can be selected, but it's not visible.

![image](https://user-images.githubusercontent.com/1752124/38616370-23ccb8be-3d94-11e8-9906-f87e93c18cdd.png)

## Solution

Remove the `background-color` from inputs as per [GOV.UK Elements](https://github.com/alphagov/govuk_elements/blob/7a860c7274fd83484ba42eefe1575e72aefaf55d/assets/sass/elements/_forms.scss#L148-L149).

### Example Screenshot

![image](https://user-images.githubusercontent.com/1752124/38616515-8cdc87b2-3d94-11e8-9c62-b133cf743731.png)

Thanks to @grahampaulcook for discovering this issue and its fix.