### PR TITLE
Add opt-in full-width tablet breakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Updated
-- Updated VAT registration number documentation [#1012](https://github.com/hmrc/assets-frontend/pull/1012) 
+- Updated VAT registration number documentation [#1012](https://github.com/hmrc/assets-frontend/pull/1012)
 - Added a deprecation banner to direct users to the new design resources for HMRC on Heroku, with associated content and styling changes [#1011](https://github.com/hmrc/assets-frontend/pull/1011)
 - Added an LDS exception for the design-system that will be copied across to the gh-pages branch [#1013](https://github.com/hmrc/assets-frontend/pull/1012)
+
+### Added
+- Optional full width layout for tables [#1014](https://github.com/hmrc/assets-frontend/pull/1014)
 
 ## [3.8.0] and [4.8.0] - 2018-12-14
 ### New

--- a/assets/application.scss
+++ b/assets/application.scss
@@ -16,5 +16,6 @@ $path: "../images/";
 @import "scss/backward-compatibility";
 
 // HMRC Design System
+@import "styles/layout/layout";
 @import "components/all-components";
 @import "patterns/all-patterns";

--- a/assets/styles/layout/_layout.scss
+++ b/assets/styles/layout/_layout.scss
@@ -1,0 +1,13 @@
+/*
+Full width on tablet
+
+Use the `.full-width--tablet` class when you need the page content to use the full width of the page on tablets.
+
+See .full-width in /assets/scss/layouts/_page.scss for a non-tablet version.
+*/
+
+@media (min-width: 641px) and (max-width: 768px) {
+  .full-width--tablet .content__body {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
# Problem

API Platform have an unusual UX use case.

End users of third party software have to complete an "authorisation journey" on MDTP to get something called an access token, which their software can then use to call our APIs. The authorisation journey includes: a start page, sign in, all the 2SV pages, all the IV pages and a "grant authority" page.

A lot of third party software is fat client, so the authorisation journey is run in a browser launched by their software - usually IE and often at a specific page width of 650px.

MDTP pages use the standard two-thirds/one-third page split at 650px, meaning a lot of word wrapping on the left and a lot of whitespace on the right. 

# Solution

Add an opt-in breakpoint for services that need to be full-width at tablet viewport widths. 

# Notes

* It's possible to achieve this layout using the latest govuk-frontend in the form of a `*-from-desktop` class (added https://github.com/alphagov/govuk-frontend/pull/1094).
* We've named ours to be more in keeping with the existing assets-frontend `.full-width` class.
* Teams moving from assets-frontend to govuk-frontend will need to update their class names to adopt the new styles anyway. Having to do the same for this class too isn't creating massive overhead.