### PR TITLE
New patterns for confirming or not confirming who someone is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-- New pattern for help users when we cannot confirm who they are [#942](https://github.com/hmrc/assets-frontend/pull/942)
+- New patterns for help users when we cannot confirm who they are and tell user we have confirmed who they are [#942](https://github.com/hmrc/assets-frontend/pull/942)
 
 ## [3.2.4] and [4.2.4] - 2018-04-12
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- New pattern for help users when we cannot confirm who they are [#942](https://github.com/hmrc/assets-frontend/pull/942)
+
 ## [3.2.4] and [4.2.4] - 2018-04-12
 ### Fixed
 - The text in form inputs wasn't visible in high contrast mode [#939](https://github.com/hmrc/assets-frontend/pull/939)

--- a/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/README.md
+++ b/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/README.md
@@ -52,7 +52,7 @@ List what they need in the ‘before you start’ information where the service 
 
 ### Give users extra help when they have a deadline
 
-If a user must do something by a specific time and the deadline is close, help them confirm who they are as quickly as possible. For example, a Self Assessment tax return or tax credit renewal.
+Help users to confirm who they are as quickly as possible if a user must do something by a specific time and the deadline is close. For example, a Self Assessment tax return or tax credit renewal.
 
 ### Provide help specific to your service
 

--- a/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/README.md
+++ b/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/README.md
@@ -1,6 +1,6 @@
 # Help users when we cannot confirm who they are
 
-This pattern tells users we cannot confirm who they are and tells them what they can do next. This is part of confirming who they are when they sign in with a Government Gateway account for the first time.
+This pattern tells users we cannot confirm who they are and what they can do next. This is part of confirming who they are when they sign in with a Government Gateway account for the first time.
 
 {{ example('help-users-when-we-cannot-confirm-who-they-are.html', scaled=false) }}
 
@@ -13,7 +13,7 @@ Use this pattern when we cannot confirm a user’s identity. This may include wh
 - does not provide enough information
 - makes too many attempts
 
-Doing this helps users to complete the task they are trying to perform. It can also help reduce time and money spent processing queries received by phone and post.
+Doing this helps users complete the task they are trying to do. It also helps reduce time and money spent dealing with queries received by phone and post.
 
 There is also a pattern to tell users we have confirmed who they are.
 
@@ -29,7 +29,7 @@ The page should have:
 
 - “H1 – service name – GOV.UK” as the page title
 - a H1 page heading
-- content explaining what went wrong and what they can do
+- content that explains what went wrong and what they can do
 - a call to action
 
 {{ example('help-users-when-we-cannot-confirm-who-they-are.html', scaled=false) }}

--- a/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/README.md
+++ b/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/README.md
@@ -15,7 +15,7 @@ Use this pattern when we cannot confirm a user’s identity. This may include wh
 
 Doing this helps users complete the task they are trying to do. It also helps reduce time and money spent dealing with queries received by phone and post.
 
-There is also a pattern to tell users we have confirmed who they are.
+There is also a pattern to [tell users we have confirmed who they are](/patterns/tell-users-we-have-confirmed-who-they-are/index.html).
 
 ## How it works
 

--- a/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/README.md
+++ b/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/README.md
@@ -1,0 +1,65 @@
+# Help users when we cannot confirm who they are
+
+This pattern tells users we cannot confirm who they are and tells them what they can do next. This is part of confirming who they are when they sign in with a Government Gateway account for the first time.
+
+{{ example('help-users-when-we-cannot-confirm-who-they-are.html', scaled=false) }}
+
+## When to use this pattern
+
+Use this pattern when we cannot confirm a user’s identity. This may include when a user:
+
+- provides details that do not match those we have on file
+- does not complete the process
+- does not provide enough information
+- makes too many attempts
+
+Doing this helps users to complete the task they are trying to perform. It can also help reduce time and money spent processing queries received by phone and post.
+
+There is also a pattern to tell users we have confirmed who they are.
+
+## How it works
+
+Use the standard page template from your service and have the same:
+
+- header
+- phase banner
+- footer
+
+The page should have:
+
+- “H1 – service name – GOV.UK” as the page title
+- a H1 page heading
+- content explaining what went wrong and what they can do
+- a call to action
+
+{{ example('help-users-when-we-cannot-confirm-who-they-are.html', scaled=false) }}
+
+### Avoid ending a journey
+
+Offer the user a way of continuing to use the service where possible.
+
+If this is not possible, provide a way for the user to do what they need to do another way. This could be another service where they do not need to confirm who they are.
+
+{{ example('help-users-when-we-cannot-confirm-who-they-are-avoid.html', scaled=false) }}
+
+### Understand the user’s journey
+
+Work with the team responsible for the microservice that confirms who the user is to understand how the process works. This will help you decide what is the best thing to tell a user to help them complete the process.
+
+### Tell users what they will need to confirm who they are when they start to use the service
+
+List what they need in the ‘before you start’ information where the service starts.
+
+### Give users extra help when they have a deadline
+
+If a user must do something by a specific time and the deadline is close, help them confirm who they are as quickly as possible. For example, a Self Assessment tax return or tax credit renewal.
+
+### Provide help specific to your service
+
+Avoid generic content. Display content that is relevant to the user’s journey.
+
+{{ example('help-users-when-we-cannot-confirm-who-they-are-specific.html', scaled=false) }}
+
+## Research on this pattern
+
+{{ research(117) }}

--- a/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/README.md
+++ b/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/README.md
@@ -52,7 +52,7 @@ List what they need in the ‘before you start’ information where the service 
 
 ### Give users extra help when they have a deadline
 
-Help users to confirm who they are as quickly as possible if a user must do something by a specific time and the deadline is close. For example, a Self Assessment tax return or tax credit renewal.
+Help users confirm who they are as quickly as possible if they must do something by a specific time and the deadline is close. For example, a Self Assessment tax return or tax credit renewal.
 
 ### Provide help specific to your service
 

--- a/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/help-users-when-we-cannot-confirm-who-they-are-avoid.html
+++ b/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/help-users-when-we-cannot-confirm-who-they-are-avoid.html
@@ -1,0 +1,7 @@
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">You tried to confirm who you are too many times</h1>
+      <p>You can try again in 24 hours by <a href="">signing in to the service again</a>.</p>
+      <p>If you need to make a payment and know how much you need to pay, <a href="">use the payment service</a>.</p>
+    </div>
+  </div>

--- a/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/help-users-when-we-cannot-confirm-who-they-are-specific.html
+++ b/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/help-users-when-we-cannot-confirm-who-they-are-specific.html
@@ -1,7 +1,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-large">We cannot confirm who you are</h1>
-      <p>You did not give us enough information.</p>
+      <p>You have not given us enough information.</p>
       <a href="" class="button" role="button">Try again</a>
     </div>
   </div>

--- a/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/help-users-when-we-cannot-confirm-who-they-are-specific.html
+++ b/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/help-users-when-we-cannot-confirm-who-they-are-specific.html
@@ -1,0 +1,7 @@
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">We cannot confirm who you are</h1>
+      <p>You did not give us enough information.</p>
+      <a href="" class="button" role="button">Try again</a>
+    </div>
+  </div>

--- a/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/help-users-when-we-cannot-confirm-who-they-are.html
+++ b/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/help-users-when-we-cannot-confirm-who-they-are.html
@@ -1,0 +1,7 @@
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">We cannot confirm who you are</h1>
+      <p>The information you have provided does not match what we hold.</p>
+      <a href="" role="button" class="button">Try again</a>
+    </div>
+  </div>

--- a/assets/patterns/tell-users-we-have-confirmed-who-they-are/README.md
+++ b/assets/patterns/tell-users-we-have-confirmed-who-they-are/README.md
@@ -1,0 +1,33 @@
+# Tell users we have confirmed who they are
+
+This pattern lets users know we have confirmed who they are. This is part of confirming who they are when they sign in with a Government Gateway account for the first time.
+
+{{ example('tell-users-we-have-confirmed-who-they-are.html', scaled=false) }}
+
+## When to use this pattern
+
+Use this pattern when we can confirm a user’s identity.
+
+There is also a pattern to [help users when we cannot confirm who they are](/patterns/help-users-when-we-cannot-confirm-who-they-are/index.html).
+
+## How it works
+
+Use the standard page template from your service and have the same:
+
+- header
+- phase banner
+- footer
+
+The page should have:
+
+- “We have confirmed who you are – service name – GOV.UK” as the page title
+- “We have confirmed who you are”
+- a “Continue” call to action
+
+{{ example('tell-users-we-have-confirmed-who-they-are.html', scaled=false) }}
+
+Do not use the confirmation page pattern. This is not the end of their journey.
+
+## Research on this pattern
+
+{{ research(148) }}

--- a/assets/patterns/tell-users-we-have-confirmed-who-they-are/tell-users-we-have-confirmed-who-they-are.html
+++ b/assets/patterns/tell-users-we-have-confirmed-who-they-are/tell-users-we-have-confirmed-who-they-are.html
@@ -1,0 +1,6 @@
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">We have confirmed who you are</h1>      
+      <a href="" role="button" class="button">Continue</a>
+    </div>
+  </div>


### PR DESCRIPTION
Patterns for:

- how we help user when we cannot confirm who they are.
- tell users we have confirmed who they are

## Problem

All services that use the identity verification microservice the first time a user signs in through Government Gateway has to have content when this fails or succeeds.