### PR TITLE
Updated error page examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Updated
+- Page not found, service unavailable and there is a problem with the service examples [#947](https://github.com/hmrc/assets-frontend/pull/947)
+
 ### Added
 - New patterns for help users when we cannot confirm who they are and tell user we have confirmed who they are [#942](https://github.com/hmrc/assets-frontend/pull/942)
 

--- a/assets/patterns/page-not-found/page-not-found.html
+++ b/assets/patterns/page-not-found/page-not-found.html
@@ -1,7 +1,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-large">Page not found</h1>
-      <p>This has been reported to the team that manage the service and will be fixed as soon as possible.</p>
+      <p>We have reported this to the team that manages the service and they will fix it as soon as possible.</p>
       <p>Contact us if you need to speak to someone about your tax credits.</p>
       <p>Telephone:<br>
       <span style="font-weight:700">0345 300 3900</span></p>

--- a/assets/patterns/service-unavailable/service-unavailable-after.html
+++ b/assets/patterns/service-unavailable/service-unavailable-after.html
@@ -2,7 +2,7 @@
     <div class="column-two-thirds">
       <h1 class="heading-large">Service unavailable</h1>
       <p>You cannot use the online service to renew your tax credits.</p>
-      <p><a href="https://www.gov.uk/contact-the-tax-credit-office">Contact the Tax Credit Helpline</a> to renew your tax credits by phone or letter.</p>
+      <p><a href="https://www.gov.uk/contact-the-tax-credit-office">Contact the Tax Credit Helpline</a> to renew your tax credits by phone or post.</p>
       <p>You can <a href="#">use the tax credits service</a> to:</p>
       <ul class="list list-bullet">
         <li>find out more about your payments</li>

--- a/assets/patterns/service-unavailable/service-unavailable-replacement.html
+++ b/assets/patterns/service-unavailable/service-unavailable-replacement.html
@@ -2,7 +2,7 @@
     <div class="column-two-thirds">
       <h1 class="heading-large">Service unavailable</h1>
       <p>Universal Credit has replaced tax credits.</p>
-      <p><a href="https://www.gov.uk/contact-the-tax-credit-office">Contact the Tax Credit Helpline</a> if you need to speak to someone about your tax credits.</p>      
+      <p><a href="https://www.gov.uk/contact-the-tax-credit-office">Contact the Tax Credit Helpline</a> if you need to speak to someone about your tax credits.</p>
       <p>You can:</p>
       <ul class="list list-bullet">
         <li><a href="https://www.gov.uk/universal-credit">find out more about Universal Credit</a></li>

--- a/assets/patterns/there-is-a-problem-with-the-service/there-is-a-problem-with-the-service-link.html
+++ b/assets/patterns/there-is-a-problem-with-the-service/there-is-a-problem-with-the-service-link.html
@@ -3,6 +3,6 @@
       <h1 class="heading-large">Sorry, there is a problem with the service</h1>
       <p>Try again later.</p>
       <p>If you need to make a payment and know how much you need to pay, <a href="">use the payment service</a>.</p>
-      <p><a href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/income-tax-enquiries-for-individuals-pensioners-and-employees">Contact the Income Tax Helpline</a> if you need to speak to someone about your tax calculation.</p>      
+      <p><a href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/income-tax-enquiries-for-individuals-pensioners-and-employees">Contact the Income Tax Helpline</a> if you need to speak to someone about your tax calculation.</p>
     </div>
   </div>

--- a/assets/patterns/there-is-a-problem-with-the-service/there-is-a-problem-with-the-service-no-contact.html
+++ b/assets/patterns/there-is-a-problem-with-the-service/there-is-a-problem-with-the-service-no-contact.html
@@ -3,7 +3,7 @@
       <h1 class="heading-large">Sorry, there is a problem with the service</h1>
       <p>Try again later.</p>
       <p>We have not saved your answers. When the service is available, you will have to start again.</p>
-      <p>Contact the Tax Credit Helpline if you have any questions.</p>
+      <p>Contact the Tax Credit Helpline if you need to make changes to your claim or speak to someone about your tax credits.</p>
       <p>Telephone:<br/>
       <span style="font-weight:700">0345 300 3900</span></p>
       <p>Textphone:<br/>

--- a/assets/patterns/there-is-a-problem-with-the-service/there-is-a-problem-with-the-service.html
+++ b/assets/patterns/there-is-a-problem-with-the-service/there-is-a-problem-with-the-service.html
@@ -3,6 +3,6 @@
       <h1 class="heading-large">Sorry, there is a problem with the service</h1>
       <p>Try again later.</p>
       <p>We saved your answers. They will be available for 30 days.</p>
-      <p><a href="https://www.gov.uk/contact-the-tax-credit-office">Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.</p>      
+      <p><a href="https://www.gov.uk/contact-the-tax-credit-office">Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.</p>
     </div>
   </div>


### PR DESCRIPTION
Updated examples for:

- page not found
- service unavailable
- there is a problem with the service

This included content changes and removing `<br>`s.