### PR TITLE
Fix path prefix for design system nav urls depending on environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### New
 - Added expanding subnavigation to mobile navigation [#1004](https://github.com/hmrc/assets-frontend/pull/1004)
 
+### Fixed
+- Updated the fixture and tests for the design library template [#1005](https://github.com/hmrc/assets-frontend/pull/1005)
+
 ## [3.7.0 and 4.7.0] 2018-11-19
 
 ### New

--- a/gulpfile.js/tests/fixtures/pattern-library/design-pattern-library-template.html
+++ b/gulpfile.js/tests/fixtures/pattern-library/design-pattern-library-template.html
@@ -4,29 +4,29 @@
 
 <div id="sections">
 {{#each sections}}
-  <a href="{{ url }}">{{ title }}</a>
+  <a href="{{ ../pathPrefix }}{{ url }}">{{ title }}</a>
 {{/each}}
 </div>
 
 <div id="nav">
 {{#each nav}}
-  <a href="{{ url }}">{{ title }}</a>
+  <a href="{{ ../pathPrefix }}{{ url }}">{{ title }}</a>
 {{/each}}
 </div>
 
 <div id="mobileNav">
   <ul>
   {{#each sections}}
-    <li><a href="{{  ../pathPrefix }}{{ url }}">{{ title }}</a>
+    <li><a href="{{ ../pathPrefix }}{{ url }}">{{ title }}</a>
     {{#if nav}}
       <ul>
       {{#each nav}}
-        <li><a href="{{  ../pathPrefix }}{{ url }}">{{ title }}</a></li>
+        <li><a href="{{ ../../pathPrefix }}{{ url }}">{{ title }}</a></li>
       {{/each}}
       </ul>
-    {{/if}}</li> 
+    {{/if}}</li>
   {{/each}}
-  </ul> 
+  </ul>
 </div>
 
 <div id="documentation">{{{ documentation }}}</div>

--- a/gulpfile.js/tests/renderPagesFromTemplate.test.js
+++ b/gulpfile.js/tests/renderPagesFromTemplate.test.js
@@ -10,6 +10,8 @@ var templatePath = path.join(__dirname, 'fixtures', 'pattern-library', 'design-p
 var templateSource = fs.readFileSync(templatePath).toString()
 var compiledTemplate = Handlebars.compile(templateSource)
 
+var pathPrefix = (process.env.NODE_ENV === 'prod') ? '/assets-frontend' : ''
+
 var getFiles = function () {
   return [
     getFile(path.resolve('index.html'), 'section', 'Homepage'),
@@ -34,7 +36,7 @@ test('renderPagesFromTemplate - renders a homepage', function (t) {
 
   t.equal(
     $('#sections a:first-child').attr('href'),
-    '/index.html',
+    pathPrefix + '/index.html',
     'that have the expected urls'
   )
 
@@ -56,7 +58,7 @@ test('renderPagesFromTemplate - renders a homepage', function (t) {
 
   t.equal(
     $('#mobileNav > ul > li:first-child > a').attr('href'),
-    '/index.html',
+    pathPrefix + '/index.html',
     'with the first link to the homepage'
   )
 
@@ -68,7 +70,7 @@ test('renderPagesFromTemplate - renders a homepage', function (t) {
 
   t.equal(
     $('#mobileNav > ul > li:nth-child(2) > a').attr('href'),
-    '/category-one/index.html',
+    pathPrefix + '/category-one/index.html',
     'with a second section link'
   )
 
@@ -85,7 +87,7 @@ test('renderPagesFromTemplate - renders a homepage', function (t) {
 
   t.equal(
     $('#mobileNav > ul > li:nth-child(2) li:first-child a').attr('href'),
-    '/category-one/thing/index.html',
+    pathPrefix + '/category-one/thing/index.html',
     'with the correct first url'
   )
 
@@ -97,7 +99,7 @@ test('renderPagesFromTemplate - renders a homepage', function (t) {
 
   t.equal(
     $('#mobileNav > ul > li:nth-child(2) li:nth-child(2) a').attr('href'),
-    '/category-one/thing-two/index.html',
+    pathPrefix + '/category-one/thing-two/index.html',
     'with the correct second url'
   )
 
@@ -122,7 +124,7 @@ test('renderPagesFromTemplate - renders a section', function (t) {
 
   t.equal(
     $('#sections a:nth-child(2)').attr('href'),
-    '/category-one/index.html',
+    pathPrefix + '/category-one/index.html',
     'that have the expected urls'
   )
 
@@ -136,7 +138,7 @@ test('renderPagesFromTemplate - renders a section', function (t) {
 
   t.equal(
     $('#nav a:first-child').attr('href'),
-    '/category-one/thing/index.html',
+    pathPrefix + '/category-one/thing/index.html',
     'that have the expected urls'
   )
 
@@ -175,7 +177,7 @@ test('renderPagesFromTemplate - renders a page', function (t) {
 
   t.equal(
     $('#nav a:first-child').attr('href'),
-    '/category-one/thing/index.html',
+    pathPrefix + '/category-one/thing/index.html',
     'that have the expected urls'
   )
   t.equal(


### PR DESCRIPTION
The previous PR inadvertently broke a couple of tests. This was caused by the `pathPrefix` global variable not being accessed properly in the template.

This PR relies on https://github.com/hmrc/component-library-template/pull/70 being merged first.
