### PR TITLE
Corrected two typos on Open links in a new window or tab page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Added the `mailto:` scheme to the email link on the design-system *About* page. [951](https://github.com/hmrc/assets-frontend/pull/951)
 - Fixed the `sign-out` link on the *Help users when we sign them out...* page examples [953](https://github.com/hmrc/assets-frontend/pull/953)
-
+- Fixed a couple of typos on the _opens in a new window or tab_ page [954](https://github.com/hmrc/assets-frontend/pull/954)
 ### Changed
 - Moved the header pattern to patterns and updated documentation [944](https://github.com/hmrc/assets-frontend/pull/944)
 - `node-git-versioning` plugin has been published to npm so we can depend on that version [#946](https://github.com/hmrc/assets-frontend/pull/946)

--- a/assets/components/open-links-in-a-new-window-or-tab/README.md
+++ b/assets/components/open-links-in-a-new-window-or-tab/README.md
@@ -27,11 +27,11 @@ Do not use any icons in place of the words. See ‘[Removing the external link i
 
 ## How it works
 
-Always put ‘(opens in a new link or window)’ inside the link text content.
+Always put ‘(opens in a new window or tab)’ inside the link text content.
 
 In the code include:
 
-- target="_blank" top open in a new window or tab
+- target="_blank" to open in a new window or tab
 - rel="noopener noreferrer" to reduce security risks for some browsers
 
 {{ example("open-links-in-a-new-window-or-tab.html") }}


### PR DESCRIPTION
Correct a couple of Typos highlighted by @russellthorn on the _Open links in a new window or tab_ page 