### PR TITLE
Fixing sequential build steps.

### DIFF
--- a/gulpfile.js/tasks/test.js
+++ b/gulpfile.js/tasks/test.js
@@ -46,4 +46,4 @@ gulp.task('test:v4', (done) => {
   server.start()
 })
 
-gulp.task('test', gulp.parallel('style', 'images', 'svg', 'test:v3', 'test:v4'))
+gulp.task('test', gulp.series(gulp.parallel('style', 'images', 'svg'), gulp.parallel('test:v3', 'test:v4')))


### PR DESCRIPTION
Without this change the first build will generally fail.  This was shown by running:

```
git clone git@github.com:hmrc/assets-frontend.git && cd assets-frontend && nvm use && npm install && npm test
```

Once this has failed a re-test using:

```
npm test
```

Shows a pass.

This PR fixes that.