### PR TITLE
LDS exemption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Updated
 - Deleted nonsense characters from add to a list documentation. [#973](https://github.com/hmrc/assets-frontend/pull/973)
+- Added an exception for internal security tool [#974](https://github.com/hmrc/assets-frontend/pull/974)
 
 ## [3.3.1] and [4.3.1] 2018-06-11
 ### Fixed

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,4 @@
+leakDetectionExemptions:
+ - ruleId: 'ip_addresses'
+   filePaths:
+      - '/public/javascripts/mdtpdf.min.js.map'


### PR DESCRIPTION
Section ids in the file referenced were causing false-positive LDS alerts

## Problem
Leak Detection Service was detecting a false-positive and causing notification noise

## Solution
Added exemption as the text detected was section numbers and not IP addresses