### PR TITLE
Running the patterns tests alongside components tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated documentation headings and page not found pattern [#922](https://github.com/hmrc/assets-frontend/pull/922)
 - Updated documentation and examples for page heading [#923](https://github.com/hmrc/assets-frontend/pull/923)
 - Refactoring the account menu JS and adding in unit tests [#929](https://github.com/hmrc/assets-frontend/pull/929)
+- Running the patterns tests alongside components tests [#948](https://github.com/hmrc/assets-frontend/pull/948)
 
 ### Changed
 - Version build artefacts according to the [HMRC release candidate format](http://hmrc.github.io/coding-in-the-open-manual/#release-candidates) [#924](https://github.com/hmrc/assets-frontend/pull/924)

--- a/assets/patterns/timeout-dialog/timeout-dialog.test.js
+++ b/assets/patterns/timeout-dialog/timeout-dialog.test.js
@@ -11,7 +11,7 @@ describe('Given the timeout dialog has been called', function () {
   var timeoutDialog = require('./timeoutDialog.js')
 
   beforeEach(function () {
-    jasmine.getFixtures().fixturesPath = 'base/components/timeout-dialog'
+    jasmine.getFixtures().fixturesPath = 'base/patterns/timeout-dialog'
     loadFixtures('timeout-dialog.html')
 
     $.timeoutDialog = timeoutDialog

--- a/assets/test/config/karma.conf.js
+++ b/assets/test/config/karma.conf.js
@@ -35,7 +35,9 @@ module.exports = function (karmaConfig) {
     preprocessors: {
       'test/specs/*.js': ['browserify'],
       'components/**/*.test.js': ['browserify'],
-      'components/**/*.test-mobile.js': ['browserify']
+      'components/**/*.test-mobile.js': ['browserify'],
+      'patterns/**/*.test.js': ['browserify'],
+      'patterns/**/*.test-mobile.js': ['browserify']
     },
 
     // web server port

--- a/gulpfile.js/config.js
+++ b/gulpfile.js/config.js
@@ -145,12 +145,18 @@ module.exports = {
         'components/**/**.html',
         'components/**/**.test.js',
         'components/**/**.test-mobile.js',
+        'patterns/**/**.html',
+        'patterns/**/**.test.js',
+        'patterns/**/**.test-mobile.js',
         'public/v3-SNAPSHOT/stylesheets/application.min.css'
       ],
       v4: [
         'components/**/**.html',
         'components/**/**.test.js',
         'components/**/**.test-mobile.js',
+        'patterns/**/**.html',
+        'patterns/**/**.test.js',
+        'patterns/**/**.test-mobile.js',
         'public/v4-SNAPSHOT/stylesheets/application.min.css'
       ]
     },


### PR DESCRIPTION
## Problem
Without this commit tests in the `patterns` directory aren't being run, this currently only affects `timeout-dialog.test.js`.

## Solution
Add the the `patterns` directory alongside `components` in the config, fix the path in the `timeout-dialog.test.js`

## Testing approach
To prove this works I've changed the expectation of a test and watched it fail, then corrected it and watched it pass.  This pass/fail was achieved via `npm start`