### PR TITLE
SDT-1047 fix error pages assets paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [3.9.0] and [4.9.0] - 2019-04-03
+### Fixed
+- The assets path in the static error pages was pointing to a SNAPSHOT version of the assests since new build changes
+- The javascript link in the static error pages was pointing to an unminified filename which isn't present in the release
+
 ## [3.9.0] and [4.9.0] - 2019-01-24
 ### Updated
 - Updated VAT registration number documentation [#1012](https://github.com/hmrc/assets-frontend/pull/1012)

--- a/assets/error_pages/400.html
+++ b/assets/error_pages/400.html
@@ -118,6 +118,6 @@
   <!--end footer-->
 
   <script src="/template/assets/javascripts/govuk-template.js" type="text/javascript"></script>
-  <script src="{{ assetsPath }}javascripts/application.js" type="text/javascript"></script>
+  <script src="{{ assetsPath }}javascripts/application.min.js" type="text/javascript"></script>
 </body>
 </html>

--- a/assets/error_pages/401.html
+++ b/assets/error_pages/401.html
@@ -124,6 +124,7 @@
   <!--end footer-->
 
   <script src="/template/assets/javascripts/govuk-template.js" type="text/javascript"></script>
-  <script src="{{ assetsPath }}javascripts/application.js" type="text/javascript"></script>
+  <script src="{{ assetsPath }}javascripts/application.min.js" type="text/javascript"></script>
 </body>
 </html>
+s

--- a/assets/error_pages/403.html
+++ b/assets/error_pages/403.html
@@ -124,6 +124,6 @@
   <!--end footer-->
 
   <script src="/template/assets/javascripts/govuk-template.js" type="text/javascript"></script>
-  <script src="{{ assetsPath }}javascripts/application.js" type="text/javascript"></script>
+  <script src="{{ assetsPath }}javascripts/application.min.js" type="text/javascript"></script>
 </body>
 </html>

--- a/assets/error_pages/404.html
+++ b/assets/error_pages/404.html
@@ -129,6 +129,6 @@
   <!--end footer-->
 
   <script src="/template/assets/javascripts/govuk-template.js" type="text/javascript"></script>
-  <script src="{{ assetsPath }}javascripts/application.js" type="text/javascript"></script>
+  <script src="{{ assetsPath }}javascripts/application.min.js" type="text/javascript"></script>
 </body>
 </html>

--- a/assets/error_pages/500.html
+++ b/assets/error_pages/500.html
@@ -120,6 +120,6 @@
   <!--end footer-->
 
   <script src="/template/assets/javascripts/govuk-template.js" type="text/javascript"></script>
-  <script src="{{ assetsPath }}javascripts/application.js" type="text/javascript"></script>
+  <script src="{{ assetsPath }}javascripts/application.min.js" type="text/javascript"></script>
 </body>
 </html>

--- a/gulpfile.js/tasks/error-pages.js
+++ b/gulpfile.js/tasks/error-pages.js
@@ -10,7 +10,7 @@ let version = ''
 const errorPages = (v) => {
   const nextMinorVersion = parseInt(NodeGitVersion().split('.')[1]) + 1
 
-  if (process.env.JENKINS_URL === 'https://build.tax.service.gov.uk/') {
+  if (/https?:\/\/.*\.tax\.service\.gov\.uk\//.test(process.env.JENKINS_URL)) {
     version = [v.slice(1), nextMinorVersion, '0'].join('.')
   } else {
     version = path.parse(config.snapshotDir[v]).name

--- a/gulpfile.js/tasks/error-pages.js
+++ b/gulpfile.js/tasks/error-pages.js
@@ -4,10 +4,17 @@ const path = require('path')
 const gulp = require('gulp')
 const replace = require('gulp-replace')
 const config = require('../config')
+const NodeGitVersion = require('@hmrc/node-git-versioning')
+let version = ''
 
 const errorPages = (v) => {
-  const version = process.env.TAG ? process.env.TAG : path.parse(config.snapshotDir[v]).name
+  const nextMinorVersion = parseInt(NodeGitVersion().split('.')[1]) + 1
 
+  if (process.env.JENKINS_URL === 'https://build.tax.service.gov.uk/') {
+    version = [v.slice(1), nextMinorVersion, '0'].join('.')
+  } else {
+    version = path.parse(config.snapshotDir[v]).name
+  }
   return gulp.src(config.errorPages.src)
     .pipe(replace('{{ assetsPath }}', `${config.errorPages.assetsBaseUri}${version}/`))
     .pipe(gulp.dest(config.snapshotDir[v]))


### PR DESCRIPTION
## Problem
Fixes the version number in the assets path in the static error pages, previously this relied on the environment variable TAG being set for the build through a parameter. No that we always buld on a push to master this is no longer set so the default v3-SNAPSHOT and v4-SNAPSHOT entries were being used instead.

This uses a different approach and checks for the value of the JENKINS_URL environment variable to determine if this is a release build