### PR TITLE
Updated 401, 403, 404 and 500 pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Updated
+- Updated 401, 403, 404 and 500 error pages. [#988](https://github.com/hmrc/assets-frontend/pull/988)
 - Page not found documentation. [#982](https://github.com/hmrc/assets-frontend/pull/982)
 - Welsh translation of last page not found example. [#979](https://github.com/hmrc/assets-frontend/pull/979)
 - Made more small edits to documentation to make content more active, shorter and use more plain English. [#978](https://github.com/hmrc/assets-frontend/pull/978)

--- a/assets/error_pages/401.html
+++ b/assets/error_pages/401.html
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
-  <title>Unauthorized - 401</title>
+  <title>You do not have permission to access this service</title>
 
   <script type="text/javascript">
     (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
@@ -77,10 +77,6 @@
   </header>
   <!--end header-->
 
-  <div class="beta-banner">
-    <p><b>BETA:</b> This is a <a href="https://www.gov.uk/help/beta" target="_blank" data-sso="false">trial service</a>. Help us improve it - send your <a id="feedback-link" href="/beta-feedback-unauthenticated" target="_blank" data-sso="false">feedback</a>.</p>
-  </div>
-
   <main id="content" class="l-constrained--topBordered ">
     <div class="service-info">
       <div class="logo">
@@ -90,10 +86,10 @@
 
     <article>
       <header class="page-header">
-        <h1>Unauthorized</h1>
+        <h1>You do not have permission to access this service</h1>
       </header>
 
-      <p>Please check that you have permission to access this resource. Please contact <a href=“mailto:hmrc-web-operations@digital.cabinet-office.gov.uk”>hmrc-web-operations@digital.cabinet-office.gov.uk</a> if you believe you are seeing this in error.</p>
+      <p><a href=“mailto:hmrc-web-operations@digital.cabinet-office.gov.uk”>Email hmrc-web-operations@digital.cabinet-office.gov.uk</a> if you think you do have permission to access this service.</p>
     </article>
   </main>
 

--- a/assets/error_pages/403.html
+++ b/assets/error_pages/403.html
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
-  <title>Forbidden - 403</title>
+  <title>You do not have permission to access this service</title>
 
   <script type="text/javascript">
     (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
@@ -77,10 +77,6 @@
   </header>
   <!--end header-->
 
-  <div class="beta-banner">
-    <p><b>BETA:</b> This is a <a href="https://www.gov.uk/help/beta" target="_blank" data-sso="false">trial service</a>. Help us improve it - send your <a id="feedback-link" href="/beta-feedback-unauthenticated" target="_blank" data-sso="false">feedback</a>.</p>
-  </div>
-
   <main id="content" class="l-constrained--topBordered ">
     <div class="service-info">
       <div class="logo">
@@ -90,10 +86,10 @@
 
     <article>
       <header class="page-header">
-        <h1>Forbidden</h1>
+        <h1>You do not have permission to access this service</h1>
       </header>
 
-      <p>Please check that you have permission to access this resource. Please contact <a href=“mailto:hmrc-web-operations@digital.cabinet-office.gov.uk”>hmrc-web-operations@digital.cabinet-office.gov.uk</a> if you believe you are seeing this in error.</p>
+      <p><a href=“mailto:hmrc-web-operations@digital.cabinet-office.gov.uk”>Email hmrc-web-operations@digital.cabinet-office.gov.uk</a> if you think you do have permission to access this service.</p>
     </article>
   </main>
 

--- a/assets/error_pages/404.html
+++ b/assets/error_pages/404.html
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
-  <title>Page not found - 404</title>
+  <title>Page not found</title>
 
   <script type="text/javascript">
     (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
@@ -77,10 +77,6 @@
   </header>
   <!--end header-->
 
-  <div class="beta-banner">
-    <p><b>BETA:</b> This is a <a href="https://www.gov.uk/help/beta" target="_blank" data-sso="false">trial service</a>. Help us improve it - send your <a id="feedback-link" href="/beta-feedback-unauthenticated" target="_blank" data-sso="false">feedback</a>.</p>
-  </div>
-
   <main id="content" class="l-constrained--topBordered ">
     <div class="service-info">
       <div class="logo">
@@ -90,10 +86,15 @@
 
     <article>
       <header class="page-header">
-        <h1>This page can’t be found</h1>
+        <h1>Page not found</h1>
       </header>
 
-      <p>Please check that you have entered the correct web address.</p>
+      <p>If you typed the web address, check it is correct.</p>
+
+      <p>If you pasted the web address, check you copied the entire address.</p>
+
+      <p>If the web address is correct or you selected a link or button, <a href="https://www.gov.uk/contact-hmrc">contact HM Revenue and Customs if you need to speak to someone</a>.</p>
+
     </article>
   </main>
 

--- a/assets/error_pages/500.html
+++ b/assets/error_pages/500.html
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
-  <title>Sorry, we are experiencing technical difficulties - 500</title>
+  <title>Sorry, there is a problem with the service</title>
 
   <script type="text/javascript">
     (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
@@ -75,10 +75,6 @@
   </header>
   <!--end header-->
 
-  <div class="beta-banner">
-    <p><b>BETA:</b> This is a <a href="https://www.gov.uk/help/beta" target="_blank" data-sso="false">trial service</a>. Help us improve it - send your <a id="feedback-link" href="/beta-feedback-unauthenticated" target="_blank" data-sso="false">feedback</a>.</p>
-  </div>
-
   <main id="content" class="l-constrained--topBordered ">
     <div class="service-info">
       <div class="logo">
@@ -88,10 +84,13 @@
 
     <article>
       <header class="page-header">
-        <h1>Sorry, we’re experiencing technical difficulties</h1>
+        <h1>Sorry, there is a problem with the service</h1>
       </header>
 
-      <p>Please try again in a few minutes.</p>
+      <p>Try again later.</p>
+
+      <p><a href="https://www.gov.uk/contact-hmrc">Contact HM Revenue and Customs if you need to speak to someone</a></p>
+
     </article>
   </main>
 


### PR DESCRIPTION
This is to make the content match the HMRC Design System.

We do not have patterns for 401 and 403 pages so I have made them the same and removed any https status jargon that may confuse users.