### PR TITLE
SDT-833 fix sign out link closing tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Added the `mailto:` scheme to the email link on the design-system *About* page. [951](https://github.com/hmrc/assets-frontend/pull/951)
-- Fixed the `sign-out` link on the *Help users when we sign them out...* page examples
+- Fixed the `sign-out` link on the *Help users when we sign them out...* page examples [953](https://github.com/hmrc/assets-frontend/pull/953)
 
 ### Changed
 - Moved the header pattern to patterns and updated documentation [944](https://github.com/hmrc/assets-frontend/pull/944)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Added the `mailto:` scheme to the email link on the design-system *About* page. [951](https://github.com/hmrc/assets-frontend/pull/951)
+- Fixed the `sign-out` link on the *Help users when we sign them out...* page examples
 
 ### Changed
 - Moved the header pattern to patterns and updated documentation [944](https://github.com/hmrc/assets-frontend/pull/944)

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-not-signed-in.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-not-signed-in.html
@@ -85,6 +85,6 @@
 <div id="timeout-dialog" class="timeout-dialog" role="dialog" aria-labelledby="timeout-message" tabindex="-1" aria-live="polite">
   <p id="timeout-message" role="text">For your security, we will delete your answers in <span id="timeout-countdown" class="countdown">2 minutes</span>.</p>
   <button id="timeout-keep-signin-btn" class="button">Continue checking what help you can get with childcare costs</button>
-  <a id="timeout-sign-out-btn" class="link">Delete your answers</button>
+  <a id="timeout-sign-out-btn" class="link">Delete your answers</a>
 </div>
 <div id="timeout-overlay" class="timeout-overlay"></div>

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-saved.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-saved.html
@@ -85,6 +85,6 @@
 <div id="timeout-dialog" class="timeout-dialog" role="dialog" aria-labelledby="timeout-message" tabindex="-1" aria-live="polite">
   <p id="timeout-message" role="text">For your security, we will sign you out in <span id="timeout-countdown" class="countdown">2 minutes</span>. We saved your answers.</p>
   <button id="timeout-keep-signin-btn" class="button">Stay signed in</button>
-  <a id="timeout-sign-out-btn" class="link">Sign out</button>
+  <a id="timeout-sign-out-btn" class="link">Sign out</a>
 </div>
 <div id="timeout-overlay" class="timeout-overlay"></div>

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-will-not-save.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-will-not-save.html
@@ -85,6 +85,6 @@
 <div id="timeout-dialog" class="timeout-dialog" role="dialog" aria-labelledby="timeout-message" tabindex="-1" aria-live="polite">
   <p id="timeout-message" role="text">For your security, we will sign you out in <span id="timeout-countdown" class="countdown">2 minutes</span>. We will not save your answers.</p>
   <button id="timeout-keep-signin-btn" class="button">Stay signed in</button>
-  <a id="timeout-sign-out-btn" class="link">Sign out</button>
+  <a id="timeout-sign-out-btn" class="link">Sign out</a>
 </div>
 <div id="timeout-overlay" class="timeout-overlay"></div>

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout.html
@@ -85,6 +85,6 @@
 <div id="timeout-dialog" class="timeout-dialog" role="dialog" aria-labelledby="timeout-message" tabindex="-1" aria-live="polite">
   <p id="timeout-message" role="text">For your security, we will sign you out in <span id="timeout-countdown" class="countdown">2 minutes</span>.</p>
   <button id="timeout-keep-signin-btn" class="button">Stay signed in</button>
-  <a id="timeout-sign-out-btn" class="link">Sign out</button>
+  <a id="timeout-sign-out-btn" class="link">Sign out</a>
 </div>
 <div id="timeout-overlay" class="timeout-overlay"></div>

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeoutDialog.js
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeoutDialog.js
@@ -71,7 +71,7 @@ module.exports = function (options) {
         '<h1 class="heading-medium push--top">' + settings.title + '</h1>' +
         '<p id="timeout-message" role="text">' + settings.message + ' <span id="timeout-countdown" class="countdown">' + time.m + ' ' + settings.time + '</span>' + '.</p>' +
         '<button id="timeout-keep-signin-btn" class="button">' + settings.keep_alive_button_text + '</button>' +
-        '<a id="timeout-sign-out-btn" class="link">' + settings.sign_out_button_text + '</button>' +
+        '<a id="timeout-sign-out-btn" class="link">' + settings.sign_out_button_text + '</a>' +
         '</div>' +
         '<div id="timeout-overlay" class="timeout-overlay"></div>')
       .appendTo('body')


### PR DESCRIPTION
The `<a>` tag was used to open the *sign-out* link, but the `</button>` tag was trying to close it.

Replace the `</button>` tag with an `</a>` tag. 