### PR TITLE
DDCNLS-5647 - Your account menu wasn't highlighting on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+
+## [3.11.0] and [4.11.0] - 2019-04-09
+### Fixed
+- When navigating through the navigation bar, 'your account' doesn't highlight when the focus is on it. To fix this, CSS added to highlight on focus - same functionality as the other navigation buttons.
+
+
 ## [3.10.0] and [4.10.0] - 2019-04-03
 ### Fixed
 - The assets path in the static error pages was pointing to a SNAPSHOT version of the assests since new build changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 
-## [3.11.0] and [4.11.0] - 2019-04-09
+## [3.11.0] and [4.11.0] - 2019-04-11
 ### Fixed
-- When navigating through the navigation bar, 'your account' doesn't highlight when the focus is on it. To fix this, CSS added to highlight on focus - same functionality as the other navigation buttons.
+- When navigating through the navigation bar, 'your account' doesn't highlight when the focus is on it. To fix this, CSS removed that was overriding default behavious of highlighting on focus.
 
 
 ## [3.10.0] and [4.10.0] - 2019-04-03

--- a/assets/components/account-menu/_account-menu.scss
+++ b/assets/components/account-menu/_account-menu.scss
@@ -470,3 +470,8 @@ p.subnav__section__heading {
     padding: 20px 30px 10px;
   }
 }
+
+#account-menu__main-2:focus {
+  border-bottom: 4px solid #ffbf47;
+  outline: 3px solid #ffbf47;
+}

--- a/assets/components/account-menu/_account-menu.scss
+++ b/assets/components/account-menu/_account-menu.scss
@@ -374,10 +374,8 @@ p.subnav__section__heading {
   background-image: url("../images/icon-chevron-down.svg");
   background-position: right 14px center;
   background-size: 12px;
-  border-bottom: none;
   padding-right: 31px;
   position: relative;
-  outline: none;
 
   @include ie-lte(9) {
     background-image: url("../images/icon-chevron-down.png");
@@ -469,9 +467,4 @@ p.subnav__section__heading {
   .full-width-banner__container {
     padding: 20px 30px 10px;
   }
-}
-
-#account-menu__main-2:focus {
-  border-bottom: 4px solid #ffbf47;
-  outline: 3px solid #ffbf47;
 }


### PR DESCRIPTION
## Problem
When navigating through the navigation bar, 'your account' doesn't highlight when the focus is on it.

Options
Because the navigation is in govuk template, in order to make this change consistent everywhere it is being used, the change needs to be made to assets frontend along with other styles of the navigation.

### Example Screenshot
![image](https://user-images.githubusercontent.com/17907161/55809935-ad67a080-5ade-11e9-9501-c4313e7f9dfb.png)


## Solution
CSS removed that was overriding the default functionality to highlight on focus.
