### PR TITLE
Added word break fix to page heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fixed validorFocus.js to escape dots in jquery id selector [#984](https://github.com/hmrc/assets-frontend/pull/984)
+- Fixed bug where word-break and overflow-wrap didn't work with page heading elements [994](https://github.com/hmrc/assets-frontend/pull/994)
 
 ## [3.5.0 and 4.5.0] 2018-08-13
 

--- a/assets/components/page-heading/_page-heading.scss
+++ b/assets/components/page-heading/_page-heading.scss
@@ -4,6 +4,8 @@
   margin-bottom: em(30, 32);
   margin-top: em(60, 32);
   padding-top: 8px;
+  width: 100%;
+  table-layout: fixed;
 
   @include media(tablet) {
     margin-bottom: em(60, 48);


### PR DESCRIPTION
## Problem
Using `word-break`, `overflow-wrap` properties with the page heading stops the text from wrapping. This is due to the page heading having `display: table;` set.

## Solution
Adding `table-layout: fixed` fixes this issue. Firefox also seems to need `width: 100%;`. More information can be found here - https://bugs.chromium.org/p/chromium/issues/detail?id=155767
