### PR TITLE
Refactor for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Page not found, service unavailable and there is a problem with the service examples [#947](https://github.com/hmrc/assets-frontend/pull/947)
 - Markup example and tests for Account Menu and Account Header [#961](https://github.com/hmrc/assets-frontend/pull/961)
 - The timeout dialog has been heavily refactored with full test coverage, a new preferred interface has been added as `govuk.timeoutDialog()` while still supporting `$.timeoutDialog()` with its current form [#957](https://github.com/hmrc/assets-frontend/pull/957) 
+- Minor refactor to timeoutDialog for consistency - missed while doing the major change [#968](https://github.com/hmrc/assets-frontend/pull/968)
 
 ### Added
 - New pattern for asking users for their consent to meet GDPR and DPA standards [#962](https://github.com/hmrc/assets-frontend/pull/962)

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeoutDialog.js
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeoutDialog.js
@@ -109,7 +109,7 @@ var self = module.exports = {
           dialogControl.setAriaLive()
         }
         if (counter < 60) {
-          message = counter + ' ' + settings.properties[counter !== 1 ? 'seconds' : 'second']
+          message = counter + ' ' + settings.properties[counter === 1 ? 'second' : 'seconds']
         } else {
           var minutes = Math.ceil(counter / 60)
           message = minutes + ' ' + settings.properties[minutes === 1 ? 'minute' : 'minutes']


### PR DESCRIPTION
## Problem
There was an inconsistency between the condition used for minute/minutes and second/seconds

## Solution
The conditions are now equivalent.  The existing tests still pass, no change to behaviour.