### PR TITLE
Conditional reveal fix, tests passed but code was broken...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed table layout issue on messages pattern full width [959](https://github.com/hmrc/assets-frontend/pull/959)
 - Removed unwanted folder called component library template from git [964](https://github.com/hmrc/assets-frontend/pull/964)
 - Replaced missing 'add to a list' pattern files which got deleted from merge on commit 8c6fd11 [965](https://github.com/hmrc/assets-frontend/pull/965)
+- Refactored tests for show hide as we needed to test the function with DOMContentLoaded event listener, previous test were not a true reflection of when the code gets loaded in production. [971](https://github.com/hmrc/assets-frontend/pull/971) 
 
 ### Changed
 - Moved the header pattern to patterns and updated documentation [944](https://github.com/hmrc/assets-frontend/pull/944)

--- a/assets/components/show-hide-content/show-hide-content-init.js
+++ b/assets/components/show-hide-content/show-hide-content-init.js
@@ -3,12 +3,4 @@ var showHide = function () {
   var showHideContent = new GOVUK.ShowHideContent()
   showHideContent.init()
 }
-if (document.addEventListener) {
-  document.addEventListener('DOMContentLoaded', function () {
-    showHide()
-  })
-} else {
-  window.attachEvent('onload', function () {
-    showHide()
-  })
-}
+showHide()

--- a/assets/components/show-hide-content/show-hide-content-init.js
+++ b/assets/components/show-hide-content/show-hide-content-init.js
@@ -3,4 +3,12 @@ var showHide = function () {
   var showHideContent = new GOVUK.ShowHideContent()
   showHideContent.init()
 }
-showHide()
+if (document.addEventListener) {
+  document.addEventListener('DOMContentLoaded', function () {
+    showHide()
+  })
+} else {
+  window.attachEvent('onload', function () {
+    showHide()
+  })
+}

--- a/assets/components/show-hide-content/show-hide-content-init.test.js
+++ b/assets/components/show-hide-content/show-hide-content-init.test.js
@@ -3,29 +3,19 @@
 require('jquery')
 
 describe('Show hide content', function () {
-  beforeEach(function (done) {
+  beforeEach(function () {
     jasmine.getFixtures().fixturesPath = 'base/components/show-hide-content/'
     loadFixtures('show-hide-content-init.html')
-    $('html').addClass('js')
-    var event = document.createEvent('Event')
-    event.initEvent('DOMContentLoaded', true, true)
     require('govuk_frontend_toolkit/javascripts/govuk/show-hide-content') // This is added in browserify during a build
     require('../../application')
-    window.document.dispatchEvent(event)
-    done()
+    $('html').addClass('js')
   })
 
-  // Todo: See if we can find a way to check that the showHideContent.init() code has actually been called.
-
-  it('should reveal content when selecting the associated radio button', function (done) {
+  it('should have been called', function () {
+    expect($('#contact-by-phone')).toBeHidden()
     $('#example-contact-by-phone').click()
     expect($('#contact-by-phone')).not.toBeHidden()
-    done()
-  })
-
-  it('should hide content when a different radio button is clicked', function (done) {
     $('#example-contact-by-email').click()
     expect($('#contact-by-phone')).toBeHidden()
-    done()
   })
 })

--- a/assets/components/show-hide-content/show-hide-content-init.test.js
+++ b/assets/components/show-hide-content/show-hide-content-init.test.js
@@ -3,19 +3,29 @@
 require('jquery')
 
 describe('Show hide content', function () {
-  beforeEach(function () {
+  beforeEach(function (done) {
     jasmine.getFixtures().fixturesPath = 'base/components/show-hide-content/'
     loadFixtures('show-hide-content-init.html')
+    $('html').addClass('js')
+    var event = document.createEvent('Event')
+    event.initEvent('DOMContentLoaded', true, true)
     require('govuk_frontend_toolkit/javascripts/govuk/show-hide-content') // This is added in browserify during a build
     require('../../application')
-    $('html').addClass('js')
+    window.document.dispatchEvent(event)
+    done()
   })
 
-  it('should have been called', function () {
-    expect($('#contact-by-phone')).toBeHidden()
+  // Todo: See if we can find a way to check that the showHideContent.init() code has actually been called.
+
+  it('should reveal content when selecting the associated radio button', function (done) {
     $('#example-contact-by-phone').click()
     expect($('#contact-by-phone')).not.toBeHidden()
+    done()
+  })
+
+  it('should hide content when a different radio button is clicked', function (done) {
     $('#example-contact-by-email').click()
     expect($('#contact-by-phone')).toBeHidden()
+    done()
   })
 })


### PR DESCRIPTION
The tests for the conditional reveal is creating a false sense of confidence as the function is not being called in production.

## Problem
Previously we removed the DOMContentLoaded event listener as we didn't think we needed it. The tests passed but the function never got called in production.

## Solution
Replace the DOMContentLoaded event listener and get the tests to pass by creating this event listener in the tests mocking out the real behaviour.
