### PR TITLE
Welsh translation example macro...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New pattern for asking users for their consent to meet GDPR and DPA standards [#962](https://github.com/hmrc/assets-frontend/pull/962)
 - New patterns for help users when we cannot confirm who they are and tell user we have confirmed who they are [#942](https://github.com/hmrc/assets-frontend/pull/942)
 - Added new tests for the show hide content module [#969](https://github.com/hmrc/assets-frontend/pull/969)
+- Added new macro for displaying Welsh examples [#975](https://github.com/hmrc/assets-frontend/pull/975)
 
 ## [3.2.4] and [4.2.4] - 2018-04-12
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ If your prototype is based on the [GOV.UK prototype kit](https://github.com/alph
 
 Save the file found at
 [https://www.tax.service.gov.uk/assets/\<VERSION\>/stylesheets/application.min.css](https://www.tax.service.gov.uk/assets/\<VERSION\>/stylesheets/application.min.css)
-to `/app/assets/sass/assets-frontend.scss`.
+to `/app/assets/sass/assets-frontend.css`.
 
 And add the following to `app/views/includes/head.html`:
 ```
-<link href="/public/stylesheets/assets-frontend.scss" rel="stylesheet" type="text/css" />
+<link href="/public/stylesheets/assets-frontend.css" rel="stylesheet" type="text/css" />
 ```
 
 **JavaScript**

--- a/gulpfile.js/util/design-system/lib/parseDocumentation.js
+++ b/gulpfile.js/util/design-system/lib/parseDocumentation.js
@@ -15,6 +15,15 @@ var parseDocumentation = function (files) {
       path.parse(file.path).dir,
       config.designSystem.sourceBaseDir
     ])
+
+    environment.addFilter('getWelshFileName', function (filePath) {
+      var filePathArray = filePath.split('.')
+      var fileType = filePathArray.pop()
+      filePathArray.push('cy')
+      filePathArray.push(fileType)
+      return filePathArray.join('.')
+    })
+
     environment.addGlobal('filePath', path.parse(path.relative(config.designSystem.sourceBaseDir, file.path)).dir)
 
     var fileContents = macros + file.contents.toString()

--- a/gulpfile.js/util/design-system/macros/example.html
+++ b/gulpfile.js/util/design-system/macros/example.html
@@ -1,27 +1,27 @@
 {% macro example(file, scaled=false, cy=false, html=false) %}
-  {% if scaled %}
-    {% set scaledWrapperStart %}<div class="scale-wrapper"><div class="scale">{% endset %}
-    {% set scaledWrapperEnd %}</div></div>{% endset %}
-  {% else %}
-    {% set scaledWrapperStart = '' %}
-    {% set scaledWrapperEnd = '' %}
-  {% endif %}
-
-  <div class="example">{{ scaledWrapperStart | safe }}{% include file %}{{ scaledWrapperEnd | safe }}</div>
-  {% if html %}
-    {% include file %}
-  {% endif %}
-
-  {% if cy %}
-  {% set fileCy %}{{ file | getWelshFileName }}{% endset %}
-  <details>
-    <summary>Welsh example</summary>
-     <div class="example">{{ scaledWrapperStart | safe }}{% include fileCy %}{{ scaledWrapperEnd | safe }}</div>
-  </details>
-  {% if html %}
-    {% include fileCy %}
-  {% endif %}
-
-  {% endif %}
-
+{% if scaled %}
+{% set scaledWrapperStart %}<div class="scale-wrapper"><div class="scale">{% endset %}
+{% set scaledWrapperEnd %}</div></div>{% endset %}
+{% else %}
+{% set scaledWrapperStart = '' %}
+{% set scaledWrapperEnd = '' %}
+{% endif %}
+<div class="example">{{ scaledWrapperStart | safe }}{% include file %}{{ scaledWrapperEnd | safe }}</div>
+{% if html %}
+```
+{% include file %}
+```
+{% endif %}
+{% if cy %}
+{% set fileCy %}{{ file | getWelshFileName }}{% endset %}
+<details>
+<summary>Welsh example</summary>
+<div class="example">{{ scaledWrapperStart | safe }}{% include fileCy %}{{ scaledWrapperEnd | safe }}</div>
+</details>
+{% if html %}
+```
+{% include fileCy %}
+```
+{% endif %}
+{% endif %}
 {% endmacro %}

--- a/gulpfile.js/util/design-system/macros/example.html
+++ b/gulpfile.js/util/design-system/macros/example.html
@@ -18,10 +18,5 @@
 <summary>Welsh example</summary>
 <div class="example">{{ scaledWrapperStart | safe }}{% include fileCy %}{{ scaledWrapperEnd | safe }}</div>
 </details>
-{% if html %}
-```
-{% include fileCy %}
-```
-{% endif %}
 {% endif %}
 {% endmacro %}

--- a/gulpfile.js/util/design-system/macros/example.html
+++ b/gulpfile.js/util/design-system/macros/example.html
@@ -1,4 +1,4 @@
-{% macro example(file, scaled=false, cy=false, summary='', html=false) %}
+{% macro example(file, scaled=false, cy=false, html=false) %}
   {% if scaled %}
     {% set scaledWrapperStart %}<div class="scale-wrapper"><div class="scale">{% endset %}
     {% set scaledWrapperEnd %}</div></div>{% endset %}
@@ -15,7 +15,7 @@
   {% if cy %}
   {% set fileCy %}{{ file | getWelshFileName }}{% endset %}
   <details>
-    <summary>{{ summary }}</summary>
+    <summary>Welsh example</summary>
      <div class="example">{{ scaledWrapperStart | safe }}{% include fileCy %}{{ scaledWrapperEnd | safe }}</div>
   </details>
   {% if html %}

--- a/gulpfile.js/util/design-system/macros/example.html
+++ b/gulpfile.js/util/design-system/macros/example.html
@@ -1,11 +1,27 @@
-{% macro example(file, scaled=false) %}
-{% if scaled %}
-<div class="example">
-  <div class="scale-wrapper">
-    <div class="scale">{% include file %}</div>
-  </div>
-</div>
-{% else %}
-<div class="example">{% include file %}</div>
-{% endif %}
+{% macro example(file, scaled=false, cy=false, summary='', html=false) %}
+  {% if scaled %}
+    {% set scaledWrapperStart %}<div class="scale-wrapper"><div class="scale">{% endset %}
+    {% set scaledWrapperEnd %}</div></div>{% endset %}
+  {% else %}
+    {% set scaledWrapperStart = '' %}
+    {% set scaledWrapperEnd = '' %}
+  {% endif %}
+
+  <div class="example">{{ scaledWrapperStart | safe }}{% include file %}{{ scaledWrapperEnd | safe }}</div>
+  {% if html %}
+    {% include file %}
+  {% endif %}
+
+  {% if cy %}
+  {% set fileCy %}{{ file | getWelshFileName }}{% endset %}
+  <details>
+    <summary>{{ summary }}</summary>
+     <div class="example">{{ scaledWrapperStart | safe }}{% include fileCy %}{{ scaledWrapperEnd | safe }}</div>
+  </details>
+  {% if html %}
+    {% include fileCy %}
+  {% endif %}
+
+  {% endif %}
+
 {% endmacro %}


### PR DESCRIPTION
We need to be able to display the Welsh version of a component/ pattern

## Problem
We currently only have a macro for displaying English examples in the documentation. 

### Example Screenshot
![screen shot 2018-06-14 at 16 19 00](https://user-images.githubusercontent.com/10154302/41421442-be1c9fb0-6fee-11e8-9799-d92477950326.png)

## Solution
We need to consolidate the `markup()` macro with the `example()` macro whilst adding more options to accommodate for examples with HTML snippets, scaled examples and Welsh examples. 
![screen shot 2018-06-14 at 14 38 38](https://user-images.githubusercontent.com/10154302/41421320-777732f0-6fee-11e8-9bb5-5babf9371f58.png)
