### PR TITLE
Updated examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The secondary timeout dialog button should be a link [#952](https://github.com/hmrc/assets-frontend/pull/952)
 
 ### Updated
+- Examples that link to another service when a journey is incomplete [#956](https://github.com/hmrc/assets-frontend/pull/956)
 - Documentation and examples for messages pattern [#955](https://github.com/hmrc/assets-frontend/pull/955)
 - Timeout documentation and examples [#949](https://github.com/hmrc/assets-frontend/pull/949)
 - Page not found, service unavailable and there is a problem with the service examples [#947](https://github.com/hmrc/assets-frontend/pull/947)

--- a/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/help-users-when-we-cannot-confirm-who-they-are-avoid.html
+++ b/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/help-users-when-we-cannot-confirm-who-they-are-avoid.html
@@ -2,6 +2,6 @@
     <div class="column-two-thirds">
       <h1 class="heading-large">You tried to confirm who you are too many times</h1>
       <p>You can try again in 24 hours by <a href="">signing in to the service again</a>.</p>
-      <p>If you need to make a payment and know how much you need to pay, <a href="">use the payment service</a>.</p>
+      <p>If you know how much you owe, you can still <a href="">pay now</a>.</p>
     </div>
   </div>

--- a/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/help-users-when-we-cannot-confirm-who-they-are-avoid.html
+++ b/assets/patterns/help-users-when-we-cannot-confirm-who-they-are/help-users-when-we-cannot-confirm-who-they-are-avoid.html
@@ -1,7 +1,6 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-large">You tried to confirm who you are too many times</h1>
-      <p>You can try again in 24 hours by <a href="">signing in to the service again</a>.</p>
-      <p>If you know how much you owe, you can still <a href="">pay now</a>.</p>
+      <p>You can <a href="#">change other VAT details</a>.</p>
     </div>
   </div>

--- a/assets/patterns/service-unavailable/service-unavailable-link.html
+++ b/assets/patterns/service-unavailable/service-unavailable-link.html
@@ -2,7 +2,7 @@
     <div class="column-two-thirds">
       <h1 class="heading-large">Service unavailable</h1>
       <p>You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.</p>
-      <p>If you need to make a payment and know how much you need to pay, <a href="">use the payment service</a>.</p>
+      <p>If you know how much you owe, you can still <a href="">pay now</a>.</p>
       <p><a href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/income-tax-enquiries-for-individuals-pensioners-and-employees">Contact the Income Tax Helpline</a> if you need to speak to someone about your tax calculation.</p>
     </div>
   </div>

--- a/assets/patterns/service-unavailable/service-unavailable-link.html
+++ b/assets/patterns/service-unavailable/service-unavailable-link.html
@@ -2,7 +2,7 @@
     <div class="column-two-thirds">
       <h1 class="heading-large">Service unavailable</h1>
       <p>You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.</p>
-      <p>If you know how much you owe, you can still <a href="">pay now</a>.</p>
+      <p>You can <a href="#">change other VAT details</a>.</p>
       <p><a href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/income-tax-enquiries-for-individuals-pensioners-and-employees">Contact the Income Tax Helpline</a> if you need to speak to someone about your tax calculation.</p>
     </div>
   </div>

--- a/assets/patterns/there-is-a-problem-with-the-service/there-is-a-problem-with-the-service-link.html
+++ b/assets/patterns/there-is-a-problem-with-the-service/there-is-a-problem-with-the-service-link.html
@@ -2,7 +2,7 @@
     <div class="column-two-thirds">
       <h1 class="heading-large">Sorry, there is a problem with the service</h1>
       <p>Try again later.</p>
-      <p>If you need to make a payment and know how much you need to pay, <a href="">use the payment service</a>.</p>
+      <p>If you know how much you owe, you can still <a href="">pay now</a>.</p>
       <p><a href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/income-tax-enquiries-for-individuals-pensioners-and-employees">Contact the Income Tax Helpline</a> if you need to speak to someone about your tax calculation.</p>
     </div>
   </div>

--- a/assets/patterns/there-is-a-problem-with-the-service/there-is-a-problem-with-the-service-link.html
+++ b/assets/patterns/there-is-a-problem-with-the-service/there-is-a-problem-with-the-service-link.html
@@ -2,7 +2,7 @@
     <div class="column-two-thirds">
       <h1 class="heading-large">Sorry, there is a problem with the service</h1>
       <p>Try again later.</p>
-      <p>If you know how much you owe, you can still <a href="">pay now</a>.</p>
+      <p>You can <a href="#">change other VAT details</a>.</p>
       <p><a href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/income-tax-enquiries-for-individuals-pensioners-and-employees">Contact the Income Tax Helpline</a> if you need to speak to someone about your tax calculation.</p>
     </div>
   </div>


### PR DESCRIPTION
Updated examples across 3 patterns that link to another service when there is an issue. The patterns are:

- help users when we cannot confirm who they are
- service unavailable
- there is a problem with the service

This is based on user research from Telford where the updated content that focused on the task was more usable than the previous content that focused on a service.