### PR TITLE
Updated page not found documentation and examples

### DIFF
--- a/assets/patterns/page-not-found/README.md
+++ b/assets/patterns/page-not-found/README.md
@@ -16,11 +16,6 @@ Test all links and buttons to make sure they work. Remember to [do the hard work
 
 Make sure any web addresses in your service, letters, forms and on GOV.UK are for pages that exist or redirect to pages that exist.
 
-For example, if someone has bookmarked a confirmation or a page in the middle of a journey:
-
-- explain that the information or page is no longer available
-- give them a link or button to get to a sensible place in the service
-
 ## How it works
 
 The page should have:
@@ -43,23 +38,7 @@ Do not use:
 - informal or humorous words like oops
 - red text to warn people
 
-### Service error
-
 {{ example("page-not-found.html", scaled=false, cy=true, html=false) }}
-
-Use this version when you know the page not found is because of a broken link or button from inside the service. Include a back link at the top of the screen.
-
-### User or unknown error
-
-Use this version when you know the page not found is because of a user error or you do not know what caused it. This could be a link or button outside the service or the user typed or pasted the web address incorrectly.
-
-{{ example("page-not-found-user.html", scaled=false, cy=true, html=false) }}
-
-### The page exists but is no longer available
-
-Use this version if the page exists but cannot be display. This could be a page in the middle of a journey or a confirmation page. Give a link to a sensible place in the service.
-
-{{ example("page-not-found-link.html", scaled=false, cy=true, html=false) }}
 
 ## Research on this pattern
 

--- a/assets/patterns/page-not-found/page-not-found-link.cy.html
+++ b/assets/patterns/page-not-found/page-not-found-link.cy.html
@@ -1,7 +1,0 @@
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">Heb ddod o hyd i’r dudalen</h1>
-      <p>Nid yw’r dudalen hon ar gael mwyach.</p>
-      <p><a href="">Rheoli’ch credydau treth</a></p>
-    </div>
-  </div>

--- a/assets/patterns/page-not-found/page-not-found-link.html
+++ b/assets/patterns/page-not-found/page-not-found-link.html
@@ -1,8 +1,0 @@
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <a href="" class="back-link">Back</a>
-      <h1 class="heading-large">Page not found</h1>
-      <p>This page is no longer available.</p>
-      <p><a href="">Manage your tax credits</a></p>
-    </div>
-  </div>

--- a/assets/patterns/page-not-found/page-not-found-user.cy.html
+++ b/assets/patterns/page-not-found/page-not-found-user.cy.html
@@ -1,8 +1,0 @@
-<div class="grid-row">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">Heb ddod o hyd i’r dudalen</h1>
-      <p>Os gwnaethoch deipio’r cyfeiriad gwe, dylech wirio ei fod yn gywir.</p>
-      <p>Os gwnaethoch bastio’r cyfeiriad gwe, dylech wirio’ch bod wedi copïo’r cyfeiriad yn llawn.
-      <p>Os yw’r cyfeiriad gwe yn gywir neu y gwnaethoch ddewis cysylltiad neu fotwm, <a href="https://www.gov.uk/contact-the-tax-credit-office">Cysylltwch â’r Ganolfan Cyswllt Cymraeg</a> os oes angen i chi siarad â rhywun am eich credydau treth.</p>
-    </div>
-  </div>

--- a/assets/patterns/page-not-found/page-not-found-user.html
+++ b/assets/patterns/page-not-found/page-not-found-user.html
@@ -1,8 +1,0 @@
-<div class="grid-row">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">Page not found</h1>
-      <p>If you typed the web address, check it is correct.</p>
-      <p>If you pasted the web address, check you copied the entire address.</p>
-      <p>If the web address is correct or you selected a link or button, <a href="https://www.gov.uk/contact-the-tax-credit-office">contact the Tax Credit Helpline</a> if you need to speak to someone about your tax credits.</p>
-    </div>
-  </div>

--- a/assets/patterns/page-not-found/page-not-found.cy.html
+++ b/assets/patterns/page-not-found/page-not-found.cy.html
@@ -1,13 +1,8 @@
-  <div class="grid-row">
+<div class="grid-row">
     <div class="column-two-thirds">
-      <a href="" class="link-back">Yn ôl</a>
-      <h1 class="heading-large">Heb ddod o hyd i'r dudalen</h1>
-      <p>Rydym wedi rhoi gwybod am hyn i’r tîm sy’n rheoli’r gwasanaeth, byddant yn ei drwsio cyn gynted â phosibl.</p>
-      <p>Cysylltwch â’r Ganolfan Cyswllt Cymraeg os ydych am siarad â rhywun am eich credydau treth.</p>
-      <p>Ffôn:<br>
-      <span style="font-weight:700">0808 157 3901</span></p>
-      <p>Oriau agor:<br>
-      <span style="font-weight:700">Dydd Llun – Dydd Gwener: 08:30 – 17:00</span></p>
-      <p>Ar gau ar benwythnosau a gwyliau’r banc.</p>
+      <h1 class="heading-large">Heb ddod o hyd i’r dudalen</h1>
+      <p>Os gwnaethoch deipio’r cyfeiriad gwe, dylech wirio ei fod yn gywir.</p>
+      <p>Os gwnaethoch bastio’r cyfeiriad gwe, dylech wirio’ch bod wedi copïo’r cyfeiriad yn llawn.
+      <p>Os yw’r cyfeiriad gwe yn gywir neu y gwnaethoch ddewis cysylltiad neu fotwm, <a href="">Cysylltwch â’r Ganolfan Cyswllt Cymraeg</a> os oes angen i chi siarad â rhywun am eich credydau treth.</p>
     </div>
   </div>

--- a/assets/patterns/page-not-found/page-not-found.html
+++ b/assets/patterns/page-not-found/page-not-found.html
@@ -1,17 +1,8 @@
-  <div class="grid-row">
+<div class="grid-row">
     <div class="column-two-thirds">
-      <a href="" class="link-back">Back</a>
       <h1 class="heading-large">Page not found</h1>
-      <p>We have reported this to the team that manages the service and they will fix it as soon as possible.</p>
-      <p>Contact us if you need to speak to someone about your tax credits.</p>
-      <p>Telephone:<br>
-      <span style="font-weight:700">0808 157 3900</span></p>
-      <p>Textphone:<br>
-      <span style="font-weight:700">080 157 3909</span></p>
-      <p>Outside UK:<br>
-      <span style="font-weight:700">+44 0808 157 0192</span></p>
-      <p>Opening times:<br>
-      <span style="font-weight:700">Monday to Friday: 8am to 8pm</span></p>
-      <p>Closed Easter Sunday, Christmas Day, Boxing Day and New Year’s Day.</p>
+      <p>If you typed the web address, check it is correct.</p>
+      <p>If you pasted the web address, check you copied the entire address.</p>
+      <p>If the web address is correct or you selected a link or button, <a href="">contact the Tax Credit Helpline</a> if you need to speak to someone about your tax credits.</p>
     </div>
   </div>


### PR DESCRIPTION
This is following comments about what should and should not be classes as a page not found.

There is no evidence that we will ever know the page not found will be caused by the service or user. And the example of bookmarking a page in a journey or a confirmation would be better in those patterns because it is not a page not found.

This makes the pattern match the GOV.UK Design System but with the Welsh translations.