### PR TITLE
Change secondary timeout button to a link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Moved the header pattern to patterns and updated documentation [944](https://github.com/hmrc/assets-frontend/pull/944)
 - `node-git-versioning` plugin has been published to npm so we can depend on that version [#946](https://github.com/hmrc/assets-frontend/pull/946)
 
+### Changed
+- The secondary timeout dialog button should be a link
+
 ### Updated
 - Timeout documentation and examples [#949](https://github.com/hmrc/assets-frontend/pull/949)
 - Page not found, service unavailable and there is a problem with the service examples [#947](https://github.com/hmrc/assets-frontend/pull/947)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Added the `mailto:` scheme to the email link on the design-system *About* page. [951](https://github.com/hmrc/assets-frontend/pull/951)
+
 ### Changed
 - Moved the header pattern to patterns and updated documentation [944](https://github.com/hmrc/assets-frontend/pull/944)
 - `node-git-versioning` plugin has been published to npm so we can depend on that version [#946](https://github.com/hmrc/assets-frontend/pull/946)
-
-### Changed
-- The secondary timeout dialog button should be a link
+- The secondary timeout dialog button should be a link [#952](https://github.com/hmrc/assets-frontend/pull/952)
 
 ### Updated
 - Timeout documentation and examples [#949](https://github.com/hmrc/assets-frontend/pull/949)

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/_timeout-dialog.scss
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/_timeout-dialog.scss
@@ -48,13 +48,9 @@ html.noScroll {
     font-weight: 700;
   }
 
-  .button{
-    margin-bottom: 1em;
-    font-size: 19px;
-  }
-
-  .button.button--link{
-    margin: 0;
+  .link {
+    display: inline-block;
+    line-height: 1.25;
     padding: .526315em .789473em .263157em;
   }
 

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-not-signed-in.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-not-signed-in.html
@@ -85,6 +85,6 @@
 <div id="timeout-dialog" class="timeout-dialog" role="dialog" aria-labelledby="timeout-message" tabindex="-1" aria-live="polite">
   <p id="timeout-message" role="text">For your security, we will delete your answers in <span id="timeout-countdown" class="countdown">2 minutes</span>.</p>
   <button id="timeout-keep-signin-btn" class="button">Continue checking what help you can get with childcare costs</button>
-  <button id="timeout-sign-out-btn" class="button button--link">Delete your answers</button>
+  <a id="timeout-sign-out-btn" class="link">Delete your answers</button>
 </div>
 <div id="timeout-overlay" class="timeout-overlay"></div>

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-saved.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-saved.html
@@ -85,6 +85,6 @@
 <div id="timeout-dialog" class="timeout-dialog" role="dialog" aria-labelledby="timeout-message" tabindex="-1" aria-live="polite">
   <p id="timeout-message" role="text">For your security, we will sign you out in <span id="timeout-countdown" class="countdown">2 minutes</span>. We saved your answers.</p>
   <button id="timeout-keep-signin-btn" class="button">Stay signed in</button>
-  <button id="timeout-sign-out-btn" class="button button--link">Sign out</button>
+  <a id="timeout-sign-out-btn" class="link">Sign out</button>
 </div>
 <div id="timeout-overlay" class="timeout-overlay"></div>

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-will-not-save.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-will-not-save.html
@@ -85,6 +85,6 @@
 <div id="timeout-dialog" class="timeout-dialog" role="dialog" aria-labelledby="timeout-message" tabindex="-1" aria-live="polite">
   <p id="timeout-message" role="text">For your security, we will sign you out in <span id="timeout-countdown" class="countdown">2 minutes</span>. We will not save your answers.</p>
   <button id="timeout-keep-signin-btn" class="button">Stay signed in</button>
-  <button id="timeout-sign-out-btn" class="button button--link">Sign out</button>
+  <a id="timeout-sign-out-btn" class="link">Sign out</button>
 </div>
 <div id="timeout-overlay" class="timeout-overlay"></div>

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout.html
@@ -85,6 +85,6 @@
 <div id="timeout-dialog" class="timeout-dialog" role="dialog" aria-labelledby="timeout-message" tabindex="-1" aria-live="polite">
   <p id="timeout-message" role="text">For your security, we will sign you out in <span id="timeout-countdown" class="countdown">2 minutes</span>.</p>
   <button id="timeout-keep-signin-btn" class="button">Stay signed in</button>
-  <button id="timeout-sign-out-btn" class="button button--link">Sign out</button>
+  <a id="timeout-sign-out-btn" class="link">Sign out</button>
 </div>
 <div id="timeout-overlay" class="timeout-overlay"></div>

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeoutDialog.js
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeoutDialog.js
@@ -71,7 +71,7 @@ module.exports = function (options) {
         '<h1 class="heading-medium push--top">' + settings.title + '</h1>' +
         '<p id="timeout-message" role="text">' + settings.message + ' <span id="timeout-countdown" class="countdown">' + time.m + ' ' + settings.time + '</span>' + '.</p>' +
         '<button id="timeout-keep-signin-btn" class="button">' + settings.keep_alive_button_text + '</button>' +
-        '<button id="timeout-sign-out-btn" class="button button--link">' + settings.sign_out_button_text + '</button>' +
+        '<a id="timeout-sign-out-btn" class="link">' + settings.sign_out_button_text + '</button>' +
         '</div>' +
         '<div id="timeout-overlay" class="timeout-overlay"></div>')
       .appendTo('body')

--- a/package-lock.json
+++ b/package-lock.json
@@ -7340,7 +7340,7 @@
       }
     },
     "hmrc-component-library-template": {
-      "version": "github:hmrc/component-library-template#16f9c37371c08ac2da51861a77c78c75ed9baba5"
+      "version": "github:hmrc/component-library-template#f67332689069cbebf5a384006899738045300b07"
     },
     "hoek": {
       "version": "4.2.1",


### PR DESCRIPTION
## Problem

Having 2 buttons next to each other is an anti-pattern.

### Example Screenshot

![image](https://user-images.githubusercontent.com/1752124/39623115-e10b0072-4f94-11e8-9666-8fed5db7eb85.png)

## Solution

Change the secondary action to a link

### Example Screenshot

![image](https://user-images.githubusercontent.com/1752124/39623135-f0788642-4f94-11e8-8785-05edbe851d94.png)
