### PR TITLE
updated CHANGELOG.md for releases 3.7.0 and 4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [3.7.0 and 4.7.0]
+
 ### New
 - Updated confirmed identity and could not confirm identity patterns [#1000](https://github.com/hmrc/assets-frontend/pull/1000)
 - Added references and identifiers to system [#996](https://github.com/hmrc/assets-frontend/pull/996)
@@ -21,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed bug where word-break and overflow-wrap didn't work with page heading elements [994](https://github.com/hmrc/assets-frontend/pull/994)
 
 ## [3.6.0 and 4.6.0] 2018-11-13
-- Pseudo release, no code changes
+- Tags only no actual release, no code changes
 
 ## [3.5.0 and 4.5.0] 2018-08-13
 


### PR DESCRIPTION
Prepare for a release of versions 3.7.0 and 4.7.0 by updating CHANGELOG.md

## Contents of release
Release includes #984 and #994
