### PR TITLE
fixed validorFocus.js to escape dots in jquery id selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fixed validorFocus.js to escape dots in jquery id selector [#984]
+
 ### Updated
 - Updated page not found documentation and examples. [#985](https://github.com/hmrc/assets-frontend/pull/985)
 - Updated ask user for their consent documentation. [#983](https://github.com/hmrc/assets-frontend/pull/983)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
-- Fixed validorFocus.js to escape dots in jquery id selector [#984]
+- Fixed validorFocus.js to escape dots in jquery id selector [#984](https://github.com/hmrc/assets-frontend/pull/984)
 
 ### Updated
 - Updated page not found documentation and examples. [#985](https://github.com/hmrc/assets-frontend/pull/985)

--- a/assets/javascripts/modules/validatorFocus.js
+++ b/assets/javascripts/modules/validatorFocus.js
@@ -22,7 +22,7 @@ module.exports = function () {
       focusId = '#' + focusId
     }
 
-    var inputToFocus = $(focusId)
+    var inputToFocus = $(focusId.replace('.', '\\.'))
 
     if (!inputToFocus.length) {
       return


### PR DESCRIPTION
<!-- Provide a short summary of the issue in the Title above. -->
Added backslashes to escape id's with dot notation

<!-- Make sure your work follows to our CONTRIBUTING guidelines. -->
<!-- There's a link to them above. -->

## Problem
<!-- What problem does the pull request solve? Why is this change required? -->
Using dots in id's breaks the validorFocus.js script so they need to be escaped with with two backslashes ref: https://api.jquery.com/category/selectors/

<!-- If it fixes an open issue, please link to the issue or add: Fixes #<issue_number> -->

### Example Screenshot
<!-- Add an image or gif to help illustrate the point. -->

## Solution
<!-- Describe your changes -->
Added backslashes on the focusId via replace method

### Example Screenshot
<!-- If possible, add an image or gif of what's changed. -->
