### PR TITLE
#938: removed use of suggestionDisplayTemplate in default autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Updated
+- Autocomplete default implementation stopped using suggestion display template [#938](https://github.com/hmrc/assets-frontend/pull/980)
 - Welsh translation of last page not found example. [#979](https://github.com/hmrc/assets-frontend/pull/979)
 - Made more small edits to documentation to make content more active, shorter and use more plain English. [#978](https://github.com/hmrc/assets-frontend/pull/978)
 - Made small edits to documentation to make content more active, shorter and use more plain English. [#977](https://github.com/hmrc/assets-frontend/pull/977)

--- a/assets/javascripts/modules/autoCompleteFactory.js
+++ b/assets/javascripts/modules/autoCompleteFactory.js
@@ -18,12 +18,10 @@ var createAutoCompleteCountries = function () {
 }
 
 var createAutoComplete = function () {
-  // additional work required to extract the template to a configurable option
-  var suggestionDisplayTemplate = function (title, value) {
-    return title + ' (+' + value + ')'
-  }
+  // we do not use a suggestionDisplayTemplate in this default
+  // implementation until work can be done to make it configurable
 
-  autoComplete($('.js-hmrc-auto-complete').first(), null, null, suggestionDisplayTemplate)
+  autoComplete($('.js-hmrc-auto-complete').first(), null, null, null)
 }
 
 module.exports = function () {


### PR DESCRIPTION
<!-- Provide a short summary of the issue in the Title above. -->
When using default autocompleteFactory we should not hard code a suggestionDisplayTemplate into the solution as it is quite clearly designed for use with international dialling codes only.
<!-- Make sure your work follows to our CONTRIBUTING guidelines. -->
<!-- There's a link to them above. -->

## Problem
<!-- What problem does the pull request solve? Why is this change required? -->
Using autocomplete produces an unwanted display of the suggestion value prefixed with a `+` sign in brackets - this is not applicable to our use case and we do not want to show the value to the user - just the title
<!-- If it fixes an open issue, please link to the issue or add: Fixes #<issue_number> -->
#938 
### Example Screenshot
<!-- Add an image or gif to help illustrate the point. -->
![autocomplete-suggestion-template-existing](https://user-images.githubusercontent.com/1460971/41720327-9e75b18a-755a-11e8-95bb-fe72435a308a.png)

## Solution
<!-- Describe your changes -->
Removing the template definition from the default createAutoComplete() method and passing a paramater of `null` instead fixes the issue by simply reverting to using titles only in the suggestions.
### Example Screenshot
<!-- If possible, add an image or gif of what's changed. -->
![autocomplete-suggestion-template--proposed](https://user-images.githubusercontent.com/1460971/41720386-ce096680-755a-11e8-8887-6f834216933c.png)
