### PR TITLE
Added tests for show hide content module...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New pattern for asking users for their consent to meet GDPR and DPA standards [#962](https://github.com/hmrc/assets-frontend/pull/962)
 - New patterns for help users when we cannot confirm who they are and tell user we have confirmed who they are [#942](https://github.com/hmrc/assets-frontend/pull/942)
 - Added the conditional reveal functionality from Elements [#967](https://github.com/hmrc/assets-frontend/pull/967)
+- Added new tests for the show hide content module [#969](https://github.com/hmrc/assets-frontend/pull/969)
 
 ## [3.2.4] and [4.2.4] - 2018-04-12
 ### Fixed

--- a/assets/components/show-hide-content/README.hidden.MD
+++ b/assets/components/show-hide-content/README.hidden.MD
@@ -1,0 +1,3 @@
+# Show hide content
+
+This is used for test purposes only.

--- a/assets/components/show-hide-content/show-hide-content-init.html
+++ b/assets/components/show-hide-content/show-hide-content-init.html
@@ -1,0 +1,33 @@
+<div class="form-group">
+  <fieldset>
+    <legend>
+      <h1 class="heading-medium">
+        How do you want to be contacted?
+      </h1>
+    </legend>
+    <div class="multiple-choice" data-target="contact-by-email">
+      <input id="example-contact-by-email" type="radio" name="radio-contact-group" value="Yes">
+      <label for="example-contact-by-email">Email</label>
+    </div>
+    <div class="panel panel-border-narrow js-hidden" id="contact-by-email">
+      <label class="form-label" for="contact-email">Email address</label>
+      <input class="form-control" name="contact-email" type="text" id="contact-email">
+    </div>
+    <div class="multiple-choice" data-target="contact-by-phone">
+      <input id="example-contact-by-phone" type="radio" name="radio-contact-group" value="No">
+      <label for="example-contact-by-phone">Phone</label>
+    </div>
+    <div class="panel panel-border-narrow js-hidden" id="contact-by-phone">
+      <label class="form-label" for="contact-phone">Phone number</label>
+      <input class="form-control" name="contact-phone" type="text" id="contact-phone">
+    </div>
+    <div class="multiple-choice" data-target="contact-by-text">
+      <input id="example-contact-by-text" type="radio" name="radio-contact-group" value="No">
+      <label for="example-contact-by-text">Text message</label>
+    </div>
+    <div class="panel panel-border-narrow js-hidden" id="contact-by-text">
+      <label class="form-label" for="contact-text-message">Mobile phone number</label>
+      <input class="form-control" name="contact-text-message" type="text" id="contact-text-message">
+    </div>
+  </fieldset>
+</div>

--- a/assets/components/show-hide-content/show-hide-content-init.js
+++ b/assets/components/show-hide-content/show-hide-content-init.js
@@ -3,12 +3,4 @@ var showHide = function () {
   var showHideContent = new GOVUK.ShowHideContent()
   showHideContent.init()
 }
-if (document.addEventListener) {
-  document.addEventListener('DOMContentLoaded', function () {
-    showHide()
-  })
-} else {
-  window.attachEvent('onload', function () {
-    showHide()
-  })
-}
+showHide()

--- a/assets/components/show-hide-content/show-hide-content-init.test.js
+++ b/assets/components/show-hide-content/show-hide-content-init.test.js
@@ -1,0 +1,21 @@
+/* eslint-env jasmine, jquery */
+/* global loadFixtures */
+require('jquery')
+
+describe('Show hide content', function () {
+  beforeEach(function () {
+    jasmine.getFixtures().fixturesPath = 'base/components/show-hide-content/'
+    loadFixtures('show-hide-content-init.html')
+    require('govuk_frontend_toolkit/javascripts/govuk/show-hide-content') // This is added in browserify during a build
+    require('../../application')
+    $('html').addClass('js')
+  })
+
+  it('should have been called', function () {
+    expect($('#contact-by-phone')).toBeHidden()
+    $('#example-contact-by-phone').click()
+    expect($('#contact-by-phone')).not.toBeHidden()
+    $('#example-contact-by-email').click()
+    expect($('#contact-by-phone')).toBeHidden()
+  })
+})


### PR DESCRIPTION
We need to know that the show hide content function works when integrating Assets Frontend with the Gov.uk Toolkit.

## Problem
We do not have any tests running on the show hide content module.

## Solution
Add tests to show that the show hide content module works alongside Gov.uk Toolkit.
