### PR TITLE
PSEC-461 Add an ajaxPrefilter to patch jQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### New
+- Added mitigation for the vulnerability [CVE-2015-9251](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9251) in older versions of jQuery [#1009](https://github.com/hmrc/assets-frontend/pull/1009)
 - Added expanding subnavigation to mobile navigation [#1004](https://github.com/hmrc/assets-frontend/pull/1004)
 
 ### Fixed

--- a/assets/application.js
+++ b/assets/application.js
@@ -1,6 +1,14 @@
 window._gaq = window._gaq || []
 
 require('jquery')
+
+// patch jQuery for http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9251
+window.jQuery.ajaxPrefilter(function (s) {
+  if (s.crossDomain) {
+    s.contents.script = false
+  }
+})
+
 require('govuk-template')
 require('javascripts')
 require('./components')


### PR DESCRIPTION
Use an ajaxPrefilter to block ajax requests from automatically executing inferred javascript responses where the request was across domains and made without setting an explicit dataType.

## Problem
jQuery before 3.0.0 contains an potential XSS vulnerability under some specific conditions, there is a mitigation for the vulnerability detailed in this issue.
https://github.com/jquery/jquery/commit/f60729f3903d17917dc351f3ac87794de379b0cc

## Solution
Added the code from a jQuery commit thread describing the potential vulnerability