### PR TITLE
PLATUI-1086: Delete old cookie banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [4.17.0] and [3.17.0] - 2020-02-22
+## [4.19.0] and [3.19.0] - 2020-06-15
+### Changed
+- Removed old cookie banner functionality replaced by 
+  [hmrc/tracking-consent-frontend](https://www.github.com/hmrc/tracking-consent-frontend)
+
+## [4.18.0] and [3.18.0] - 2020-02-22
 ### Security
 - Patch security vulnerabilities
 
-## [3.15.1] and [4.15.1] - 2020-12-11
+## [4.17.0] and [3.17.0] - 2020-01-28
+### Changed
+- Inlined hmrc/node-git-versioning
+
+## [3.16.1] and [4.16.1] - 2020-12-11
 ### Security
 - Bump version of ini to 1.3.7
 

--- a/assets/components/account-header/account-header-example.cy.html
+++ b/assets/components/account-header/account-header-example.cy.html
@@ -1,9 +1,3 @@
-<!-- COOKIE MESSAGE -->
-<div id="global-cookie-message" style="display: block;">
-  <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
-    cookies</a></p>
-</div>
-<!-- END COOKIE MESSAGE -->
 <!-- GOV.UK HEADER -->
 <header role="banner" id="global-header" class="with-proposition">
   <div class="header-wrapper">

--- a/assets/components/account-header/account-header-example.html
+++ b/assets/components/account-header/account-header-example.html
@@ -1,9 +1,3 @@
-<!-- COOKIE MESSAGE -->
-<div id="global-cookie-message" style="display: block;">
-  <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
-    cookies</a></p>
-</div>
-<!-- END COOKIE MESSAGE -->
 <!-- GOV.UK HEADER -->
 <header role="banner" id="global-header" class="with-proposition">
   <div class="header-wrapper">

--- a/assets/components/account-menu/_account-menu.scss
+++ b/assets/components/account-menu/_account-menu.scss
@@ -13,11 +13,6 @@
   }
 }
 
-#global-cookie-message {
-  position: relative;
-  z-index: 999;
-}
-
 .service-info {
   display: block;
   position: relative;

--- a/assets/javascripts/vendor/govuk-template.js
+++ b/assets/javascripts/vendor/govuk-template.js
@@ -59,21 +59,6 @@
     return null;
   };
 }).call(this);
-(function () {
-  "use strict"
-  var root = this;
-  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
-
-  GOVUK.addCookieMessage = function () {
-    var message = document.getElementById('global-cookie-message'),
-        hasCookieMessage = (message && GOVUK.cookie('seen_cookie_message') === null);
-
-    if (hasCookieMessage) {
-      message.style.display = 'block';
-      GOVUK.cookie('seen_cookie_message', 'yes', { days: 28 });
-    }
-  };
-}).call(this);
 (function() {
   "use strict"
 
@@ -90,11 +75,6 @@
     document.getElementsByTagName('head')[0].appendChild(style);
   }
 
-
-  // add cookie message
-  if (window.GOVUK && GOVUK.addCookieMessage) {
-    GOVUK.addCookieMessage();
-  }
 
   // header navigation toggle
   if (document.querySelectorAll && document.addEventListener){

--- a/assets/patterns/header/header--phase-banner.html
+++ b/assets/patterns/header/header--phase-banner.html
@@ -1,9 +1,3 @@
-<!-- COOKIE MESSAGE -->
-<div id="global-cookie-message" style="display: block;">
-  <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
-    cookies</a></p>
-</div>
-<!-- END COOKIE MESSAGE -->
 <!-- GOV.UK HEADER -->
 <header role="banner" id="global-header" class="with-proposition">
   <div class="header-wrapper">

--- a/assets/patterns/header/header--signed-in.html
+++ b/assets/patterns/header/header--signed-in.html
@@ -1,8 +1,3 @@
-<!-- COOKIE MESSAGE -->
-<div id="global-cookie-message" style="display: block;">
-  <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
-</div>
-<!-- END COOKIE MESSAGE -->
 <!-- GOV.UK HEADER -->
 <header role="banner" id="global-header" class="with-proposition">
   <div class="header-wrapper">

--- a/assets/patterns/header/header.html
+++ b/assets/patterns/header/header.html
@@ -1,9 +1,3 @@
-<!-- COOKIE MESSAGE -->
-<div id="global-cookie-message" style="display: block;">
-  <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
-    cookies</a></p>
-</div>
-<!-- END COOKIE MESSAGE -->
 <!-- GOV.UK HEADER -->
 <header role="banner" id="global-header" class="with-proposition">
   <div class="header-wrapper">

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/dialog.js
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/dialog.js
@@ -20,7 +20,7 @@ module.exports = {
     })
 
     // disable the non-dialog page to prevent confusion for VoiceOver users
-    $('#skiplink-container, body>header, #global-cookie-message, body>main, body>footer').each(function () {
+    $('#skiplink-container, body>header, body>main, body>footer').each(function () {
       var value = $(this).attr('aria-hidden')
       var $elem = $(this)
       resetElementsFunctionList.push(function () {

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/dialog.test.js
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/dialog.test.js
@@ -176,9 +176,6 @@ describe('Dialog', function () {
       if ($('#skiplink-container').length === 0) {
         testScope.elementsCreatedForThisTest.push($('<div id=skiplink-container>').appendTo($('body')))
       }
-      if ($('#global-cookie-message').length === 0) {
-        testScope.elementsCreatedForThisTest.push($('<div id=global-cookie-message>').appendTo($('body')))
-      }
       if ($('body>header').length === 0) {
         testScope.elementsCreatedForThisTest.push($('<header>').appendTo($('body')))
       }
@@ -199,7 +196,6 @@ describe('Dialog', function () {
       var selectors = [
         '#skiplink-container',
         'body>header',
-        '#global-cookie-message',
         'body>main',
         'body>footer'
       ];

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-dialog.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-dialog.html
@@ -1,10 +1,3 @@
-<!-- COOKIE MESSAGE -->
-<div id="global-cookie-message">
-  <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
-    cookies</a></p>
-</div>
-<!-- END COOKIE MESSAGE -->
-
 <!-- GOV.UK HEADER -->
 <header role="banner" id="global-header" class="with-proposition">
   <div class="header-wrapper">

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-not-signed-in.cy.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-not-signed-in.cy.html
@@ -1,10 +1,3 @@
-<!-- COOKIE MESSAGE -->
-<!-- <div id="global-cookie-message">
-  <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
-    cookies</a></p>
-</div> -->
-<!-- END COOKIE MESSAGE -->
-
 <!-- GOV.UK HEADER -->
 <header role="banner" id="global-header" class="with-proposition">
   <div class="header-wrapper">

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-not-signed-in.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-not-signed-in.html
@@ -1,10 +1,3 @@
-<!-- COOKIE MESSAGE -->
-<!-- <div id="global-cookie-message">
-  <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
-    cookies</a></p>
-</div> -->
-<!-- END COOKIE MESSAGE -->
-
 <!-- GOV.UK HEADER -->
 <header role="banner" id="global-header" class="with-proposition">
   <div class="header-wrapper">

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-saved.cy.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-saved.cy.html
@@ -1,10 +1,3 @@
-<!-- COOKIE MESSAGE -->
-<!-- <div id="global-cookie-message">
-  <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
-    cookies</a></p>
-</div>
- --><!-- END COOKIE MESSAGE -->
-
 <!-- GOV.UK HEADER -->
 <header role="banner" id="global-header" class="with-proposition">
   <div class="header-wrapper">

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-saved.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-saved.html
@@ -1,10 +1,3 @@
-<!-- COOKIE MESSAGE -->
-<!-- <div id="global-cookie-message">
-  <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
-    cookies</a></p>
-</div>
- --><!-- END COOKIE MESSAGE -->
-
 <!-- GOV.UK HEADER -->
 <header role="banner" id="global-header" class="with-proposition">
   <div class="header-wrapper">

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-will-not-save.cy.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-will-not-save.cy.html
@@ -1,10 +1,3 @@
-<!-- COOKIE MESSAGE -->
-<!-- <div id="global-cookie-message">
-  <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
-    cookies</a></p>
-</div>
- --><!-- END COOKIE MESSAGE -->
-
 <!-- GOV.UK HEADER -->
 <header role="banner" id="global-header" class="with-proposition">
   <div class="header-wrapper">

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-will-not-save.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout-will-not-save.html
@@ -1,10 +1,3 @@
-<!-- COOKIE MESSAGE -->
-<div id="global-cookie-message">
-  <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
-    cookies</a></p>
-</div>
-<!-- END COOKIE MESSAGE -->
-
 <!-- GOV.UK HEADER -->
 <header role="banner" id="global-header" class="with-proposition">
   <div class="header-wrapper">

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout.cy.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout.cy.html
@@ -1,10 +1,3 @@
-<!-- COOKIE MESSAGE -->
-<!-- <div id="global-cookie-message">
-  <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
-    cookies</a></p>
-</div> -->
-<!-- END COOKIE MESSAGE -->
-
 <!-- GOV.UK HEADER -->
 <header role="banner" id="global-header" class="with-proposition">
   <div class="header-wrapper">

--- a/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout.html
+++ b/assets/patterns/help-users-when-we-time-them-out-of-a-service/timeout.html
@@ -1,10 +1,3 @@
-<!-- COOKIE MESSAGE -->
-<!-- <div id="global-cookie-message">
-  <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about
-    cookies</a></p>
-</div> -->
-<!-- END COOKIE MESSAGE -->
-
 <!-- GOV.UK HEADER -->
 <header role="banner" id="global-header" class="with-proposition">
   <div class="header-wrapper">

--- a/template/assets/javascripts/vendor/govuk-template.js
+++ b/template/assets/javascripts/vendor/govuk-template.js
@@ -63,24 +63,9 @@
   "use strict"
   var root = this;
   if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
-
-  GOVUK.addCookieMessage = function () {
-    var message = document.getElementById('global-cookie-message'),
-        hasCookieMessage = (message && GOVUK.cookie('seen_cookie_message') === null);
-
-    if (hasCookieMessage) {
-      message.style.display = 'block';
-      GOVUK.cookie('seen_cookie_message', 'yes', { days: 28 });
-    }
-  };
 }).call(this);
 (function() {
   "use strict"
-
-  // add cookie message
-  if (window.GOVUK && GOVUK.addCookieMessage) {
-    GOVUK.addCookieMessage();
-  }
 
   // header navigation toggle
   if (document.querySelectorAll && document.addEventListener){

--- a/template/assets/stylesheets/govuk-template-ie6.css
+++ b/template/assets/stylesheets/govuk-template-ie6.css
@@ -36,7 +36,7 @@
     display: block;
     clear: both; }
 
-#global-header-bar, #global-cookie-message p {
+#global-header-bar {
   max-width: 960px;
   width: 960px;
   margin: 0 15px;
@@ -520,29 +520,6 @@ button:focus,
   height: 10px;
   background-color: #005ea5;
   font-size: 0; }
-
-/* Global cookie message */
-.js-enabled #global-cookie-message {
-  display: none;
-  /* shown with JS, always on for non-JS */ }
-
-#global-cookie-message {
-  width: 100%;
-  background-color: #d5e8f3;
-  padding-top: 10px;
-  padding-bottom: 10px; }
-  #global-cookie-message p {
-    font-family: "nta", Arial, sans-serif;
-    font-size: 16px;
-    line-height: 1.25;
-    font-weight: 400;
-    text-transform: none;
-    margin-top: 0;
-    margin-bottom: 0; }
-    @media (max-width: 640px) {
-      #global-cookie-message p {
-        font-size: 14px;
-        line-height: 1.14286; } }
 
 /* Global footer */
 #footer {

--- a/template/assets/stylesheets/govuk-template-ie7.css
+++ b/template/assets/stylesheets/govuk-template-ie7.css
@@ -36,7 +36,7 @@
     display: block;
     clear: both; }
 
-#global-header-bar, #global-cookie-message p {
+#global-header-bar {
   max-width: 960px;
   width: 960px;
   margin: 0 15px;
@@ -520,29 +520,6 @@ button:focus,
   height: 10px;
   background-color: #005ea5;
   font-size: 0; }
-
-/* Global cookie message */
-.js-enabled #global-cookie-message {
-  display: none;
-  /* shown with JS, always on for non-JS */ }
-
-#global-cookie-message {
-  width: 100%;
-  background-color: #d5e8f3;
-  padding-top: 10px;
-  padding-bottom: 10px; }
-  #global-cookie-message p {
-    font-family: "nta", Arial, sans-serif;
-    font-size: 16px;
-    line-height: 1.25;
-    font-weight: 400;
-    text-transform: none;
-    margin-top: 0;
-    margin-bottom: 0; }
-    @media (max-width: 640px) {
-      #global-cookie-message p {
-        font-size: 14px;
-        line-height: 1.14286; } }
 
 /* Global footer */
 #footer {

--- a/template/assets/stylesheets/govuk-template-ie8.css
+++ b/template/assets/stylesheets/govuk-template-ie8.css
@@ -33,7 +33,7 @@
   display: block;
   clear: both; }
 
-#global-header-bar, #global-cookie-message p {
+#global-header-bar {
   max-width: 960px;
   width: 960px;
   margin: 0 15px;
@@ -506,29 +506,6 @@ button:focus,
   height: 10px;
   background-color: #005ea5;
   font-size: 0; }
-
-/* Global cookie message */
-.js-enabled #global-cookie-message {
-  display: none;
-  /* shown with JS, always on for non-JS */ }
-
-#global-cookie-message {
-  width: 100%;
-  background-color: #d5e8f3;
-  padding-top: 10px;
-  padding-bottom: 10px; }
-  #global-cookie-message p {
-    font-family: "nta", Arial, sans-serif;
-    font-size: 16px;
-    line-height: 1.25;
-    font-weight: 400;
-    text-transform: none;
-    margin-top: 0;
-    margin-bottom: 0; }
-    @media (max-width: 640px) {
-      #global-cookie-message p {
-        font-size: 14px;
-        line-height: 1.14286; } }
 
 /* Global footer */
 #footer {

--- a/template/assets/stylesheets/govuk-template-print.css
+++ b/template/assets/stylesheets/govuk-template-print.css
@@ -93,6 +93,5 @@ select {
 /* hide the unnecessary page elements */
 body footer,
 .visuallyhidden,
-#global-cookie-message,
 #skiplink-container {
   display: none !important; }

--- a/template/assets/stylesheets/govuk-template.css
+++ b/template/assets/stylesheets/govuk-template.css
@@ -33,14 +33,14 @@
   display: block;
   clear: both; }
 
-#global-header-bar, #global-cookie-message p {
+#global-header-bar {
   max-width: 960px;
   margin: 0 15px; }
   @media (min-width: 641px) {
-    #global-header-bar, #global-cookie-message p {
+    #global-header-bar {
       margin: 0 30px; } }
   @media (min-width: 1020px) {
-    #global-header-bar, #global-cookie-message p {
+    #global-header-bar {
       margin: 0 auto; } }
 
 @-ms-viewport {
@@ -534,29 +534,6 @@ button:focus,
 #global-header-bar {
   height: 10px;
   background-color: #005ea5; }
-
-/* Global cookie message */
-.js-enabled #global-cookie-message {
-  display: none;
-  /* shown with JS, always on for non-JS */ }
-
-#global-cookie-message {
-  width: 100%;
-  background-color: #d5e8f3;
-  padding-top: 10px;
-  padding-bottom: 10px; }
-  #global-cookie-message p {
-    font-family: "nta", Arial, sans-serif;
-    font-size: 16px;
-    line-height: 1.25;
-    font-weight: 400;
-    text-transform: none;
-    margin-top: 0;
-    margin-bottom: 0; }
-    @media (max-width: 640px) {
-      #global-cookie-message p {
-        font-size: 14px;
-        line-height: 1.14286; } }
 
 /* Global footer */
 #footer {


### PR DESCRIPTION
This PR:
* removes the Javascript logic that conditionally shows the old cookie banner when Javascript is enabled and the user has not previously seen the cookie banner.
* removes the logic that sets the `seen_cookie_message` cookie that records whether the old cookie banner has been seen on a particular browser

Note, the styles for this banner live in https://www.github.com/hmrc/govuk-template . The removal of the govuk-template styles from assets-frontend is needed because govuk-template styles are inlined for
* the deprecated component library documentation that does not have the old cookie banner
* the deprecated design system documentation that does not have the old cookie banner
* the deprecated error pages that do not have the old cookie banner

This PR is the first of three related PRs that will need to be merged:
* https://github.com/hmrc/frontend-template-provider/pull/132
* https://github.com/hmrc/govuk-template/pull/117